### PR TITLE
fix: Resolve bug which meant that two users could not save a route with the same name

### DIFF
--- a/migrations/env.py
+++ b/migrations/env.py
@@ -24,6 +24,9 @@ if config.config_file_name is not None:
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
+
+from src.models import User, Route, Point, Settings, BetaCode, ActionLog, Issues
+
 target_metadata = SQLModel.metadata
 
 # other values from the config, defined by the needs of env.py,

--- a/migrations/versions/b6b92be4d26b_amend_saved_routes_and_points_database.py
+++ b/migrations/versions/b6b92be4d26b_amend_saved_routes_and_points_database.py
@@ -1,0 +1,43 @@
+"""Amend saved routes and points database
+
+Revision ID: b6b92be4d26b
+Revises: ca5bbea5443f
+Create Date: 2026-07-18 16:18:41.324884
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'b6b92be4d26b'
+down_revision: Union[str, Sequence[str], None] = 'ca5bbea5443f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # --- ROUTE TABLE CHANGES ---
+    # Drop the old standalone unique constraint on the name column
+    op.drop_constraint('route_name_key', 'route', type_='unique')
+    # Add the new composite unique constraint (user_id + name)
+    op.create_unique_constraint('user_route_name', 'route', ['user_id', 'name'])
+
+    # --- POINT TABLE CHANGES ---
+    # Drop the old standalone unique constraint on the name column
+    op.drop_constraint('point_name_key', 'point', type_='unique')
+    # Add the new composite unique constraint (user_id + name)
+    op.create_unique_constraint('user_point_name', 'point', ['user_id', 'name'])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # --- Revert POINT CHANGES ---
+    op.drop_constraint('user_point_name', 'point', type_='unique')
+    op.create_unique_constraint('point_name_key', 'point', ['name'])
+
+    # --- Revert ROUTE CHANGES ---
+    op.drop_constraint('user_route_name', 'route', type_='unique')
+    op.create_unique_constraint('route_name_key', 'route', ['name'])

--- a/src/models.py
+++ b/src/models.py
@@ -6,6 +6,7 @@ from sqlalchemy import Text, Column, func
 from datetime import timezone, datetime
 from typing import Optional, List
 from sqlalchemy.dialects.postgresql import TIMESTAMP
+from sqlalchemy import UniqueConstraint
 
 
 # DB MODELS
@@ -35,7 +36,7 @@ class Route(SQLModel, table=True):
     __tablename__ = "route"
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    name: str = Field(max_length=100, unique=True, nullable=False)
+    name: str = Field(max_length=100, nullable=False)
     coordinates: str = Field(sa_column=Column(Text, nullable=False))
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     eta_seconds: int = Field(nullable=False)
@@ -46,6 +47,11 @@ class Route(SQLModel, table=True):
     user_id: Optional[int] = Field(default=None, foreign_key="user.id")
     user: Optional[User] = Relationship(back_populates="routes")
 
+    # table arguments
+    __table_args__ = (
+        UniqueConstraint("user_id", "name", name="user_route_name"),
+    )
+
 # POINT TABLE
 class Point(SQLModel, table=True):
 
@@ -53,13 +59,18 @@ class Point(SQLModel, table=True):
     __tablename__ = "point"
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    name: str = Field(max_length=50, unique=True, nullable=False)
+    name: str = Field(max_length=50, nullable=False)
     coordinates: str = Field(max_length=1000, nullable=False)
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
     # relationships
     user_id: Optional[int] = Field(default=None, foreign_key="user.id")
     user: Optional[User] = Relationship(back_populates="points")
+
+    # table arguments
+    __table_args__ = (
+        UniqueConstraint("user_id", "name", name="user_point_name"),
+    )
 
 # SETTINGS TABLE
 class Settings(SQLModel, table=True):


### PR DESCRIPTION
# PR: Amend saved routes and points database schema

## Summary
Updates the unique constraints on the `route` and `point` tables. Instead of forcing global uniqueness on the name column alone, this introduces a composite unique constraint that allows different users to reuse the same names for their routes and points while maintaining uniqueness per user profile.

## What Changed
* Removed the global `unique=True` constraint from the `name` column on both the `Route` and `Point` models.
* Added a composite `UniqueConstraint` for `("user_id", "name")` across the `route` and `point` tables to ensure user-specific name uniqueness.
* Created and applied an Alembic migration script to safely alter the local and remote PostgreSQL database schemas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Route and point names can now be reused across different accounts.
  * Names remain unique within each account, preventing duplicate route or point names for the same account.

* **Bug Fixes**
  * Updated database migration behavior to apply the revised naming rules consistently to existing installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->