### PR TITLE
feat: Add login modal to replace tooltips shown when a guest user att…

### DIFF
--- a/static/css/components/modal.css
+++ b/static/css/components/modal.css
@@ -106,6 +106,8 @@
   background-color: #dc2626;
 }
 
+/* This is meant for regular actions
+   such as transitioning to a different page */
 .modal-btn-normal {
     background-color: var(--blue);
     color: white;

--- a/static/js/routes/saveRoute.js
+++ b/static/js/routes/saveRoute.js
@@ -10,7 +10,7 @@ import { getCurrentMode,
   setCurrentPathData, 
   normaliseCoordLength
  } from "./routeState.js";
-import { defaultCentre, homeButtonFunction, updateSaveRouteContainer } from "../ui.js";
+import { defaultCentre, homeButtonFunction, updateSaveRouteContainer, showLoginModal } from "../ui.js";
 import { getMap } from "../map.js";
 import { initSavedRoutesDashboard } from "./savedRoutesDashboard.js";
 import { createRouteCard, formatDistance, formatElevation, formatETA, removeDOMElement, showError } from "../utils.js";
@@ -33,6 +33,11 @@ export function initSaveRoute() {
 
 function handleSaveRoute(e) {
   e.preventDefault();
+
+  if (!window.appConfig.loggedIn) {
+    showLoginModal(true, 'save routes');
+    return;
+  }
 
   let elevDisplayValue; 
   let routeName = "";

--- a/static/js/saved_points/savedPoints.js
+++ b/static/js/saved_points/savedPoints.js
@@ -1,6 +1,6 @@
 import { getSavedPointStyle } from "./style.js";
 import { getMap } from "../map.js";
-import { showError } from "../utils.js";
+import { showLoginModal } from "../ui.js";
 
 let savedPointsLayer = null;
 
@@ -68,6 +68,13 @@ export function loadAndDisplaySavedPoints() {
 }
 
 export function saveNewPoint(coordinate, name) {
+
+  const isLoggedIn = window.appConfig.loggedIn
+  if (!isLoggedIn) {
+    showLoginModal(true);
+    return;
+  }
+
   const url = window.appConfig.apiSavePointUrl;
   const x = coordinate[0];
   const y = coordinate[1];

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -128,7 +128,13 @@ const deletePointConfirmationDialog = document.getElementById("delete-point-conf
 const pointDeleteModalNameDisplay = document.getElementById("point-name-display");
 const pointDeleteDeleteButton = document.getElementById("point-delete-delete-button");
 const pointDeleteExitButton = document.getElementById("point-delete-exit-button");
-const dialogWrapper = deletePointConfirmationDialog?.querySelector(".wrapper");
+const pointDeleteDialogWrapper = deletePointConfirmationDialog?.querySelector(".wrapper");
+
+// login modal
+const loginModal = document.getElementById('login-dialog');
+const loginModalLoginButton = document.getElementById('login-dialog-login');
+const loginModalExitButton = document.getElementById('login-dialog-exit');
+const loginModalContent = loginModal.querySelector('.modal-content');
 
 // saved route dash panel
 const openSavedRoutesDashButton = document.getElementById('saved-routes-dash-open-button');
@@ -213,6 +219,51 @@ function noRouteCreateFunction() {
   closeNav()
   closeSavedRoutesDash()
 }
+
+//#region LOGIN MODAL
+
+/**
+ * Toggles the login modal display and sets the action context
+ * @param {boolean} show true if you want to show the modal, false if you want to hide the modal
+ * @param {string} [actionName='perform this action'] the specific action that is being performed when showing the modal e.g save routes 
+ * @returns {void}
+ */
+export function showLoginModal(show, actionName = 'perform this action') {
+  const dialog = document.getElementById('login-dialog');
+  const messageElement = dialog.querySelector('.modal-body p');
+
+  if (show) {
+
+    // This updates the message dynamically
+    messageElement.textContent = `An account is required to ${actionName}.`;
+    dialog.showModal();
+  } 
+  else {
+    dialog.close();
+  }
+};
+
+/**
+ * Function used to transition to the login page from the login modal
+ * @returns {void}
+ */
+function loginModalLogin() {
+  showLoginModal(false);
+  window.location.href = 'https://app.crestr.co.uk/login-page';
+  return;
+};
+
+/**
+ * Function used to catch clicks outside of the modal in order to close the modal upon these clicks 
+ * @returns {void}
+ */
+function dismissLoginModal(e) {
+  if (loginModalContent && !loginModalContent.contains(e.target)) {
+      showLoginModal(false);
+    }
+};
+
+//#endregion
 
 //#region COORDINATE INPUT FUNCTIONS
 
@@ -406,7 +457,10 @@ export function closeNav() {
 function openSavedRoutesDash() {
 
   // This prevents non-logged in and registered users from opening the save route panel
-  if (!window.appConfig.loggedIn) return;
+  if (!window.appConfig.loggedIn) {
+    showLoginModal(true, "save routes");
+    return;
+  };
 
   savedRoutesDashContent.style.width = "100vw";
 
@@ -446,7 +500,10 @@ export function closeSettings() {
 function openImportRoute() {
 
   // This prevents non-logged in and registered users from opening the save route panel
-  if (!window.appConfig.loggedIn) return;
+  if (!window.appConfig.loggedIn) {
+    showLoginModal(true, "import routes");
+    return;
+  };
 
   importRoutePanel.style.width = "100vw";
 
@@ -1264,7 +1321,7 @@ function initPointDeleteHandlers() {
   if (!deletePointConfirmationDialog) return;
 
   deletePointConfirmationDialog.addEventListener("click", (e) => {
-    if (dialogWrapper && !dialogWrapper.contains(e.target)) {
+    if (pointDeleteDialogWrapper && !pointDeleteDialogWrapper.contains(e.target)) {
       deletePointConfirmationDialog.close();
     }
   });
@@ -1484,6 +1541,11 @@ export function initUi() {
 
   // These event listeners are for keyboard shortcuts.
   addClickListener(document, handleKeyboardShortcuts, "keydown");
+
+  // These event listeners are for the login modal
+  addClickListener(loginModalExitButton, () => showLoginModal(false), 'click');
+  addClickListener(loginModalLoginButton, loginModalLogin, 'click');
+  addClickListener(loginModal, dismissLoginModal, 'click');
 
   onMapClick(mapClickHandler);
   onMapRenderComplete(mapRenderComplete);

--- a/templates/map.html
+++ b/templates/map.html
@@ -23,6 +23,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/components/error-toast.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/components/loading-spinner.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/components/tooltip.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/components/modal.css') }}">
 
     <!-- Layout CSS Files -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/layout/nav-menu.css') }}">
@@ -173,20 +174,38 @@
             <button id="remove-point-button">remove</button>
         </div>
 
+        <!-- ##### LOGIN MODAL ##### -->
+        <dialog id="login-dialog" class="modal-overlay">
+            <div class="modal-wrapper">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h2>Login</h2>
+                    </div>
+                    <div class="modal-body">
+                        <p>An account is required to perform this action.</p>
+                    </div>
+                    <div class="modal-actions">
+                        <button type="button" id="login-dialog-exit" class="modal-btn modal-btn-secondary">Close</button>
+                        <button id="login-dialog-login" class="modal-btn modal-btn-normal">Login</button>
+                    </div>
+                </div>
+            </div>
+        </dialog>
+
         <!-- ##### DELETE POINT MODAL ##### -->
-        <dialog id="delete-point-confirmation-dialog" class="confirmation-modal">
-            <div class="wrapper">
-                <div class="confirmation-modal-content">
-                    <div class="confirmation-modal-header">
+        <dialog id="delete-point-confirmation-dialog" class="modal-overlay">
+            <div class="modal-wrapper">
+                <div class="modal-content">
+                    <div class="modal-header">
                         <h2>Delete Point</h2>
                     </div>
-                    <div class="confirmation-modal-body">
+                    <div class="modal-body">
                         <p>Are you sure you want to remove this point:</p>
                         <p><span id="point-name-display"></span>?</p>
                     </div>
-                    <div class="confirmation-buttons">
-                        <button type="button" id="point-delete-exit-button">Exit</button>
-                        <button id="point-delete-delete-button">Delete Point</button>
+                    <div class="modal-actions">
+                        <button type="button" id="point-delete-exit-button" class="modal-btn modal-btn-secondary">Exit</button>
+                        <button id="point-delete-delete-button" class="modal-btn modal-btn-danger">Delete Point</button>
                     </div>
                 </div>
             </div>
@@ -200,15 +219,8 @@
     <div id="the-sidenav" class="sidenav">
         <div id="sidenav-upper-links">
             <a id="close-nav-button" href="javascript:void(0)" class="closebtn">&times;</a>
-
-            <!-- JINJA used to determine if the saved route dashboard and import route panel is accessible to users depending on if they are logged in -->
-            {% if not session.get("preferred_name") %}
-                <a class="inactive" aria-disabled="true" data-tooltip="Please Login to save routes." id="saved-routes-dash-open-button"><i data-lucide="waypoints"></i>Saved Routes</a>
-                <a class="inactive" aria-disabled="true" data-tooltip="Please Login to import routes." id="import-route-open-button"><i data-lucide="import"></i>Import Route</a>
-            {% else %}
-                <a id="saved-routes-dash-open-button"><i data-lucide="waypoints"></i>Saved Routes</a>
-                <a id="import-route-open-button"><i data-lucide="import"></i>Import Route</a>
-            {% endif %}
+            <a id="saved-routes-dash-open-button"><i data-lucide="waypoints"></i>Saved Routes</a>
+            <a id="import-route-open-button"><i data-lucide="import"></i>Import Route</a>
             <a id="settings-open-button"><i data-lucide="settings"></i>Settings</a>
             <a id="report-issues-button" href="/report-an-issue" ><i data-lucide="bug"></i>Report Issues</a>
         </div>
@@ -353,54 +365,51 @@
                  </div>
  
                  <!-- Delete Account -->
-                 <div class="settings-item settings-item-destructive" id="delete-account-container">
-                    <div class="delete-normal-state">
 
-                        <div class="settings-text">
-                            <span class="settings-title">Delete Account</span>
-                            <span class="settings-description">Permanently remove your account and all data</span>
-                        </div>
-                        
-                        <button
-                            {% if not session.get('preferred_name') %} 
-                                disabled 
-                                class="delete-account-btn inactive"
-                                data-tooltip="You must Login to perform this action."
-                            {% else %} 
+                 {% if not session.get('preferred_name') %} 
+
+                {% else %} 
+                    <div class="settings-item settings-item-destructive" id="delete-account-container">
+                        <div class="delete-normal-state">
+
+                            <div class="settings-text">
+                                <span class="settings-title">Delete Account</span>
+                                <span class="settings-description">Permanently remove your account and all data</span>
+                            </div>
+                            
+                            <button
                                 class="delete-account-btn"
-                            {% endif %}
-                            type="button"
-                            id="settings-delete-account-button"
-                        >Delete</button>
-                        
-                    </div>
+                                type="button"
+                                id="settings-delete-account-button"
+                            >Delete</button>
+                            
+                        </div>
 
-                    <div class="delete-confirm-state" style="display: none; width: 100%;">
-                        <div class="settings-text">
-                            <span class="settings-title" style="color: #b91c1c;">Delete account?</span>
-                            <span class="settings-description">This cannot be undone.</span>
-                        </div>
-                        <div style="display: flex; gap: 8px; flex-shrink: 0;">
-                            <button type="button" class="cancel-delete-btn" id="delete-cancel-button">Cancel</button>
-                            <button type="button" class="confirm-delete-btn" id="delete-confirm-button">Delete forever</button>
+                        <div class="delete-confirm-state" style="display: none; width: 100%;">
+                            <div class="settings-text">
+                                <span class="settings-title" style="color: #b91c1c;">Delete account?</span>
+                                <span class="settings-description">This cannot be undone.</span>
+                            </div>
+                            <div style="display: flex; gap: 8px; flex-shrink: 0;">
+                                <button type="button" class="cancel-delete-btn" id="delete-cancel-button">Cancel</button>
+                                <button type="button" class="confirm-delete-btn" id="delete-confirm-button">Delete forever</button>
+                            </div>
                         </div>
                     </div>
-                </div>
+                {% endif %}
             </section>
 
             <!-- ##### FOOTER (inc. logout button) ##### -->
             <div class="settings-sticky-footer">
 
-                <button
-                id="settings-logout-button"
                 {% if not session.get('preferred_name') %} 
-                    disabled 
-                    class="logout-button inactive"
-                    data-tooltip="You must Login to perform this action."
+
                 {% else %} 
+                    <button
+                    id="settings-logout-button"
                     class="logout-button"
+                    >Log out</button>
                 {% endif %}
-                >Log out</button>
 
             </div>
         </div>


### PR DESCRIPTION
# Pull Request Template

## Summary
Introduced an authentication wall (auth wall) modal that prompts guest/non-logged-in users to log in or sign up when attempting to save or import routes, while hiding account-specific settings for unauthenticated users.

## Related Issue
N/A

## Type of Change
Select all that apply:
- [ ] Bug fix  
- [x] New feature  
- [ ] Documentation update  
- [x] Refactor  
- [ ] Other (explain below)

## Description of Changes
- **Feature Discovery & Guest UX:** Kept the "Save Route" and "Import Route" sidebar links visible to non-logged-in users to showcase platform capability.
- **Auth Wall Integration:** Updated the action handlers for saving and importing routes so that clicking them triggers a Login Modal if the user is not authenticated, providing a direct path to sign up or log in.
- **Settings Clean-up:** Hidden account-specific buttons ("Delete Account" and "Log Out") from the settings panel when a user is not logged in to eliminate visual clutter and redundant options.

## Screenshots / Visuals (if applicable)

### Light Mode Login Modal
<img width="1470" height="831" alt="image" src="https://github.com/user-attachments/assets/77626028-a3f5-401d-92a6-da76e547ccd2" />


### Dark Mode Login Modal
<img width="1470" height="832" alt="image" src="https://github.com/user-attachments/assets/40a4f15e-5e0b-422d-ad49-603c3f396166" />


## Testing
1. **Unauthenticated User Flow:**
   - Navigated to the application while logged out.
   - Verified that "Delete Account" and "Log Out" options are not visible in Settings.
   - Verified that "Save Route" and "Import Route" options remain visible in the sidebar.
   - Clicked "Save Route" and confirmed the auth wall modal appears.
   - Clicked "Import Route" and confirmed the auth wall modal appears.
   - Tested light and dark theme toggles on the login modal to ensure proper styling.
2. **Authenticated User Flow:**
   - Logged in and verified that route saving/importing actions execute normally without triggering the modal.
   - Verified that "Delete Account" and "Log Out" options appear in Settings when logged in.

## Checklist
- [x] My code follows the project’s style guidelines  
- [x] I have tested my changes  
- [x] I have updated documentation if needed  
- [x] I have referenced the related issue  
- [x] This PR is scoped, focused, and ready for review  

> **Note:**  
> PRs for issues **not** tagged as contributor‑friendly may be closed without review.