### PR TITLE
chore: bump graph asset download link to v0.2.1

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,7 +19,7 @@ GRAPH_PATH="/app/graph_generation/elevation_populated_igraph.pkl"
 if [ ! -f "$GRAPH_PATH" ]; then
     echo "Pathfinding graph ($GRAPH_PATH) is missing, downloading from github releases..."
 
-    curl -L -o "$GRAPH_PATH" "https://github.com/abdlfc11/Crestr-Hiking-App/releases/download/v0.2.0/graph.pkl"
+    curl -L -o "$GRAPH_PATH" "https://github.com/abdlfc11/Crestr-Hiking-App/releases/download/v0.2.1/graph.pkl"
 
     echo "Pathfinding graph downloaded"
 else


### PR DESCRIPTION
# Summary

- Replaced `v0.2.0` in the docker entrypoint download link for the graph asset to `v0.2.1`