### PR TITLE
chore: Bump graph asset download to v0.2.4

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,7 +19,7 @@ GRAPH_PATH="/app/graph_generation/elevation_populated_igraph.pkl"
 if [ ! -f "$GRAPH_PATH" ]; then
     echo "Pathfinding graph ($GRAPH_PATH) is missing, downloading from github releases..."
 
-    curl -L -o "$GRAPH_PATH" "https://github.com/abdlfc11/Crestr-Hiking-App/releases/download/v0.2.3/graph.pkl"
+    curl -L -o "$GRAPH_PATH" "https://github.com/abdlfc11/Crestr-Hiking-App/releases/download/v0.2.4/graph.pkl"
 
     echo "Pathfinding graph downloaded"
 else


### PR DESCRIPTION
# PR: Bump to v0.2.4

- This PR bumps up the graph asset download link to v0.2.4