### PR TITLE
feat: Amend styling of saved points to use an SVG pin

### DIFF
--- a/static/js/saved_points/style.js
+++ b/static/js/saved_points/style.js
@@ -1,34 +1,118 @@
+//#region 
+
+const UNSELECTED_FILL = "#11617c"
+const UNSELECTED_STROKE = "#FFFFFF"
+const UNSELECTED_TEXT_FONT = "bold 12px system-ui"
+
+const SELECTED_FILL = "#e92e60"
+const SELECTED_STROKE = "#FFFFFF"
+const SELECTED_TEXT_FONT = "bold 13px system-ui"
+
+const TEXT_STROKE = "#FFFFFF"
+const TEXT_FILL = '#000000'
+
+//#endregion
+
+/**
+ * helper to generate SVG Data URIs with custom fill and stroke colors
+ * @param {string} fillColor Hex or RGB color code for the pin interior
+ * @param {string} [strokeColor="#FFFFFF"] Hex or RGB color code for the pin border
+ * @returns {string} Data URI suitable for OpenLayers ol.style.Icon
+ */
+function createPinSvg(fillColor, strokeColor = "#FFFFFF") {
+  const svg = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none">
+      <ellipse cx="12" cy="22" rx="4" ry="1.5" fill="black" fill-opacity="0.25"/>
+      
+      <path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0" 
+            fill="${fillColor}" 
+            stroke="${strokeColor}" 
+            stroke-width="1.5" 
+            stroke-linecap="round" 
+            stroke-linejoin="round"/>
+            
+      <circle cx="12" cy="10" r="3" fill="#FFFFFF" stroke="${strokeColor}" stroke-width="0.5"/>
+    </svg>
+  `;
+  return 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(svg);
+}
+
+/**
+ * returns the default OpenLayers style for a saved map point
+ * @param {string} name the label text to display above the pin
+ * @returns {ol.style.Style} OpenLayers Style object for standard points
+ */
 export function getSavedPointStyle(name) {
   return new ol.style.Style({
-    image: new ol.style.Circle({
-      radius: 7,
-      fill: new ol.style.Fill({
-        color: "#8903ff",
-      }),
-      stroke: new ol.style.Stroke({
-        color: "white",
-        width: 3,
-      }),
+
+    // icon
+    image: new ol.style.Icon({
+      src: createPinSvg(UNSELECTED_FILL), 
+
+      // anchor in order to place the icon above the point slightly rather than directly on-top of the point 
+      anchor: [0.5, 1],           
+      anchorXUnits: 'fraction',
+      anchorYUnits: 'fraction',
+
+      scale: 1,
     }),
+
+    // text (name of point)
     text: new ol.style.Text({
       text: name,
-      font: "bold 12px sans-serif",
+      
+      font: UNSELECTED_TEXT_FONT,
+
       fill: new ol.style.Fill({
-        color: "black",
+        color: TEXT_FILL,
       }),
-      stroke: new ol.style.Stroke({ color: '#fff', width: 3 }),
-      offsetY: -15,
+
+      stroke: new ol.style.Stroke({
+        color: TEXT_STROKE,
+        width: 3
+      }),
+
+      offsetY: -36, 
     }),
   });
 }
 
+/**
+ * returns the OpenLayers style for a selected/highlighted map point
+ * @param {string} name the label text to display above the pin
+ * @returns {ol.style.Style} OpenLayers Style object for selected points
+ */
 export function getSelectedPointStyle(name) {
-  const baseStyle = getSavedPointStyle(name);
-  baseStyle.getImage().setStroke(
-    new ol.style.Stroke({
-      color: "blue",
-      width: 4,
+  return new ol.style.Style({
+
+    // icon
+    image: new ol.style.Icon({
+      src: createPinSvg(SELECTED_FILL), 
+
+      // anchor in order to place the icon above the point slightly rather than directly on-top of the point 
+      anchor: [0.5, 0.9],
+      anchorXUnits: 'fraction',
+      anchorYUnits: 'fraction',
+
+      scale: 1.2, // scaled up for visual representation that it is selected 
     }),
-  );
-  return baseStyle;
+
+    // text (name of point)
+    text: new ol.style.Text({
+      text: name,
+
+      font: SELECTED_TEXT_FONT,
+
+      fill: new ol.style.Fill({
+        color: TEXT_FILL,
+      }),
+
+      stroke: new ol.style.Stroke({
+        color: TEXT_STROKE,
+        width: 3 
+      }),
+
+      offsetY: -42,
+    }),
+  });
 }


### PR DESCRIPTION
# Pull Request Template

## Summary
This PR aims to implement an update in the representation of saved points, making them more visually appealing and clearer to identify against the map tiles. This is done by replacing the use of colours to represent points with SVGs, allowing icons such as a pin to be used to represent saved points. 

## Related Issue
Not Applicable

## Type of Change
Select all that apply:
- [ ] Bug fix  
- [x] New feature  
- [ ] Documentation update  
- [ ] Refactor  
- [ ] Other (explain below)

## Description of Changes
- New `createPinSVG()` helper function created to generate the SVG that will be used in the `image` attribute of saved points
- New constants added such as `TEXT_STROKE`, `TEXT_FILL` and `SELECTED_FILL` to easily test other colour schemes 
- Replacement of OpenLayers-rendered circles as points with the new SVGs created by the `createPinSVG()` helper function

## Screenshots / Visuals (if applicable)

### Before

<img width="1470" height="832" alt="image" src="https://github.com/user-attachments/assets/9b6ce568-bcbe-4fc6-bece-16a2f26fd844" />


### After

<img width="1470" height="833" alt="image" src="https://github.com/user-attachments/assets/6acdb405-dfd1-4aec-94a7-f0bb8a95790d" />


## Testing
- Refreshed the page to ensure that saved points were rendered without an issue
- Added new points, and deleted them to ensure that the actions associated with saving points were unchanged and unaltered 

## Checklist
- [x] My code follows the project’s style guidelines  
- [x] I have tested my changes  
- [x] I have updated documentation if needed  
- [x] I have referenced the related issue  
- [x] This PR is scoped, focused, and ready for review  

> **Note:**  
> PRs for issues **not** tagged as contributor‑friendly may be closed without review.
