### PR TITLE
PR: v0.2.2 changes 

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,7 +19,7 @@ GRAPH_PATH="/app/graph_generation/elevation_populated_igraph.pkl"
 if [ ! -f "$GRAPH_PATH" ]; then
     echo "Pathfinding graph ($GRAPH_PATH) is missing, downloading from github releases..."
 
-    curl -L -o "$GRAPH_PATH" "https://github.com/abdlfc11/Crestr-Hiking-App/releases/download/v0.2.1/graph.pkl"
+    curl -L -o "$GRAPH_PATH" "https://github.com/abdlfc11/Crestr-Hiking-App/releases/download/v0.2.2/graph.pkl"
 
     echo "Pathfinding graph downloaded"
 else

--- a/src/Pathfinding/pathfinder.py
+++ b/src/Pathfinding/pathfinder.py
@@ -140,12 +140,19 @@ def a_star(graph, start_xy, end_xy, min_slope=0.0):
     _, global_end_id = _global_kdtree.query(end_xy)
 
     # This calculates the bbox (bounding box)
-    buffer = 2000  
-    min_x = min(start_xy[0], end_xy[0]) - buffer
+
+    buffer = 5000  # 5000 metres, increased from 2000m as 2000m sometimes meant that paths could not be found, especially across ridge walks 
+
+    # This takes the minimum value and subtract the buffer
+    # and takes the maximum value and adds the buffer
+    # for both the x and y coordinate of the start and end points to create a rectangle 
+    min_x = min(start_xy[0], end_xy[0]) - buffer 
     max_x = max(start_xy[0], end_xy[0]) + buffer
     min_y = min(start_xy[1], end_xy[1]) - buffer
     max_y = max(start_xy[1], end_xy[1]) + buffer
 
+    # this finds the coordinate for the centre of the rectangle, used to make a diagonal radius 
+    # a diagonal radius is used to ensure that ALL four corners of the rectangle are included within the circle queried by the KDTree.query_ball_point() method 
     centre_x = (start_xy[0] + end_xy[0]) / 2
     centre_y = (start_xy[1] + end_xy[1]) / 2
     bbox_half_diag = ((max_x - min_x)**2 + (max_y - min_y)**2)**0.5 / 2
@@ -154,7 +161,8 @@ def a_star(graph, start_xy, end_xy, min_slope=0.0):
     # This filters node indicies within the given circular area using the global KDTree 
     candidate_indices = _global_kdtree.query_ball_point([centre_x, centre_y], radius)
 
-    # This filters nodes further with the bounding box
+    # This filters nodes further with the bounding box by cutting nodes off that are outside of the rectangle
+    # after the KDTree queried for the circle (which has a larger surface area than the rectangle)
     valid_indices_set = set()
     for index in candidate_indices:
         x, y = _global_node_coords[index]
@@ -173,7 +181,8 @@ def a_star(graph, start_xy, end_xy, min_slope=0.0):
         graph=graph,
         start_id=global_start_id,
         end_id=global_end_id,
-        valid_indices_set=valid_indices_set
+        valid_indices_set=valid_indices_set,
+        min_slope=min_slope
     )
 
     global_path = pathfinder.find_path()

--- a/src/app.py
+++ b/src/app.py
@@ -72,7 +72,7 @@ app.config["TEMPLATES_AUTO_RELOAD"] = True
 session_cookie_secure = os.environ.get("FLASK_ENV", "Production") != "development"
 
 app.config.update(
-    SESSION_COOKIE_SECURE=session_cookie_secure,
+    SESSION_COOKIE_SECURE=False,
     SESSION_COOKIE_HTTPONLY=True,    # Prevents JavaScript access (XSS mitigation)
     SESSION_COOKIE_SAMESITE='Lax',   # CSRF protection
     PERMANENT_SESSION_LIFETIME=3600  # Expires sessions after 1 hour
@@ -91,6 +91,7 @@ def format_distance(distance_km):
                 .where(Settings.key == "distanceUnit")
             ).first()
 
+            # if the user has not interacted with the settings before, distance_unit will be none, and so the distance is returned with the default distance units (km)
             if distance_unit == "km":
                 return f"{round(distance_km, 2)} km"
             elif distance_unit == "miles":

--- a/src/app.py
+++ b/src/app.py
@@ -92,7 +92,7 @@ def format_distance(distance_km):
             ).first()
 
             # if the user has not interacted with the settings before, distance_unit will be none, and so the distance is returned with the default distance units (km)
-            if distance_unit == "km":
+            if distance_unit == "km" or distance_unit is None:
                 return f"{round(distance_km, 2)} km"
             elif distance_unit == "miles":
                 return f"{round(distance_km * 0.621371, 2)} mi"

--- a/src/app.py
+++ b/src/app.py
@@ -72,7 +72,7 @@ app.config["TEMPLATES_AUTO_RELOAD"] = True
 session_cookie_secure = os.environ.get("FLASK_ENV", "Production") != "development"
 
 app.config.update(
-    SESSION_COOKIE_SECURE=False,
+    SESSION_COOKIE_SECURE=session_cookie_secure,
     SESSION_COOKIE_HTTPONLY=True,    # Prevents JavaScript access (XSS mitigation)
     SESSION_COOKIE_SAMESITE='Lax',   # CSRF protection
     PERMANENT_SESSION_LIFETIME=3600  # Expires sessions after 1 hour

--- a/static/js/routing/routing.js
+++ b/static/js/routing/routing.js
@@ -6,6 +6,7 @@ import { manualRouteState,
   cumbriaBoundary,
   isPointInPolygon
 } from "../routes/routeState.js";
+import { showError } from "../utils.js";
 
 export async function calculatePath(startPoint, endPoint) {
   const url = window.appConfig.apiCalculatePathUrl;
@@ -22,6 +23,7 @@ export async function calculatePath(startPoint, endPoint) {
   });
 
   if (!response.ok) {
+    showError("Sorry, there was an unexpected error when calculating your route, please try again later.")
     throw new Error(`HTTP error: ${response.status}`);
   }
 
@@ -30,6 +32,7 @@ export async function calculatePath(startPoint, endPoint) {
   if (data.success) {
     return data;
   }
+  showError("Sorry, there was an unexpected error when calculating your route, please try again later.")
   throw new Error(data.message || "Path creation failed");
 }
 


### PR DESCRIPTION
## PR: v0.2.2 

### Summary

This PR consolidates frontend error handling improvements and critical backend calculation updates for the v0.2.2 release. It introduces fallback logic for uninitialised user distance units, implements explicit user notifications on frontend routing failures, and optimises the backend pathfinding search area to fix edge-case routing failures.

---

### Changes

#### 1. Settings & Unit System
* Added a fallback check to ensure that when the distance unit is uninitialised (None), it automatically defaults to "km" instead of causing potential system exceptions.

#### 2. Frontend Routing (routing.js)
* Integrated the showError utility from utils.js into the calculatePath function. 
* Triggers explicit error messages to the user if the network response fails or if the backend returns an unsuccessful path generation flag.

#### 3. Backend Pathfinding & Calculations
* Increased the search bounding box buffer from 2000m to 5000m to resolve path-generation issues across challenging terrains like ridge walks.
* Appended geometric code commentary clarifying the bounding box construction and how the diagonal radius ensures all four corners are included in the circular KD-Tree search.