### PR TITLE
fix: Resolve z-index error which prevented the error popup to show in…

### DIFF
--- a/static/css/layout/slide-panel.css
+++ b/static/css/layout/slide-panel.css
@@ -22,7 +22,7 @@
   background: var(--glass-bg);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
-  z-index: 9999;
+  z-index: 3000;
   transition: all 0.35s ease-in-out;
 }
 


### PR DESCRIPTION
# Pull Request Template

## Summary
This PR aims to make error-popups, such as those informing users that they need to log in to perform a certain action, observable from the settings, saved route, and import route panels, by decreasing the z-index of the panels which is used in the 3 areas mentioned. 

## Related Issue
(Not Applicable) 

## Type of Change
Select all that apply:
- [x] Bug fix  
- [ ] New feature  
- [ ] Documentation update  
- [ ] Refactor  
- [ ] Other (explain below)

## Description of Changes
- `z-index` of the identifiers `#settings-panel`, `#import-route-panel` and `#saved-routes-dashboard` was decreased from `9999` to `3000` to ensure that the error-popup container had a higher `z-index` than these panels 
- This ensured that the 

## Screenshots / Visuals (if applicable)
(Not Applicable) 

## Testing
I tested that the error-popup showed by intentionally producing errors and observing that the error-popup appeared when these errors were produced, of which they did.

## Checklist
- [x] My code follows the project’s style guidelines  
- [x] I have tested my changes  
- [x] I have updated documentation if needed  
- [x] I have referenced the related issue  
- [x] This PR is scoped, focused, and ready for review  

> **Note:**  
> PRs for issues **not** tagged as contributor‑friendly may be closed without review.
