### PR TITLE
Fix/lat lon routing

### DIFF
--- a/src/Routes/helpers.py
+++ b/src/Routes/helpers.py
@@ -16,7 +16,11 @@ from constants import MAX_X, MAX_Y, MIN_X, MIN_Y
 
 #region ROUTING HELPER FUNCTIONS
 
-def isRoughlyInCumbria(x: int | float, y: int | float) -> bool:
+def isRoughlyInCumbria(x: float, y: float) -> bool:
+
+    if (-180 <= x <= 180) and (-90 <= y <= 90):
+        x, y = service.convert_wgs84_to_web_mercator(x, y)
+
     return x >= MIN_X and x <= MAX_X and y >= MIN_Y and y <= MAX_Y 
 
 def haversine(x1, y1, x2, y2):

--- a/src/Routes/routes_api.py
+++ b/src/Routes/routes_api.py
@@ -88,7 +88,7 @@ def calculate_path():
         
         # Validation of coord format 
         if not isinstance(start_array, list) or not isinstance(end_array, list):
-            raise ValueError("Start and end coordinates are required as arrays")
+            raise TypeError("Start and end coordinates are required as arrays")
 
         if len(start_array) < 2 or len(end_array) < 2:
             raise ValueError("Coordinates must be in format [x, y]")
@@ -119,7 +119,7 @@ def calculate_path():
             s_x, s_y = service.convert_wgs84_to_web_mercator(s_x, s_y)
         if abs(e_x) <= 180 and abs(e_y) <= 90:
             print("Detected Lat/Lon for end point. Converting to Web Mercator...")
-            s_x, s_y = service.convert_wgs84_to_web_mercator(e_x, e_y)
+            e_x, e_y = service.convert_wgs84_to_web_mercator(e_x, e_y)
         
     except (KeyError, ValueError, TypeError) as e:
         # This is wrapped in a try/except fallback block so that if logging functions fail, the program doesn't crash 
@@ -284,7 +284,7 @@ def calculate_path():
             "success": False,
             "map_centre": DEFAULT_CENTRE,
             "available_routes": [],
-            "message": f"Pathfinder execution error: {str(general_error)}"
+            "message": "Pathfinder execution error: {str(general_error)}"
         }), 500
   
 # flask-route which is used to save a route that has been passed into the backend into the PostgreSQL database 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -13,7 +13,8 @@ import {
   formatETA,
   removeDOMElement,
   createStatsPanel,
-  formatElevation
+  formatElevation,
+  isLonLat
 } from "./utils.js";
 import { calculatePath, addManualPoint } from "./routing/routing.js";
 import {
@@ -316,13 +317,26 @@ function validateInputCoords(startPoint, endPoint) {
   }
 
   // This parses the full string into numbers 
-  const startX = parseInt(startParts[0].trim(), 10);
-  const startY = parseInt(startParts[1].trim(), 10);
-  const endX = parseInt(endParts[0].trim(), 10);
-  const endY = parseInt(endParts[1].trim(), 10);
+  const startX = parseFloat(startParts[0].trim());
+  const startY = parseFloat(startParts[1].trim());
+  const endX = parseFloat(endParts[0].trim());
+  const endY = parseFloat(endParts[1].trim());
 
-  const startLonLat = ol.proj.toLonLat([startX, startY]);
-  const endLonLat = ol.proj.toLonLat([endX, endY]);
+  let startLonLat
+  let endLonLat
+
+  // conditional logic to ensure that if values are already in lon lat they are not incorrectly passed into ol.proj.toLonLat()
+  if (isLonLat([startX, startY]) && isLonLat([endX, endY])) {
+    startLonLat = [startX, startY];
+    endLonLat = [endX, endY];
+    
+    console.log('LonLat detected ')
+    console.log(startLonLat)
+  }
+  else {
+    startLonLat = ol.proj.toLonLat([startX, startY]);
+    endLonLat = ol.proj.toLonLat([endX, endY]);
+  }
 
   if ( !isPointInPolygon(startLonLat)) {
     showError("Please enter start coordinates within Cumbria.")

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -28,6 +28,58 @@ export function roundCoords (coordArray, decimals) {
     return [roundedX, roundedY];
 }
 
+
+/**
+ * Validates whether the input is a valid WGS84 (lat / lon) coordinate 
+ * 
+ * @param {LatLonObject | [number, number] | null | undefined} coord - The coordinate data to validate NOTE it is in lon lat format 
+ * @returns {boolean} True if the input represents a valid latitude and longitude, false otherwise.
+ * 
+ * @example
+ * isValidCoordinate({ lon: -0.1, lat: 51.5 }); // returns true
+ * isValidCoordinate([-0.1, 51.5]);             // returns true
+ * isValidCoordinate({ lon: -0.1, lat: 95 });   // returns false (latitude out of bounds)
+ */
+export function isLonLat(coordinate) {
+
+  // local variables to store extracted coordinate values
+  let lat;
+  let lon;
+
+  // stores if coordinate is array or not 
+  const isCoordinateArray = Array.isArray(coordinate)
+
+  // this ensures it handles dictionaries (objects)
+  if (coordinate && typeof coordinate === 'object' && !isCoordinateArray) {
+    lat = coordinate.lat ?? coordinate.latitude 
+    lon = coordinate.lon ?? coordinate.lng ?? coordinate.longitude
+  }
+
+  // this ensures it handles arrays 
+  else if (isCoordinateArray && coordinate.length >= 2) {
+    lon = coordinate[0];
+    lat = coordinate[1]
+  }
+
+  // returns false for any other format 
+  else {
+    console.warn('isLonLat(coord) : Pass dictionary/object or array into function "isLonLat". ');
+    return false;
+  };
+
+  // this ensures that both lat and lon variables are numbers and can be used in the conditional checks to ensure they are valid WGS84 coordinates 
+  if (!typeof lat === 'number' || !Number.isFinite(lat)) {
+    console.warn('isLonLat(coord) : variable lat is either not a number or is infinite')
+  }; 
+
+  if (!typeof lon === 'number' || !Number.isFinite(lon)) {
+    console.warn('isLonLat(coord) : variable lon is either not a number or is infinite')
+  }; 
+
+  // this returns true if lat is between -90 and 90 and if lon is between -180 and 180, and returns false otherwise
+  return lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180;
+}
+
 // function to set the styling for points that are added in manual routing mode
 export function createManualPointStyle(label, colour, radius=7.5, strokeBorderColor="#FFFFFF") {
   return new ol.style.Style({


### PR DESCRIPTION
# Pull Request Template

## Summary
This PR aims to implement a fix for a bug caused when users enter WGS84 coordinates (Lat, Lon) when routing. After the PR is implemented users will no longer see errors when entering WGS84 coordinates and routing will occur normally. 

## Related Issue
No dedicated related issue. 

The issue was caused as a result of assuming all user-entered coordinates would be in Web Mercator projection, with `ol.proj.toLonLat(coords)` being called on all inputted coordinates. This means that the wrong coordinates would be formed if a user enters Lat, Lon coordinates, causing users to view an error message incorrectly informing them that the inputted coordinates were not in Cumbria, even if they were. 

## Type of Change
Select all that apply:
- [x] Bug fix  
- [ ] New feature  
- [ ] Documentation update  
- [ ] Refactor  
- [ ] Other (explain below)

## Description of Changes
- **Utils.js**: Implemented a new `isLonLat()` function which accepts both dictionary/object and array input, and checks if coordinates are in WGS84 projection using the condition that Longitude must be between 180 and -180 and Latitude must be between 90 and -90
- **`ui.js`**: Added conditional logic to check if coordinates were already in Lat, Lon format using the new function defined in `utils.js` and skipped the `ol.proj.toLonLat()` function call if the coordinates were in Lat, Lon format
- **Routes/helpers.py**: Added conditional logic to convert coordinates into Web Mercator Projection if they were in Lon, Lat format via `service.convert_wgs84_to_web_mercator(x, y)`
- **`Routes/route_api.py`**: Fixed naming bug which prevented route creation even if the initial issue of bypassing the `Points not in Cumbria` 

## Screenshots / Visuals (if applicable)
Not Applicable 

## Testing
Tested route creation with various different WGS84 coordinates and validated that all the routes generated were correct and began at the defined start and end points
## Checklist
- [x] My code follows the project’s style guidelines  
- [x] I have tested my changes  
- [x] I have updated documentation if needed  
- [x] I have referenced the related issue  
- [x] This PR is scoped, focused, and ready for review  

> **Note:**  
> PRs for issues **not** tagged as contributor‑friendly may be closed without review.
