### PR TITLE
Fix/import route empty file

### DIFF
--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -500,6 +500,10 @@ async function handleRouteImport() {
       
       const file = importRouteFileInput.files[0];
 
+      if (file.size === 0) {
+        showError("The selected file is empty.")
+      }
+
       if (!file) {
         showError("Please select a file to import.");
         return false;

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -500,16 +500,6 @@ async function handleRouteImport() {
       
       const file = importRouteFileInput.files[0];
 
-      if (file.size === 0) {
-        showError("The selected file is empty.")
-        return false;
-      }
-
-      if (!file) {
-        showError("Please select a file to import.");
-        return false;
-      }
-
       if (!validateFileInput()) {
         return false;
       }
@@ -613,6 +603,12 @@ function validateFileInput() {
     if (file.size > 5 * 1024 * 1024) {
         showError("File size is too large. Please select a file smaller than 5MB.");
         return false;
+    }
+
+    // this checks if the file is empty or not
+    if (file.size === 0) {
+      showError("The selected file is empty.")
+      return false;
     }
 
     return true;

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -502,6 +502,7 @@ async function handleRouteImport() {
 
       if (file.size === 0) {
         showError("The selected file is empty.")
+        return false;
       }
 
       if (!file) {


### PR DESCRIPTION
# Pull Request Template

## Summary
This PR aims to prevent confusion when importing files that are empty. Previously when attempting to import an empty file the user would receive a generic error, which implied that the error was due to the server, and, incorrectly, asking the user to try again later. After this PR, the user receives an error-popup which tells them that the selected file is empty. 

## Related Issue
(Not Applicable)

## Type of Change
Select all that apply:
- [x] Bug fix  
- [ ] New feature  
- [ ] Documentation update  
- [ ] Refactor  
- [ ] Other (explain below)

## Description of Changes
Conditional logic was implemented when receiving the file, with `file.size === 0` being used to evaluate if the file is empty or not. This ensures that empty files are accounted for during file validation, and ensures that the user immediately receives feedback on the file being empty when they enter the file into the file input. 

## Screenshots / Visuals (if applicable)
(Not Applicable)

## Testing
Tested importing an empty file and ensured that the UI popup which informed the user that the selected file was empty appeared

## Checklist
- [x] My code follows the project’s style guidelines  
- [x] I have tested my changes  
- [x] I have updated documentation if needed  
- [x] I have referenced the related issue  
- [x] This PR is scoped, focused, and ready for review  

> **Note:**  
> PRs for issues **not** tagged as contributor‑friendly may be closed without review.
