### PR TITLE
chore: Remove legacy console.log() remaining from debugging

### DIFF
--- a/static/js/elevationChart.js
+++ b/static/js/elevationChart.js
@@ -296,8 +296,8 @@ export function createElevationProfile(coordinates) {
         ctx.addEventListener('mouseleave', () => {
             clearMapHoverPoint();
         });
-    }
-}
+    };
+};
 
 export function toggleElevationChart() {
     const container = document.getElementById('elevation-chart-container');
@@ -309,17 +309,15 @@ export function toggleElevationChart() {
     if (isActive) {
         if (currentCoordinates && currentCoordinates.length >= 2) {
             createElevationProfile(currentCoordinates);
-        } else {
-            console.log("Chart container visible, waiting for route coords");
-        }
-    }
-}
+        };
+    };
+};
 
 export function initChartToggleListener() {
     const toggleButton = document.getElementById('toggle-elevation-chart');
     if (toggleButton) {
         toggleButton.onclick = toggleElevationChart;
     }
-}
+};
 
 


### PR DESCRIPTION
# Pull Request Template

## Summary
The PR aims to remove a recurring console.log() statement which occurs when both the following conditions are met:
   - The elevation profile chart is present and built
   - There are no coordinates for the elevation profile chart to use

## Related Issue
(Not Applicable)

## Type of Change
Select all that apply:
- [x] Bug fix  
- [ ] New feature  
- [ ] Documentation update  
- [ ] Refactor  
- [ ] Other (explain below)

## Description of Changes
Removed the line `console.log("Chart container visible, waiting for route coords");` as this was old legacy console.log() statements left over during debugging / the initial implementation of the elevation chart 

## Screenshots / Visuals (if applicable)
(Not Applicable)

## Testing
I checked the Dev console provided by the browser to ensure that the console.log() statements shown when the elevation profile chart does not have any coordinates, is removed 

## Checklist
- [x] My code follows the project’s style guidelines  
- [x] I have tested my changes  
- [x] I have updated documentation if needed  
- [x] I have referenced the related issue  
- [x] This PR is scoped, focused, and ready for review  

> **Note:**  
> PRs for issues **not** tagged as contributor‑friendly may be closed without review.