### PR TITLE
Fix/saved routes dash

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -72,7 +72,7 @@ app.config["TEMPLATES_AUTO_RELOAD"] = True
 session_cookie_secure = os.environ.get("FLASK_ENV", "Production") != "development"
 
 app.config.update(
-    SESSION_COOKIE_SECURE=session_cookie_secure,
+    SESSION_COOKIE_SECURE=False,
     SESSION_COOKIE_HTTPONLY=True,    # Prevents JavaScript access (XSS mitigation)
     SESSION_COOKIE_SAMESITE='Lax',   # CSRF protection
     PERMANENT_SESSION_LIFETIME=3600  # Expires sessions after 1 hour
@@ -91,6 +91,7 @@ def format_distance(distance_km):
                 .where(Settings.key == "distanceUnit")
             ).first()
 
+            # if the user has not interacted with the settings before, distance_unit will be none, and so the distance is returned with the default distance units (km)
             if distance_unit == "km":
                 return f"{round(distance_km, 2)} km"
             elif distance_unit == "miles":

--- a/src/app.py
+++ b/src/app.py
@@ -92,7 +92,7 @@ def format_distance(distance_km):
             ).first()
 
             # if the user has not interacted with the settings before, distance_unit will be none, and so the distance is returned with the default distance units (km)
-            if distance_unit == "km":
+            if distance_unit == "km" or distance_unit is None:
                 return f"{round(distance_km, 2)} km"
             elif distance_unit == "miles":
                 return f"{round(distance_km * 0.621371, 2)} mi"

--- a/src/app.py
+++ b/src/app.py
@@ -72,7 +72,7 @@ app.config["TEMPLATES_AUTO_RELOAD"] = True
 session_cookie_secure = os.environ.get("FLASK_ENV", "Production") != "development"
 
 app.config.update(
-    SESSION_COOKIE_SECURE=False,
+    SESSION_COOKIE_SECURE=session_cookie_secure,
     SESSION_COOKIE_HTTPONLY=True,    # Prevents JavaScript access (XSS mitigation)
     SESSION_COOKIE_SAMESITE='Lax',   # CSRF protection
     PERMANENT_SESSION_LIFETIME=3600  # Expires sessions after 1 hour


### PR DESCRIPTION
# PR: Handle None value for default distance unit

## Summary

This PR adds a fallback check for `distance_unit`. If a user has not interacted with the settings yet, `distance_unit` defaults to `None`. This change ensures that the system treats a `None` value the same as "km", preventing potential bugs and ensuring the default distance unit is correctly applied.
