### PR TITLE
chore: Modify the sliding panels (such as Import Route, Saved Routes and Settings panels) to use solid colours rather than glassmorphism for better UX

### DIFF
--- a/static/css/layout/slide-panel.css
+++ b/static/css/layout/slide-panel.css
@@ -19,9 +19,7 @@
   overflow-y: auto;
   box-sizing: border-box;
   font-family: var(--font-system);
-  background: var(--glass-bg);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
+  background: var(--bg);
   z-index: 3000;
   transition: all 0.35s ease-in-out;
 }
@@ -38,23 +36,19 @@
   flex-direction: column;
 }
 
-/* Frosted header bar */
+/* Header bar */
 .settings-header,
 .import-route-header,
 #top-section {
-  background: rgba(255, 255, 255, 0.65);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  border-bottom: 1px solid rgba(229, 231, 235, 0.7);
+  background: var(--bg);
+  border-bottom: 1px solid var(--border-alt);
 }
 
-/* Frosted footer bar */
+/* Solid footer bar */
 .settings-sticky-footer,
 .import-route-footer {
-  background: rgba(255, 255, 255, 0.65);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  border-top: 1px solid rgba(229, 231, 235, 0.7);
+  background: var(--card-bg);
+  border-top: 1px solid var(--card-border);
   padding: 1.1rem 4rem;
   display: flex;
   justify-content: center;
@@ -71,7 +65,7 @@
   font-size: 32px;
   line-height: 1;
   cursor: pointer;
-  color: #4b5563;
+  color: var(--muted-alt);
   text-decoration: none;
   transition: transform 0.2s ease, color 0.2s ease;
   display: inline-flex;
@@ -83,39 +77,6 @@
 .settingCloseButton:hover,
 .import-route-close-button:hover,
 #saved-routes-dashboard .closebtn:hover {
-  color: #111827;
+  color: var(--ink-strong);
   transform: scale(1.1);
-}
-
-/* DARK MODE */
-html.dark #settings-panel,
-html.dark #import-route-panel,
-html.dark #saved-routes-dashboard {
-  background: var(--glass-bg);
-}
-
-html.dark .settings-header,
-html.dark .import-route-header,
-html.dark #top-section {
-  background: rgba(31, 41, 55, 0.75);
-  border-bottom-color: #374151;
-}
-
-html.dark .settings-sticky-footer,
-html.dark .import-route-footer {
-  background: rgba(31, 41, 55, 0.75);
-  border-top-color: #374151;
-}
-
-html.dark .settingCloseButton,
-html.dark .import-route-close-button,
-html.dark #saved-routes-dashboard .closebtn {
-  color: #9ca3af;
-}
-
-html.dark .settingCloseButton:hover,
-html.dark .import-route-close-button:hover,
-html.dark #saved-routes-dashboard .closebtn:hover {
-  color: #f3f4f6;
-  background-color: rgba(255, 255, 255, 0.12);
 }

--- a/static/css/pages/import-route.css
+++ b/static/css/pages/import-route.css
@@ -23,7 +23,7 @@
   margin: 0 .5rem 0 0;
   font-size: 2.2rem;
   font-weight: 700;
-  color: #111827;
+  color: var(--ink-strong);
 }
 
 .import-route-close-container {
@@ -51,8 +51,8 @@
   justify-content: space-between;
   align-items: center;
   padding: 1.5rem 2.5rem;
-  background: #ffffff;
-  border: 1px solid rgba(229, 231, 235, 0.8);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 100px;
 }
 
@@ -65,12 +65,12 @@
 .import-route-item-title {
   font-size: 1.1rem;
   font-weight: 600;
-  color: #111827;
+  color: var(--ink-strong);
 }
 
 .import-route-item-description {
   font-size: 0.875rem;
-  color: #4b5563;
+  color: var(--muted-alt);
 }
 
 /* FOOTER BUTTONS */
@@ -90,7 +90,7 @@
 }
 
 .import-route-footer-button.primary:hover {
-  background: #1e40af;
+  background: var(--blue-dark-alt);
 }
 
 .import-route-footer-button.secondary {
@@ -103,23 +103,6 @@
 }
 
 /* DARK MODE */
-
-html.dark .import-route-title {
-  color: #f3f4f6;
-}
-
-html.dark .import-route-item {
-  background: #1f2937;
-  border-color: #374151;
-}
-
-html.dark .import-route-item-title {
-  color: #f3f4f6;
-}
-
-html.dark .import-route-item-description {
-  color: #9ca3af;
-}
 
 html.dark .import-route-footer-button.primary {
   background: #374151;

--- a/static/css/pages/saved-routes.css
+++ b/static/css/pages/saved-routes.css
@@ -37,7 +37,7 @@ body {
   min-width: 0;
   font-size: clamp(1.5rem, 2.2vw, 2.2rem);
   font-weight: 700;
-  color: #111827;
+  color: var(--ink-strong);
   white-space: nowrap;
   overflow: visible;
 }
@@ -86,7 +86,8 @@ body {
 /* Route Cards (inc. internal metrics) */
 .route-card {
   border-radius: 8px;
-  background-color: rgba(255, 255, 255, 0.771);
+  background-color: var(--surface-bg);
+  border: 1px solid var(--card-border);
   padding: 1.25rem;
   width: 24.5rem;
   max-height: 17rem;
@@ -98,7 +99,7 @@ body {
 }
 
 .route-card:hover {
-  box-shadow: 0px 8px 12px rgba(0, 0, 0, 0.3);
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.3);
   transform: translateY(-2px);
 }
 
@@ -110,6 +111,7 @@ body {
   margin: 0 0 0.25rem 0;
   font-size: 1.2rem;
   font-weight: 700;
+  color: var(--ink-strong);
 }
 
 .route-card-date {
@@ -132,7 +134,15 @@ body {
 }
 
 .stat-label {
-  color: rgb(123, 123, 123);
+  color: var(--ink);
+}
+
+.stat-value {
+  color: var(--ink);
+}
+
+.route-card-date {
+  color: var(--ink);
 }
 
 
@@ -194,14 +204,12 @@ body {
 }
 
 .no-routes-card {
-  background: rgba(255, 255, 255, 0.55);
-  backdrop-filter: blur(18px);
-  -webkit-backdrop-filter: blur(18px);
+  background: var(--card-bg);
   border-radius: 16px;
   padding: 2.8rem 2.4rem;
   max-width: 420px;
   text-align: center;
-  border: 1px solid rgba(255, 255, 255, 0.35);
+  border: 1px solid var(--card-border);
   box-shadow: 0 8px 25px rgba(0, 0, 0, 0.12);
 }
 
@@ -231,14 +239,6 @@ html.dark #saved-routes-dashboard .inner-content {
   background: transparent;
 }
 
-html.dark #dashboard-header h1,
-html.dark #saved-routes-dashboard .route-card-name,
-html.dark #saved-routes-dashboard .stat-label,
-html.dark #saved-routes-dashboard .stat-value,
-html.dark #saved-routes-dashboard .route-card-date {
-  color: #f3f4f6;
-}
-
 html.dark #saved-routes-dashboard .route-card {
   background-color: #374151;
   border-color: #4b5563;
@@ -247,11 +247,6 @@ html.dark #saved-routes-dashboard .route-card {
 html.dark #saved-routes-dashboard .route-btn {
   background-color: #4b5563;
   color: #f3f4f6;
-}
-
-html.dark .no-routes-card {
-  background: rgba(31, 41, 55, 0.55);
-  border-color: rgba(255, 255, 255, 0.15);
 }
 
 html.dark .no-routes-title,

--- a/static/css/pages/settings-panel.css
+++ b/static/css/pages/settings-panel.css
@@ -11,9 +11,9 @@
 */
 
 .settings-header-container {
-  max-width: 1200px;
   margin: 0 auto;
   padding: 3rem 4rem 2rem 4rem;
+  border-bottom: 1px solid var(--card-border);
   display: flex;
   flex-direction: row;
   box-sizing: border-box;
@@ -26,7 +26,7 @@
   margin: 0;
   font-size: 2.2rem;
   font-weight: 700;
-  color: #111827;
+  color: var(--ink-strong);
   letter-spacing: -0.025em;
   line-height: 1.2;
 }
@@ -57,8 +57,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 1.5rem 2.5rem;
-  background-color: #ffffff;
-  border: 1px solid rgba(229, 231, 235, 0.8);
+  background-color: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 100px;
   box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.01), 0 2px 4px -1px rgba(0, 0, 0, 0.01);
 }
@@ -72,36 +72,12 @@
 .settings-title {
   font-size: 1.1rem;
   font-weight: 600;
-  color: #111827;
+  color: var(--ink-strong);
 }
 
 .settings-description {
   font-size: 0.875rem;
-  color: #4b5563;
-}
-
-.logout-button {
-  background: #111827;
-  color: #ffffff;
-  border: none;
-  border-radius: 9999px;
-  padding: 0.7rem 2.75rem;
-  font-size: 1rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  letter-spacing: -0.01em;
-}
-
-.logout-button:hover {
-  background: #1f2937;
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
-}
-
-.logout-button:active {
-  transform: translateY(0);
+  color: var(--muted-alt);
 }
 
 /* DELETE ACCOUNT ROW */
@@ -180,12 +156,12 @@
 /* INPUT TYPES */
 
 .settings-input {
-  background: #ffffff;
-  border: 1px solid rgba(229, 231, 235, 0.9);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 9999px;
   padding: 0.55rem 1.1rem;
   font-size: 0.95rem;
-  color: #111827;
+  color: var(--ink-strong);
   width: fit-content;
   max-width: 100%;
   box-sizing: border-box;
@@ -200,12 +176,12 @@
 }
 
 .settings-select {
-  background: #ffffff;
-  border: 1px solid rgba(229, 231, 235, 0.9);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
   border-radius: 9999px;
   padding: 0.55rem 1.1rem;
   font-size: 0.95rem;
-  color: #111827;
+  color: var(--ink-strong);
   min-width: 120px;
   max-width: 100%;
   cursor: pointer;
@@ -229,7 +205,7 @@
 /* Radio Pills */
 .settings-radio-pills {
   display: inline-flex;
-  background: #f3f4f6;
+  background: var(--bg);
   border-radius: 9999px;
   padding: 3px;
   gap: 2px;
@@ -262,6 +238,7 @@
 }
 
 .radio-pill input:checked + span {
+  border: 1px solid var(--card-border);
   background: #ffffff;
   color: #111827;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
@@ -338,29 +315,6 @@
 
 /* DARK MODE */
 
-html.dark .settings-header h1 {
-  color: #f3f4f6;
-}
-
-html.dark .settings-input {
-  background: #1f2937;
-  border-color: #374151;
-  color: white;
-}
-
-html.dark .settings-item {
-  background: #1f2937;
-  border-color: #374151;
-}
-
-html.dark .settings-title {
-  color: #f3f4f6;
-}
-
-html.dark .settings-description {
-  color: #9ca3af;
-}
-
 html.dark .settings-radio-pills {
   background: #374151;
 }
@@ -397,13 +351,4 @@ html.dark .cancel-delete-btn {
 
 html.dark .confirm-delete-btn {
   background: #b91c1c;
-}
-
-html.dark .logout-button {
-  background: #374151;
-  color: #f3f4f6;
-}
-
-html.dark .logout-button:hover {
-  background: #4b5563;
 }


### PR DESCRIPTION
# Pull Request Template

## Summary
This PR aims to introduce solid colours to the sliding panels used by the settings, import route and saved route dashboard sections of the app. This would lead to better UX as there is less detail in the background to detract from the content in the panels, allowing full focus towards the current panel the user is on.  

## Related Issue
Not Applicable 

## Type of Change
Select all that apply:
- [ ] Bug fix  
- [ ] New feature  
- [ ] Documentation update  
- [ ] Refactor  
- [x] Other (explain below)

## Description of Changes
This was a design change 

The key change was a move from a glass-morphism effect on the background to a more conservative solid colour using variables from `tokens.css` which automatically changed according to the theme that the user had set (light or dark). During testing this led to a much easier and less distracting experience in the settings, import route and saved routes dashboard panels. 

## Screenshots / Visuals (if applicable)
Not Applicable 

## Testing
Since this was a design change, little testing was needed apart from having others decide which UI and layout looked better, and people consistently chose the new design, showing it was a step in the right direction. 

## Checklist
- [x] My code follows the project’s style guidelines  
- [x] I have tested my changes  
- [x] I have updated documentation if needed  
- [x] I have referenced the related issue  
- [x] This PR is scoped, focused, and ready for review  

> **Note:**  
> PRs for issues **not** tagged as contributor‑friendly may be closed without review.
