### PR TITLE
Feat/accountless routing

### DIFF
--- a/src/Auth/auth_api.py
+++ b/src/Auth/auth_api.py
@@ -90,6 +90,7 @@ def login():
 def logout():
     username = session.get("username", "user")
     session.pop('username', None)
+    session.clear()
     return jsonify({"success": True, "message": f"Sucessfully logged out of {username}"})
     
 @auth_api_bp.route("/registering", methods=["POST"])

--- a/src/Points/points_api.py
+++ b/src/Points/points_api.py
@@ -27,6 +27,10 @@ point_api_bp = Blueprint("point_api", __name__)
 @point_api_bp.route("/save_point", methods=["POST"])
 @limiter.limit("10 per minute")
 def save_point():
+
+    if not get_current_user():
+        return jsonify({"success": False, "message": "Please Login to save points."})
+
     # data received from front-end is broken down into web mercator coords that can be converted into bng
     data = request.get_json()
     point_name = data.get('point_name', '').strip()
@@ -81,6 +85,8 @@ def get_saved_points():
                 select(Point)
                 .where(Point.user_id == user.id)
             ).all()
+    else:
+        return jsonify({"success": False, "message": "User not logged in, no saved points to load"})
     
     if not points:
         return jsonify({"success": False, "message": "No points found" ,"points": []})

--- a/src/Report_Issue/report_issue_api.py
+++ b/src/Report_Issue/report_issue_api.py
@@ -9,12 +9,11 @@ from flask import (
     Blueprint,
     jsonify,
     request,
-    url_for,
 )
 
 # Local Modules
 from Report_Issue.helpers import log_issue
-from extensions import get_current_user, log_action, limiter
+from extensions import log_action, limiter
 
 
 #endregion
@@ -36,10 +35,6 @@ def report_issue_api():
         data = request.get_json()
         title = data.get("title")
         description = data.get("description")
-        user = get_current_user()
-
-        if not user:
-            return url_for("auth_api.login"), 401
 
         if not title or not description:
             return jsonify({"success": False, "message": "Title and description are required"}), 400

--- a/src/Routes/routes_api.py
+++ b/src/Routes/routes_api.py
@@ -17,6 +17,7 @@ from flask import (
     request,
     send_file,
 )
+from flask_limiter.errors import RateLimitExceeded
 
 # Local Modules
 from db import engine
@@ -41,6 +42,36 @@ from Routes.helpers import (
 route_api_bp = Blueprint("route_api", __name__)
 
 #endregion
+
+@route_api_bp.errorhandler(RateLimitExceeded)
+def handle_rate_limit_exceeded(e):
+    """
+    Function to handle if too many requests have been made, this shows an error to the end-user providing them information
+    instead of just failing if they try to generate too many routes (or any other action that is rate limited)
+    """
+    try:
+        with Session(engine) as db:
+            user = get_current_user()
+            if user:
+                db_routes = db.exec(
+                    select(Route).where(Route.user_id == user.id)
+                ).all()
+                available_routes = [r.model_dump() for r in db_routes]
+            else:
+                available_routes = []
+                
+            log_action('MISC', False, 'Rate limit exceeded', None, 'RATE_LIMIT_HIT')
+    except Exception as logging_error:
+        short_traceback = "".join(traceback.format_exception_only(type(logging_error), logging_error)).strip()
+        log_action('MISC', False, short_traceback, None, 'RATE_LIMIT_HIT')
+        available_routes = []
+
+    return jsonify({
+        "success": False,
+        "map_centre": DEFAULT_CENTRE, # This keeps the front-end Map safe from crashing
+        "available_routes": available_routes, # So does this
+        "message": "Too many requests. Please slow down."
+    }), 429
 
 # route which forms a path from the set of points the back-end receives as coordinates and returns it to the front-end
 @route_api_bp.route("/calculate_path", methods=["POST"])
@@ -267,6 +298,9 @@ def save_route():
                 return jsonify({"success": False, "message": "Invalid request"}), 400
 
             user = get_current_user()
+
+            if not user: 
+                return jsonify({"success": False, "message": "Please log in to save routes. "})
 
             route_name = data.get("route_name")
             coordinates = data.get("coordinates")
@@ -513,6 +547,9 @@ def import_route():
             success (bool)
             coords (list of [lat, lon, ele?])
     """
+
+    if not get_current_user():
+        return jsonify({"success": False, "message": "Please log in to import files. "})
 
     # this retrieves the uploaded file from the request
     uploaded_file = request.files.get("route_file")

--- a/src/app.py
+++ b/src/app.py
@@ -196,12 +196,20 @@ def register_page():
 @limiter.exempt
 def map_view():
 
-    # gets list of available routes for the load dropdown
+    # gets user details, if there is no user then available routes and saved points are set to be empty 
     user = get_current_user()
+
     if user is None:
         available_routes = []
         saved_points = []
-        return redirect(url_for("login_page"))
+        return render_template("map.html",
+                                map_centre = DEFAULT_CENTRE,
+                                map_zoom = 10.5,
+                                current_path = session.get('current_path', None),
+                                available_routes=available_routes,
+                                saved_points=saved_points,
+                                logged_in = "false" if user is None else "true"
+        )
     
     with Session(engine) as db:
         try: 

--- a/src/app.py
+++ b/src/app.py
@@ -208,7 +208,7 @@ def map_view():
                                 current_path = session.get('current_path', None),
                                 available_routes=available_routes,
                                 saved_points=saved_points,
-                                logged_in = "false" if user is None else "true"
+                                logged_in = "false"
         )
     
     with Session(engine) as db:
@@ -242,7 +242,8 @@ def map_view():
                                 current_path = session.get('current_path', None),
                                 available_routes=available_routes,
                                 saved_points=web_mercator_points,
-                                logged_in = (user is not None))
+                                logged_in = "true"
+                            )
         except Exception as e:
 
             short_traceback = "".join(traceback.format_exception_only(type(e), e)).strip()

--- a/static/css/base/reset.css
+++ b/static/css/base/reset.css
@@ -23,8 +23,23 @@ html.dark input:-webkit-autofill {
   -webkit-text-fill-color: #f3f4f6 !important;
 }
 
-/* Respect reduced-motion preference — was previously report-issue.css-only,
-   promoted here since it's a general accessibility rule that should apply
+/* This class is used on both links and buttons, signalling that the action cannot be performed
+  pointer-events is intentionally not set to none as hover interaction is required to register the tooltip
+  which adds further info to the user */
+.inactive {
+  cursor: not-allowed !important;
+  opacity: .8 !important;
+}
+
+.inactive[data-tooltip]::after,
+.inactive[data-tooltip]::before {
+  opacity: 1 !important;
+}
+
+
+
+/* This respects reduced-motion preference 
+  Implemented as a general accessibility rule that applies
    to any transition using these component classes on any page. */
 @media (prefers-reduced-motion: reduce) {
   .btn,

--- a/static/css/components/tooltip.css
+++ b/static/css/components/tooltip.css
@@ -6,12 +6,14 @@
 
 /* Tooltip wrapper */
 label[data-tooltip],
-a[data-tooltip] {
+a[data-tooltip],
+button[data-tooltip] {
   position: relative;
 }
 
 label[data-tooltip]::after,
-a[data-tooltip]::after {
+a[data-tooltip]::after,
+button[data-tooltip]::after {
   content: attr(data-tooltip);
   position: absolute;
   bottom: calc(100% + 8px);
@@ -41,7 +43,8 @@ a[data-tooltip]::after {
 
 /* Little arrow */
 label[data-tooltip]::before,
-a[data-tooltip]::before {
+a[data-tooltip]::before,
+button[data-tooltip]::before {
   content: "";
   position: absolute;
   bottom: 100%;
@@ -61,7 +64,9 @@ a[data-tooltip]::before {
 label[data-tooltip]:hover::after,
 label[data-tooltip]:hover::before,
 a[data-tooltip]:hover::after,
-a[data-tooltip]:hover::before {
+a[data-tooltip]:hover::before,
+button[data-tooltip]:hover::after,
+button[data-tooltip]:hover::before {
   opacity: 1;
   visibility: visible;
   transform: translateX(-50%) translateY(0);

--- a/static/js/routes/saveRoute.js
+++ b/static/js/routes/saveRoute.js
@@ -127,8 +127,7 @@ function handleSaveRoute(e) {
         homeButtonFunction();
         updateSaveRouteContainer();
       } else {
-        showError("There was an error saving your route. Please try again later.")
-        console.error(data.message)
+        showError( data.message || "There was an error saving your route. Please try again later.")
         return false;
       }
     })

--- a/static/js/routing/routing.js
+++ b/static/js/routing/routing.js
@@ -22,17 +22,17 @@ export async function calculatePath(startPoint, endPoint) {
     }),
   });
 
+  const data = await response.json();
+
   if (!response.ok) {
-    showError("Sorry, there was an unexpected error when calculating your route, please try again later.")
+    showError(data.message || "Sorry, there was an unexpected error when calculating your route, please try again later.")
     throw new Error(`HTTP error: ${response.status}`);
   }
-
-  const data = await response.json();
 
   if (data.success) {
     return data;
   }
-  showError("Sorry, there was an unexpected error when calculating your route, please try again later.")
+  showError(data.message || "Sorry, there was an unexpected error when calculating your route, please try again later.")
   throw new Error(data.message || "Path creation failed");
 }
 

--- a/static/js/saved_points/savedPoints.js
+++ b/static/js/saved_points/savedPoints.js
@@ -1,5 +1,6 @@
 import { getSavedPointStyle } from "./style.js";
 import { getMap } from "../map.js";
+import { showError } from "../utils.js";
 
 let savedPointsLayer = null;
 
@@ -50,13 +51,20 @@ function getSavedPoints() {
 }
 
 export function loadAndDisplaySavedPoints() {
-    clearOldSavedPointsLayer();
 
-    getSavedPoints()
-        .then(convertPointsToFeatures)
-        .then(createSavedPointsLayer)
-        .then(addLayerToMap)
-        .catch(err => console.error("Error:", err))
+  // This is to ensure that no errors are thrown when a user is not logged in
+  const isLoggedIn = window.appConfig.loggedIn
+  if (!isLoggedIn) {
+    return;
+  }
+
+  clearOldSavedPointsLayer();
+
+  getSavedPoints()
+      .then(convertPointsToFeatures)
+      .then(createSavedPointsLayer)
+      .then(addLayerToMap)
+      .catch(err => console.error("Error:", err))
 }
 
 export function saveNewPoint(coordinate, name) {
@@ -80,16 +88,16 @@ export function saveNewPoint(coordinate, name) {
             errorData.message ||
               `Server responded with status ${response.status}`,
           );
-        });
+        })
       }
       return response.json();
     })
     .then((data) => {
       if (data.success) {
-        alert(`Saved ${data.message}`);
         return loadAndDisplaySavedPoints();
       }
-      alert(`Error saving point: ${data.message}`);
+      showError(data.message || "There was an error on our end, please try again later.");
+      return;
     })
     .catch((error) => {
       alert(`Could not save point: ${error.message}`);

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -47,6 +47,12 @@ export function initSettings() {
   syncCheckboxWithCurrentSettings();
   syncThemeRadiosWithCurrentSettings();
   applyTheme(getTheme());
+
+  const isLoggedIn = window.appConfig.loggedIn
+
+  if (!isLoggedIn) {
+    return;
+  }
  
   // 2. Background sync with server (user is authenticated on /map)
   loadAppSettingsFromServer()
@@ -205,7 +211,7 @@ function initAccountManagementButtons() {
   // Final confirmation calls the delete endpoint from flask backend
   if (confirmBtn) {
     confirmBtn.addEventListener("click", () => {
-      deleteAccount(true); // skip the browser confirm, we already did the nice UI version
+      deleteAccount(true);
     });
   }
 }

--- a/static/js/settingsState.js
+++ b/static/js/settingsState.js
@@ -85,6 +85,12 @@ export async function loadAppSettingsFromServer() {
     return getAppSettings();
   }
 
+  // This is to ensure that no errors are thrown when a user is not logged in
+  const isLoggedIn = window.appConfig.loggedIn
+  if (!isLoggedIn) {
+    return getAppSettings();
+  }
+
   try {
     const res = await fetch(url, { method: "GET", credentials: "same-origin" });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -114,6 +120,13 @@ export async function loadAppSettingsFromServer() {
  * @returns {Promise<{ success: boolean, message?: string }>}
  */
 export async function saveAppSettingsToServer(settingsDict) {
+
+  // This is to ensure that no errors are thrown when a user is not logged in
+  const isLoggedIn = window.appConfig.loggedIn
+  if (!isLoggedIn) {
+    return;
+  }
+
   const url = window.appConfig && window.appConfig.apiSaveSettings;
   if (!url) throw new Error("apiSaveSettings not present in window.appConfig");
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -404,6 +404,10 @@ export function closeNav() {
 }
 
 function openSavedRoutesDash() {
+
+  // This prevents non-logged in and registered users from opening the save route panel
+  if (!window.appConfig.loggedIn) return;
+
   savedRoutesDashContent.style.width = "100vw";
 
   if (!localStorage.getItem('seenSavedRouteDashTour')) {
@@ -440,6 +444,10 @@ export function closeSettings() {
 };
 
 function openImportRoute() {
+
+  // This prevents non-logged in and registered users from opening the save route panel
+  if (!window.appConfig.loggedIn) return;
+
   importRoutePanel.style.width = "100vw";
 
   if (!localStorage.getItem('seenImportRouteTour')) {
@@ -504,7 +512,7 @@ async function handleRouteImport() {
       data = await processImportedRouteFile(file); 
 
       if (!data || !data.coords) {
-        showError("There was an error on our end. Please try again later.");
+        showError(data || "There was an error on our end. Please try again later.");
         return false;
       }
 

--- a/templates/map.html
+++ b/templates/map.html
@@ -49,7 +49,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/driver.js@latest/dist/driver.css"/>
     
     <!-- Chart.js -->
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js"></script>
 
     <!-- Umami Analytics -->
     <!-- SELF HOSTERS: Change values in you .env file -->
@@ -200,8 +200,15 @@
     <div id="the-sidenav" class="sidenav">
         <div id="sidenav-upper-links">
             <a id="close-nav-button" href="javascript:void(0)" class="closebtn">&times;</a>
-            <a onclick="openSavedRoutesDash()" id="saved-routes-dash-open-button"><i data-lucide="waypoints"></i>Saved Routes</a>
-            <a id="import-route-open-button"><i data-lucide="import"></i>Import Route</a>
+
+            <!-- JINJA used to determine if the saved route dashboard and import route panel is accessible to users depending on if they are logged in -->
+            {% if not session.get("preferred_name") %}
+                <a class="inactive" aria-disabled="true" data-tooltip="Please Login to save routes." id="saved-routes-dash-open-button"><i data-lucide="waypoints"></i>Saved Routes</a>
+                <a class="inactive" aria-disabled="true" data-tooltip="Please Login to import routes." id="import-route-open-button"><i data-lucide="import"></i>Import Route</a>
+            {% else %}
+                <a id="saved-routes-dash-open-button"><i data-lucide="waypoints"></i>Saved Routes</a>
+                <a id="import-route-open-button"><i data-lucide="import"></i>Import Route</a>
+            {% endif %}
             <a id="settings-open-button"><i data-lucide="settings"></i>Settings</a>
             <a id="report-issues-button" href="/report-an-issue" ><i data-lucide="bug"></i>Report Issues</a>
         </div>
@@ -216,67 +223,81 @@
     <div id="saved-routes-dashboard">
         <div class="inner-content">
             
-            <header id="dashboard-header" class="saved-route-header">
-                <div id="top-section">
-                    <h1>Hi {{ session.get("preferred_name") }}, these are your saved routes</h1>
-                    
-                    <div id="go-back-button-container">
-                        <a class="closebtn" id="saved-routes-dash-go-back-button">&times;</a>
-                    </div>  
-                </div>
-            </header>
+                {% if not session.get("preferred_name") %}
+                    <header id="dashboard-header" class="saved-route-header">
+                        <div id="top-section">
+                            <h1>Please Login to save routes</h1>
+                            <div id="go-back-button-container">
+                                <a class="closebtn" id="saved-routes-dash-go-back-button">&times;</a>
+                            </div>  
 
-            <div id="all-routes-container">
-                {% if available_routes %}
-                    {% for route in available_routes %}
-                    <div class="route-card" data-route-name="{{ route.name }}">
-                        <div class="route-card-header">
-                            <h3 class="route-card-name">{{ route.name }}</h3>
-                            <span class="route-card-date">Saved on {{ route.created_at | strftime("%d/%m/%Y") }}</span>
                         </div>
-                        <div class="route-card-stats">
-                            <div class="stat-item">
-                                <span class="stat-label">Distance:</span>
-                                <span class="stat-value" data-distance-km="{{ route.distance_km }}">{{ route.distance_km | format_distance }}</span>
-                            </div>
-                            <div class="stat-item">
-                                <span class="stat-label">ETA:</span>
-                                <span class="stat-value">{{ route.eta_seconds | format_eta }}</span>
-                            </div>
-                            <div class="stat-item">
-                                <span class="stat-label">Elevation Gain:</span>
-                                <span class="stat-value">{{ route.elevation_change | format_elevation }}</span>
-                            </div>
-                        </div>
-                        <div class="route-card-actions">
-                            <button type="button" class="route-btn route-btn-delete">Delete</button>
-                            <button type="button" class="route-btn route-btn-download-gpx">
-                                <span class="route-btn-text">GPX</span>
-                                <span class="loader"></span>
-                            </button>
-                            <button type="button" class="route-btn route-btn-download-geojson">
-                                <span class="route-btn-text">GeoJSON</span>
-                                <span class="loader"></span>
-                            </button>
-                            <button type="button" class="route-btn route-btn-load">Load</button>
-                        </div>
-                    </div>
-                    {% endfor %}
-                
+                    </header>
                 {% else %}
-                    <div id="no-routes-wrapper" class="no-routes-wrapper">
-                        <div class="no-routes-card">
-                            <h2 class="no-routes-title">No routes saved yet</h2>
-                            <p class="no-routes-description">
-                                You haven’t created any routes. Start planning your next adventure below.
-                            </p>
-                            <button id="no-route-create-button" class="no-routes-create-btn generate-button">
-                                Create a route
-                            </button>
-                        </div>
+
+                <header id="dashboard-header" class="saved-route-header">
+                    <div id="top-section">
+                        <h1>Hi {{ session.get("preferred_name") }}, these are your saved routes</h1>
+
+                        <div id="go-back-button-container">
+                            <a class="closebtn" id="saved-routes-dash-go-back-button">&times;</a>
+                        </div>  
+
                     </div>
-                {% endif %}
-            </div>
+                </header>
+
+                <div id="all-routes-container">
+                    {% if available_routes %}
+                        {% for route in available_routes %}
+                        <div class="route-card" data-route-name="{{ route.name }}">
+                            <div class="route-card-header">
+                                <h3 class="route-card-name">{{ route.name }}</h3>
+                                <span class="route-card-date">Saved on {{ route.created_at | strftime("%d/%m/%Y") }}</span>
+                            </div>
+                            <div class="route-card-stats">
+                                <div class="stat-item">
+                                    <span class="stat-label">Distance:</span>
+                                    <span class="stat-value" data-distance-km="{{ route.distance_km }}">{{ route.distance_km | format_distance }}</span>
+                                </div>
+                                <div class="stat-item">
+                                    <span class="stat-label">ETA:</span>
+                                    <span class="stat-value">{{ route.eta_seconds | format_eta }}</span>
+                                </div>
+                                <div class="stat-item">
+                                    <span class="stat-label">Elevation Gain:</span>
+                                    <span class="stat-value">{{ route.elevation_change | format_elevation }}</span>
+                                </div>
+                            </div>
+                            <div class="route-card-actions">
+                                <button type="button" class="route-btn route-btn-delete">Delete</button>
+                                <button type="button" class="route-btn route-btn-download-gpx">
+                                    <span class="route-btn-text">GPX</span>
+                                    <span class="loader"></span>
+                                </button>
+                                <button type="button" class="route-btn route-btn-download-geojson">
+                                    <span class="route-btn-text">GeoJSON</span>
+                                    <span class="loader"></span>
+                                </button>
+                                <button type="button" class="route-btn route-btn-load">Load</button>
+                            </div>
+                        </div>
+                        {% endfor %}
+                    
+                    {% else %}
+                        <div id="no-routes-wrapper" class="no-routes-wrapper">
+                            <div class="no-routes-card">
+                                <h2 class="no-routes-title">No routes saved yet</h2>
+                                <p class="no-routes-description">
+                                    You haven’t created any routes. Start planning your next adventure below.
+                                </p>
+                                <button id="no-route-create-button" class="no-routes-create-btn generate-button">
+                                    Create a route
+                                </button>
+                            </div>
+                        </div>
+                    {% endif %}
+                </div>
+            {% endif %}
 
         </div>
     </div>
@@ -286,8 +307,9 @@
         <div class="inner-content">
             <header class="settings-header">
                 <div class="settings-header-container">
-                    <h1>Welcome,</h1>
-                    <h1 style="margin-left: .75rem;" >{{ session.get("preferred_name") }}</h1>
+
+                    <h1>Settings</h1>
+                    
                     <div id="settings-close-button-container">
                         <a class="settingCloseButton" id="settings-close-button">&times;</a>
                     </div>
@@ -333,11 +355,24 @@
                  <!-- Delete Account -->
                  <div class="settings-item settings-item-destructive" id="delete-account-container">
                     <div class="delete-normal-state">
+
                         <div class="settings-text">
                             <span class="settings-title">Delete Account</span>
                             <span class="settings-description">Permanently remove your account and all data</span>
                         </div>
-                        <button type="button" class="delete-account-btn" id="settings-delete-account-button">Delete</button>
+                        
+                        <button
+                            {% if not session.get('preferred_name') %} 
+                                disabled 
+                                class="delete-account-btn inactive"
+                                data-tooltip="You must Login to perform this action."
+                            {% else %} 
+                                class="delete-account-btn"
+                            {% endif %}
+                            type="button"
+                            id="settings-delete-account-button"
+                        >Delete</button>
+                        
                     </div>
 
                     <div class="delete-confirm-state" style="display: none; width: 100%;">
@@ -355,7 +390,18 @@
 
             <!-- ##### FOOTER (inc. logout button) ##### -->
             <div class="settings-sticky-footer">
-                <button id="settings-logout-button" class="logout-button">Log out</button>
+
+                <button
+                id="settings-logout-button"
+                {% if not session.get('preferred_name') %} 
+                    disabled 
+                    class="logout-button inactive"
+                    data-tooltip="You must Login to perform this action."
+                {% else %} 
+                    class="logout-button"
+                {% endif %}
+                >Log out</button>
+
             </div>
         </div>
     </div>
@@ -484,6 +530,7 @@
     <!-- ##### AppConfig to access API Enpoint URLS ##### -->
     <script>
         window.appConfig = {
+            loggedIn: {{ logged_in }},
             mapInitialCenter: {{ map_centre | tojson }},
             mapInitialZoom: {{ map_zoom | default(10) }},
             initialCurrentPath: {% if current_path %}{{ current_path | tojson }}{% else %}null{% endif %},


### PR DESCRIPTION
# Pull Request Template

## Summary
Adds support for unauthenticated access to public-facing routes (map view, route generation, settings) while clearly gating account-specific features (saving routes/points, report issue, delete account, logout) behind login, with clean UX feedback instead of hard redirects.

## Related Issue
(Not Applicable 

## Type of Change
Select all that apply:
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (explain below)

## Description of Changes
Previously, several routes forced a redirect to the login page for unauthenticated users, even where login wasn't strictly necessary (e.g. viewing the map, generating a route). This PR reworks auth handling so unauthenticated users can access the core app experience directly, while account-bound features are gated cleanly instead of via redirect.

Specific changes:

- **Auth routes**: reworked to support the new unauthenticated access model.
- **Map view routes**: no longer redirect to login if the user isn't authenticated, map and routing are now accessible without an account.
- **Report issue route**: previously required login; now accessible without one. "Not applicable" issue option and screenshot attachment both retained and working.
- **Saving points / saving routes**: now locked behind both backend and frontend barriers.
  - Backend: requests from unauthenticated users are rejected.
  - Frontend: action is blocked and clearly communicated via popup rather than failing silently or redirecting.
- **Saved route panel / import route panel**: made unclickable for unauthenticated users.
- **Delete account / logout buttons**: made unclickable for unauthenticated users (they shouldn't be actionable with no active session).
- **Unclickable elements** (panels + buttons above) now have consistent visual + accessible affordances:
  - Reduced opacity
  - `cursor: not-allowed`
  - Tooltip explaining why the action is disabled
- **Settings routes**: previously worked for unauthenticated users but silently logged errors in the background. This is now resolved, settings routes function correctly for unauthenticated users with no error logging.

## Screenshots / Visuals (if applicable)
(Not Applicable)

## Testing
Manually tested locally across both authenticated and unauthenticated states:
- Verified map view and route generation load and function without an account, with no redirect to login.
- Verified report issue flow (including "not applicable" option and screenshot attachment) works while logged out.
- Attempted to save a route/point while logged out: confirmed both backend rejection and frontend popup fire correctly.
- Confirmed saved route panel, import route panel, delete account, and logout are unclickable while logged out, with correct tooltip, opacity, and cursor styling.
- Confirmed settings routes work while logged out and no longer produce errors in logs.
- Re-tested all of the above while logged in to confirm no regressions to existing authenticated behavior.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have tested my changes
- [x] I have updated documentation if needed
- [x] I have referenced the related issue
- [x] This PR is scoped, focused, and ready for review

> **Note:**
> PRs for issues **not** tagged as contributor‑friendly may be closed without review.