### PR TITLE
PR: Bump main to v0.2.7

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -19,7 +19,7 @@ GRAPH_PATH="/app/graph_generation/elevation_populated_igraph.pkl"
 if [ ! -f "$GRAPH_PATH" ]; then
     echo "Pathfinding graph ($GRAPH_PATH) is missing, downloading from github releases..."
 
-    curl -L -o "$GRAPH_PATH" "https://github.com/abdlfc11/Crestr-Hiking-App/releases/download/v0.2.6/graph.pkl"
+    curl -L -o "$GRAPH_PATH" "https://github.com/abdlfc11/Crestr-Hiking-App/releases/download/v0.2.7/graph.pkl"
 
     echo "Pathfinding graph downloaded"
 else

--- a/static/css/layout/nav-menu.css
+++ b/static/css/layout/nav-menu.css
@@ -85,7 +85,7 @@
   transform: scale(1.05);
 }
 
-#sidenav-login-button-container {
+#sidenav-login-logout-button-container {
   margin-top: auto;
   padding-bottom: 1.5rem;
   flex-shrink: 0;
@@ -95,9 +95,8 @@
   flex-direction: column;
 }
 
-#sidenav-login-button {
+.sidenav-login-logout-button {
   font-size: 1.1rem;
-  
 }
 
 #donate-button {

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -16,7 +16,9 @@ import {
   formatElevation,
   isLonLat
 } from "./utils.js";
+
 import { calculatePath, addManualPoint } from "./routing/routing.js";
+
 import {
   getMap,
   onMapClick,
@@ -25,19 +27,23 @@ import {
   getPathColour,
   setRouteLayer,
 } from "./map.js";
+
 import {
   loadAndDisplaySavedPoints,
   getSavedPointsLayer,
   saveNewPoint,
 } from "./saved_points/index.js";
+
 import {
   getSavedPointStyle,
   getSelectedPointStyle,
 } from "./saved_points/style.js";
+
 import {
   initSaveRoute,
   loadRoute,
 } from "./routes/index.js";
+
 import {
   getCurrentMode,
   setCurrentMode,
@@ -62,18 +68,34 @@ import {
   calculateElevationGain,
   isPointInPolygon
 } from "./routes/routeState.js";
+
 import {
   initCursorManager,
   updateCursor,
   setCursor,
   forceApplyCursor,
 } from "./cursorManager.js";
+
 import { setOnDistanceUnitChange } from "./settings.js";
+
 import { getTheme } from "./settingsState.js";
+
 import { displayLoadedRouteOnMap, displayLoadedRouteStats } from "./routes/loadRoute.js";
+
 import { createElevationProfile, initChartToggleListener, resetElevationChart, setHoverPointFeature, toggleElevationChart } from "./elevationChart.js";
+
 import { displayImportedRouteCard, processImportedRouteFile } from "./importRoute.js";
-import { createAutomaticRoutingTour, createImportRoutePanelTour, createManualRoutingTour, createSavedRouteDashboardTour, createSavingRoutesTour, createSettingsTour } from "./tours/tours.js";
+
+import { 
+  createAutomaticRoutingTour,
+  createImportRoutePanelTour,
+  createManualRoutingTour,
+  createSavedRouteDashboardTour,
+  createSavingRoutesTour,
+  createSettingsTour
+} from "./tours/tours.js";
+
+import { logout } from "./auth.js";
 
 //#endregion
 
@@ -112,6 +134,8 @@ const startCoordEntry = document.getElementById("start-point-entry");
 const endCoordEntry = document.getElementById("end-point-entry");
 
 const navBar = document.getElementById("the-sidenav");
+const loginNavBarButton = document.getElementById('sidenav-login-button');
+const logoutNavBarButton = document.getElementById('sidenav-logout-button');
 
 // automatic mode + manual mode contents i.e mode-specific panels
 const autoModeContent = document.getElementById("auto-mode-content");
@@ -1523,6 +1547,9 @@ export function initUi() {
   addClickListener(importRouteOpenButton, openImportRoute, "click");
   addClickListener(importRouteCloseButton, closeImportRoute, "click");
   addClickListener(importRouteCancelButton, cancelRouteImport, "click");
+  addClickListener(loginNavBarButton, () => window.location.href = "https://app.crestr.co.uk/login-page", 'click')
+  addClickListener(logoutNavBarButton, logout, 'click')
+
 
   // These event listeners are for route import.
   addClickListener(importRouteFileInput, validateFileInput, "change");

--- a/templates/map.html
+++ b/templates/map.html
@@ -228,8 +228,12 @@
                 <a class="tooltip-left" id="donate-button" data-tooltip="We're still in Beta, so donations are closed for now. Thank you so much for the support!" href="javascript:void(0)"><i data-lucide="heart"></i>Donate</a>
             </div>
             {% if not session.get("preferred_name") %}
-                <div id="sidenav-login-button-container">
-                    <button style="margin: .5rem;" id="sidenav-login-button" class="btn-pill">Login</button>
+                <div id="sidenav-login-logout-button-container">
+                    <button style="margin: .5rem;" id="sidenav-login-button" class="btn-pill sidenav-login-logout-button">Log In</button>
+                </div>
+            {% else %}
+                <div id="sidenav-login-logout-button-container">
+                    <button style="margin: .5rem;" id="sidenav-logout-button" class="btn-pill sidenav-login-logout-button">Log Out</button>
                 </div>
             {% endif %}
         </div>
@@ -407,16 +411,7 @@
 
             <!-- ##### FOOTER (inc. logout button) ##### -->
             <div class="settings-sticky-footer">
-
-                {% if not session.get('preferred_name') %} 
-
-                {% else %} 
-                    <button
-                    id="settings-logout-button"
-                    class="btn-pill"
-                    >Log out</button>
-                {% endif %}
-
+                <!-- Used to have logout button but this was moved to the sidenav -->
             </div>
         </div>
     </div>
@@ -453,7 +448,7 @@
                             <span>File</span>
                         </label>
 
-                        <label id="url-route-input-pill" class="radio-pill disabled" data-tooltip="URL import is currently disabled. Please use the file upload option.">
+                        <label id="url-route-input-pill" class="radio-pill disabled" data-tooltip="We're currently building URL Import, please use the File Import feature to add your files.">
                             <input id="url-route-input-type" type="radio" name="import-route-method" value="url" disabled>
                             <span>URL</span>
                         </label>


### PR DESCRIPTION
# Release Notes: v0.2.7

This merges changes included in the following PRs:

#71 

## Summary

Fixed a bug where the **Log In** button in the sidenav had no event listener, and improved the authentication UI by moving the **Log Out** button exclusively into the sidebar.

## Changes

### Bug fix (`ui.js`)
- Added click event listener for the Log In button → redirects to the login page.
- Added click event listener for the Log Out button → triggers logout.

### UI improvements (`map.html`)
- Removed the Log Out button from the Settings panel.
- Added Jinja2 logic so the correct button (Log In / Log Out) is shown based on the user’s authentication state.
- Updated the disabled URL Route Import tooltip with a clearer message directing users to the File Import feature (while URL import is still in development).
- Renamed the container from `sidenav-login-button-container` (ID) to `sidenav-login-logout-button-container` (class) to better reflect that it now holds either button.

### CSS update (`nav-menu.css`)
- Updated the selector to match the new class name used for the login/logout container.

## Why this matters

- Restores working Log In functionality from the sidenav.
- Improves visual consistency (both auth buttons live in the same place).
- Moves Log Out further away from destructive actions (e.g. account deletion) in Settings.

## Files changed

- `static/js/ui.js`
- `templates/map.html`
- `static/css/layout/nav-menu.css`