### PR TITLE
Fix/pathfinding

### DIFF
--- a/src/Pathfinding/pathfinder.py
+++ b/src/Pathfinding/pathfinder.py
@@ -140,12 +140,19 @@ def a_star(graph, start_xy, end_xy, min_slope=0.0):
     _, global_end_id = _global_kdtree.query(end_xy)
 
     # This calculates the bbox (bounding box)
-    buffer = 2000  
-    min_x = min(start_xy[0], end_xy[0]) - buffer
+
+    buffer = 5000  # 5000 metres, increased from 2000m as 2000m sometimes meant that paths could not be found, especially across ridge walks 
+
+    # This takes the minimum value and subtract the buffer
+    # and takes the maximum value and adds the buffer
+    # for both the x and y coordinate of the start and end points to create a rectangle 
+    min_x = min(start_xy[0], end_xy[0]) - buffer 
     max_x = max(start_xy[0], end_xy[0]) + buffer
     min_y = min(start_xy[1], end_xy[1]) - buffer
     max_y = max(start_xy[1], end_xy[1]) + buffer
 
+    # this finds the coordinate for the centre of the rectangle, used to make a diagonal radius 
+    # a diagonal radius is used to ensure that ALL four corners of the rectangle are included within the circle queried by the KDTree.query_ball_point() method 
     centre_x = (start_xy[0] + end_xy[0]) / 2
     centre_y = (start_xy[1] + end_xy[1]) / 2
     bbox_half_diag = ((max_x - min_x)**2 + (max_y - min_y)**2)**0.5 / 2
@@ -154,7 +161,8 @@ def a_star(graph, start_xy, end_xy, min_slope=0.0):
     # This filters node indicies within the given circular area using the global KDTree 
     candidate_indices = _global_kdtree.query_ball_point([centre_x, centre_y], radius)
 
-    # This filters nodes further with the bounding box
+    # This filters nodes further with the bounding box by cutting nodes off that are outside of the rectangle
+    # after the KDTree queried for the circle (which has a larger surface area than the rectangle)
     valid_indices_set = set()
     for index in candidate_indices:
         x, y = _global_node_coords[index]
@@ -173,7 +181,8 @@ def a_star(graph, start_xy, end_xy, min_slope=0.0):
         graph=graph,
         start_id=global_start_id,
         end_id=global_end_id,
-        valid_indices_set=valid_indices_set
+        valid_indices_set=valid_indices_set,
+        min_slope=min_slope
     )
 
     global_path = pathfinder.find_path()

--- a/static/js/routing/routing.js
+++ b/static/js/routing/routing.js
@@ -6,6 +6,7 @@ import { manualRouteState,
   cumbriaBoundary,
   isPointInPolygon
 } from "../routes/routeState.js";
+import { showError } from "../utils.js";
 
 export async function calculatePath(startPoint, endPoint) {
   const url = window.appConfig.apiCalculatePathUrl;
@@ -22,6 +23,7 @@ export async function calculatePath(startPoint, endPoint) {
   });
 
   if (!response.ok) {
+    showError("Sorry, there was an unexpected error when calculating your route, please try again later.")
     throw new Error(`HTTP error: ${response.status}`);
   }
 
@@ -30,6 +32,7 @@ export async function calculatePath(startPoint, endPoint) {
   if (data.success) {
     return data;
   }
+  showError("Sorry, there was an unexpected error when calculating your route, please try again later.")
   throw new Error(data.message || "Path creation failed");
 }
 


### PR DESCRIPTION
# PR: Enhance Route Error Handling and Optimise Bounding Box Buffer

## Summary
This PR improves user experience on the frontend by displaying explicit error notifications when route calculation fails. On the backend, it expands the pathfinding bounding box buffer from 2000m to 5000m to resolve issues where paths could not be found (particularly across ridge walks), and introduces detailed commentary explaining the geometric logic used for the bounding box and KD-Tree query radius.

---

## Changes

### 1. Frontend (routing.js)
The frontend changes import the showError utility from the utils.js file. Inside the calculatePath function, explicit user-facing error notifications are triggered using this utility under two conditions: if the network response is not OK, or if the backend returns a response indicating that data.success is false. In both error paths, an error is still thrown after notifying the user.

### 2. Backend (Path Finding)
The backend modifications increase the search area buffer from 2000 meters to 5000 meters. This update fixes edge cases where valid paths could not be resolved in sparse or complex terrains, such as across ridge walks. 

Additionally, comprehensive documentation has been added to clarify the bounding box logic. The comments explain how the minimum and maximum X and Y coordinates are adjusted by the buffer to form a bounding rectangle around the start and end points. Further comments outline how the center coordinates of this rectangle are determined to calculate a diagonal radius (bbox_half_diag). This diagonal radius guarantees that all four corners of the bounding rectangle are properly enclosed within the circular search area queried by the KD-Tree ball point method.