### PR TITLE
PR feat: Add representation of start/end points during automatic routing 

### DIFF
--- a/src/Points/points_fastapi.py
+++ b/src/Points/points_fastapi.py
@@ -96,14 +96,14 @@ def save_point(
 
         return {"success": True, "message": 'Successfully saved the point'}
     
-    except IntegrityError:
+    except IntegrityError as exception:
         raise HTTPException(
             status_code=409,
             detail={
                 "success": False,
                 "message": "A point already exists with that name, use a different name."
             }
-        )
+        ) from exception
 
     except HTTPException:
         raise

--- a/src/Points/points_fastapi.py
+++ b/src/Points/points_fastapi.py
@@ -10,6 +10,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi_limiter.depends import RateLimiter
 from pyrate_limiter import Duration, Limiter, Rate
 from sqlmodel import Session, select
+from sqlalchemy.exc import IntegrityError
 
 # Local Modules
 from src.db import engine
@@ -94,6 +95,18 @@ def save_point(
             log_action('Saving Point', True, None, None, 'SAVING_POINT')
 
         return {"success": True, "message": 'Successfully saved the point'}
+    
+    except IntegrityError:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "success": False,
+                "message": "A point already exists with that name, use a different name."
+            }
+        )
+
+    except HTTPException:
+        raise
     
     # if float() fails
     except ValueError as e:

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -20,6 +20,11 @@ export function getRouteLayer() {
   return routeLayer;
 }
 
+export function routeLayerHasFeatures() {
+  const source = getRouteLayer()?.getSource();
+  return Boolean(source && source.getFeatures().length > 0);
+}
+
 export function getTileLayer() {
   return tileLayer;
 }

--- a/static/js/saved_points/savedPoints.js
+++ b/static/js/saved_points/savedPoints.js
@@ -77,7 +77,7 @@ export function loadAndDisplaySavedPoints() {
       .then(addLayerToMap)
       .catch(err => {
         logError("Getting Saved Points", err.message, null, "GET_SAVED_POINT")
-        showError(err.message || "Sorry, there was an unexpected error whilst displaying saved points.");
+        showError("Sorry, there was an unexpected error whilst displaying saved points.");
       })
 }
 

--- a/static/js/saved_points/savedPoints.js
+++ b/static/js/saved_points/savedPoints.js
@@ -31,7 +31,8 @@ function convertPointsToFeatures(data) {
 function createSavedPointsLayer(features) {
     return new ol.layer.Vector({
         source: new ol.source.Vector({ features }),
-        style: f => getSavedPointStyle(f.get("name"))
+        style: f => getSavedPointStyle(f.get("name")),
+        zIndex: 1000
     });
 };
 

--- a/static/js/saved_points/savedPoints.js
+++ b/static/js/saved_points/savedPoints.js
@@ -75,8 +75,8 @@ export function loadAndDisplaySavedPoints() {
       .then(createSavedPointsLayer)
       .then(addLayerToMap)
       .catch(err => {
-        logError("Getting Saved Points", error.message, null, "GET_SAVED_POINT")
-        showError("Sorry, there was an unexpected error whilst displaying saved points.");
+        logError("Getting Saved Points", err.message, null, "GET_SAVED_POINT")
+        showError(err.message || "Sorry, there was an unexpected error whilst displaying saved points.");
       })
 }
 
@@ -123,7 +123,7 @@ export async function saveNewPoint(coordinate, name) {
       return;
   }
   catch(error) {
-    showError("There was an unexpected error whilst saving your point, try again later.");
+    showError(error.message || "There was an unexpected error whilst saving your point, try again later.");
     return false;
   }
 }

--- a/static/js/saved_points/style.js
+++ b/static/js/saved_points/style.js
@@ -40,14 +40,15 @@ function createPinSvg(fillColor, strokeColor = "#FFFFFF") {
 /**
  * returns the default OpenLayers style for a saved map point
  * @param {string} name the label text to display above the pin
+ * @param {string} [fill=null] The Fill colour of the point to be added, defaults to null 
  * @returns {ol.style.Style} OpenLayers Style object for standard points
  */
-export function getSavedPointStyle(name) {
+export function getSavedPointStyle(name, fill) {
   return new ol.style.Style({
 
     // icon
     image: new ol.style.Icon({
-      src: createPinSvg(UNSELECTED_FILL), 
+      src: createPinSvg(fill || UNSELECTED_FILL), 
 
       // anchor in order to place the icon above the point slightly rather than directly on-top of the point 
       anchor: [0.5, 1],           

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -496,7 +496,7 @@ export function mapClickHandler(event) {
     // adding end point 
     const pointFeature = createPoint(event.coordinate, getSavedPointStyle("End", "#074df0"), "end", "End")
     addStartEndPoint(pointFeature, interactivePointLayer, "end");
-    setUpPointInteraction();
+    setUpPointInteraction([interactivePointLayer]);
 
     if (interactivePointLayer.getSource().getFeatures().length > 1) {
       handleAutoRouteGeneration(startCoordEntry.value, endCoordEntry.value);
@@ -1088,7 +1088,6 @@ async function handleAutoRouteGeneration(start=null, end=null) {
     if (saveContainer) saveContainer.style.display = "flex";
 
   } catch (error) {
-    throw new Error(error.message || "Sorry, there was an unexpected error when calculating your route, please try again later.");
     showError("Sorry, there was an unexpected error when calculating your route, please try again later.");
     return;
   } finally {
@@ -1430,18 +1429,16 @@ export function handleInitialTour() {
 //#region POINT INTERACTION
 
 /**
- * Ensures the coordinate is in EPSG:3857 (Web Mercator).
- * Uses the existing isLonLat helper.
+ * Ensures the coordinate is in EPSG:3857 (Web Mercator)
  */
 function toWebMercator(coords) {
   if (!coords) return null;
 
   if (isLonLat(coords)) {
-    // OpenLayers expects [longitude, latitude]
+    // reversed coords as OpenLayers expects [longitude, latitude]
     return ol.proj.fromLonLat([coords[1], coords[0]]);
   }
 
-  // Already projected (EPSG:3857)
   return coords;
 }
 
@@ -1452,10 +1449,10 @@ function handleCoordEntryChange(entry, type) {
   const raw = entry?.value?.trim() ?? "";
   const parsed = parseCoordString(raw);
 
-  // Invalid format → silent return
+  // this returns if the string is in an invalid format
   if (!parsed) return;
 
-  // Convert to Web Mercator when the value is lon/lat
+  // this converts coords to Web Mercator when the value is lon/lat
   const mercatorCoords = toWebMercator(parsed);
   if (!mercatorCoords) return;
 
@@ -1463,6 +1460,10 @@ function handleCoordEntryChange(entry, type) {
     type === "start" ? "Start" : "End",
     "#074df0"
   );
+
+  if (!isPointInPolygon(ol.proj.toLonLat(mercatorCoords))) {
+    return;
+  }
 
   const pointFeature = createPoint(
     mercatorCoords,

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -23,7 +23,8 @@ import {
   showError,
   addClickListener,
   removeDOMElement,
-  createStatsPanel
+  createStatsPanel,
+  parseCoordString
 } from "./utils/ui-utils.js";
 
 import { calculatePath, addManualPoint } from "./routing/routing.js";
@@ -123,6 +124,9 @@ const manualModeOption = document.getElementById("manual-mode-option");
 const setStartCoordButton = document.getElementById("set-start-coord-button");
 const setEndCoordButton = document.getElementById("set-end-coord-button");
 
+const startCoordEntry = document.getElementById("start-point-entry");
+const endCoordEntry = document.getElementById("end-point-entry");
+
 const autoOpenNavButton = document.getElementById("auto-open-nav-button");
 const manualOpenNavButton = document.getElementById("manual-open-nav-button");
 const closeNavButton = document.getElementById("close-nav-button");
@@ -142,8 +146,6 @@ const searchEntry = document.getElementById("search-entry");
 const searchForAreaButton = document.getElementById("search-for-area-button");
 
 const mapElement = document.getElementById("map");
-const startCoordEntry = document.getElementById("start-point-entry");
-const endCoordEntry = document.getElementById("end-point-entry");
 
 const navBar = document.getElementById("the-sidenav");
 const loginNavBarButton = document.getElementById('sidenav-login-button');
@@ -481,6 +483,11 @@ export function mapClickHandler(event) {
     const pointFeature = createPoint(event.coordinate, getSavedPointStyle("Start", "#074df0"), "start", "Start");
     addStartEndPoint(pointFeature, interactivePointLayer, "start");
     setUpPointInteraction([interactivePointLayer]);
+
+    if (interactivePointLayer.getSource().getFeatures().length > 1) {
+      handleAutoRouteGeneration(startCoordEntry.value, endCoordEntry.value);
+    };
+
     return;
   }
   if (clickMode === "setEnd") {
@@ -490,6 +497,11 @@ export function mapClickHandler(event) {
     const pointFeature = createPoint(event.coordinate, getSavedPointStyle("End", "#074df0"), "end", "End")
     addStartEndPoint(pointFeature, interactivePointLayer, "end");
     setUpPointInteraction();
+
+    if (interactivePointLayer.getSource().getFeatures().length > 1) {
+      handleAutoRouteGeneration(startCoordEntry.value, endCoordEntry.value);
+    };
+
     return;
   }
 
@@ -1418,6 +1430,65 @@ export function handleInitialTour() {
 //#region POINT INTERACTION
 
 /**
+ * Ensures the coordinate is in EPSG:3857 (Web Mercator).
+ * Uses the existing isLonLat helper.
+ */
+function toWebMercator(coords) {
+  if (!coords) return null;
+
+  if (isLonLat(coords)) {
+    // OpenLayers expects [longitude, latitude]
+    return ol.proj.fromLonLat(coords);
+  }
+
+  // Already projected (EPSG:3857)
+  return coords;
+}
+
+/**
+ * Handles a change on either the start or end coordinate input.
+ */
+function handleCoordEntryChange(entry, type) {
+  const raw = entry?.value?.trim() ?? "";
+  const parsed = parseCoordString(raw);
+
+  // Invalid format → silent return
+  if (!parsed) return;
+
+  // Convert to Web Mercator when the value is lon/lat
+  const mercatorCoords = toWebMercator(parsed);
+  if (!mercatorCoords) return;
+
+  const style = getSavedPointStyle(
+    type === "start" ? "Start" : "End",
+    "#074df0"
+  );
+
+  const pointFeature = createPoint(
+    mercatorCoords,
+    style,
+    type,
+    type === "start" ? "Start" : "End"
+  );
+
+  addStartEndPoint(pointFeature, interactivePointLayer, type);
+  setUpPointInteraction([interactivePointLayer]);
+
+  const map = getMap();
+  map.renderSync();
+
+  const startVal = startCoordEntry?.value?.trim();
+  const endVal = endCoordEntry?.value?.trim();
+
+  if (startVal && endVal) {
+    handleAutoRouteGeneration(startVal, endVal);
+  }
+  else {
+    moveMapToPosition(map, mercatorCoords, 1200, 12);
+  }
+}
+
+/**
  * Adds a start/end point feature to a vector layer, removing any existing feature of the same type first
  *
  * @param {ol.Feature} pointFeature The point feature to add
@@ -1720,6 +1791,8 @@ export function initUi() {
   addClickListener(searchForAreaButton, searchArea, "click");
   addClickListener(setStartCoordButton, setStartCoord, "click");
   addClickListener(setEndCoordButton, setEndCoord, "click");
+  addClickListener(startCoordEntry, () => handleCoordEntryChange(startCoordEntry, "start"), 'change')
+  addClickListener(endCoordEntry, () => handleCoordEntryChange(endCoordEntry, "end"), 'change')
 
   // These event listeners are for manual route creation.
   addClickListener(clearManualRouteButton, clearManualRoute, "click");

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -35,6 +35,7 @@ import {
   getRouteLayer,
   getPathColour,
   setRouteLayer,
+  routeLayerHasFeatures
 } from "./map.js";
 
 import {
@@ -211,6 +212,11 @@ const allowedFileTypes = ['.gpx', '.kml', '.geojson', '.fit'];
 let clickMode = null;
 let manualRouteLayer = null;
 let selectedPoint = null;
+
+// Start and End points 
+
+let interactivePointLayerInteraction = null; // holds the OpenLayer interaction for the start and end points 
+let interactivePointLayer = null; // stores the vector layer which holds the point features 
 
 //#endregion
 
@@ -470,10 +476,20 @@ export function mapClickHandler(event) {
 
   if (clickMode === "setStart") {
     setCoordEntry(startCoordEntry, event);
+
+    // adding start point
+    const pointFeature = createPoint(event.coordinate, getSavedPointStyle("Start", "#074df0"), "start", "Start");
+    addStartEndPoint(pointFeature, interactivePointLayer, "start");
+    setUpPointInteraction([interactivePointLayer]);
     return;
   }
   if (clickMode === "setEnd") {
     setCoordEntry(endCoordEntry, event);
+
+    // adding end point 
+    const pointFeature = createPoint(event.coordinate, getSavedPointStyle("End", "#074df0"), "end", "End")
+    addStartEndPoint(pointFeature, interactivePointLayer, "end");
+    setUpPointInteraction();
     return;
   }
 
@@ -865,39 +881,44 @@ export function clearAutoRoute() {
   if (!map) return;
 
   clearPathState();
-
-  const routeLayer = getRouteLayer();
-  if (routeLayer) routeLayer.getSource().clear();
-
-  if (getCurrentMode() === "manual") {
-    clearManualRoute();
-  }
-
-  map
-    .getLayers()
-    .getArray()
-    .slice()
-    .forEach((layer) => {
-      if (
-        layer instanceof ol.layer.Vector &&
-        layer !== getSavedPointsLayer() &&
-        layer !== routeLayer
-      ) {
-        layer.getSource()?.clear();
-      }
-    });
-
-  document.getElementById("route-stats")?.remove();
-
   clearLastAutoRouteStats();
 
+  // this clears the permanent route layer
+  getRouteLayer()?.getSource()?.clear();
+
+  // this clears start / end markers from the interactive layer
+  if (interactivePointLayer) {
+    const source = interactivePointLayer.getSource();
+    source.getFeatures()
+      .filter(f => f.get("type") === "start" || f.get("type") === "end")
+      .forEach(f => source.removeFeature(f));
+  }
+
+  // this clears any other temporary vector layers (but leaves saved-points + interactive + route alone)
+  map.getLayers().getArray().slice().forEach((layer) => {
+    if (
+      layer instanceof ol.layer.Vector &&
+      layer !== getSavedPointsLayer() &&
+      layer !== getRouteLayer() &&
+      layer !== interactivePointLayer
+    ) {
+      layer.getSource()?.clear();
+    }
+  });
+
+  // this cleans up the UI
+  document.getElementById("route-stats")?.remove();
   if (startCoordEntry) startCoordEntry.value = "";
   if (endCoordEntry) endCoordEntry.value = "";
   if (routeNameEntry) routeNameEntry.value = "";
   if (saveContainer) saveContainer.style.display = "none";
   updateSaveRouteContainer();
-  
-};
+
+  // this also wipes the manual route if the user is in manual mode 
+  if (getCurrentMode() === "manual") {
+    clearManualRoute();
+  }
+}
 
 export function clearManualRoute() {
   const map = getMap();
@@ -905,77 +926,73 @@ export function clearManualRoute() {
 
   clearManualRouteState();
 
+  // this removes the temporary manual route layer
   if (manualRouteLayer) {
     map.removeLayer(manualRouteLayer);
     manualRouteLayer = null;
   }
 
-  document.getElementById("route-stats")?.remove();
+  // this also clears the permanent route layer (in case anything was drawn there)
+  getRouteLayer()?.getSource()?.clear();
 
+  document.getElementById("route-stats")?.remove();
   if (saveContainer) saveContainer.style.display = "none";
   updateSaveRouteContainer();
-
-  clearPathState();
-  getRouteLayer()?.getSource().clear();
   resetElevationChart();
-  
-};
+}
 
 export function homeButtonFunction() {
   const map = getMap();
   if (!map) return;
 
+  // this resets the coordinate input UI state
   if (startCoordEntry) {
-    startCoordEntry.classList.remove('input-error');
-    startCoordEntry.classList.remove('is-active');
+    startCoordEntry.classList.remove("input-error", "is-active");
     startCoordEntry.placeholder = "Coordinates";
+    startCoordEntry.value = "";
   }
-
   if (endCoordEntry) {
-    endCoordEntry.classList.remove('input-error');
-    endCoordEntry.classList.remove('is-active');
+    endCoordEntry.classList.remove("input-error", "is-active");
     endCoordEntry.placeholder = "Coordinates";
+    endCoordEntry.value = "";
   }
 
   clickMode = null;
   generatePathButton?.classList.remove("loading");
 
+  // this wipes all route-related state
   clearManualRoute();
   clearAutoRoute();
   clearLastLoadedRouteStats();
-  updateSaveRouteContainer()
+  clearPathState();
 
-  const layersToRemove = [];
-  map.getLayers().forEach((layer) => {
-    if (layer instanceof ol.layer.Vector) layersToRemove.push(layer);
+  // Remove only temporary vector layers.
+  // Keep: routeLayer, interactivePointLayer, saved-points layer
+  map.getLayers().getArray().slice().forEach((layer) => {
+    if (
+      layer instanceof ol.layer.Vector &&
+      layer !== getRouteLayer() &&
+      layer !== interactivePointLayer &&
+      layer !== getSavedPointsLayer()
+    ) {
+      map.removeLayer(layer);
+    }
   });
-  layersToRemove.forEach((layer) => map.removeLayer(layer));
 
-  setRouteLayer(
-    new ol.layer.Vector({
-      source: new ol.source.Vector(),
-      style: new ol.style.Style({
-        stroke: new ol.style.Stroke(getRouteStrokeStyle()),
-      }),
-      zIndex: 999,
-    }),
-  );
-  map.addLayer(getRouteLayer());
-
+  // this cleans up the UI
   document.getElementById("route-stats")?.remove();
-
-  moveMapToPosition(map)
-  if (startCoordEntry) startCoordEntry.value = "";
-  if (endCoordEntry) endCoordEntry.value = "";
   if (searchEntry) searchEntry.value = "";
   if (routeNameEntry) routeNameEntry.value = "";
-
-  clearPathState();
   if (saveContainer) saveContainer.style.display = "none";
-  
+  updateSaveRouteContainer();
+
+  // this resets the map view and re-shows saved points
   loadAndDisplaySavedPoints();
+  map.renderSync(); // this is to ensure that the map renders the deletion of the routeLayer features before the moving of the map view 
+
+  moveMapToPosition(map);
   updateCursor();
-};
+}
 
 //#endregion
 
@@ -1037,7 +1054,6 @@ async function handleAutoRouteGeneration(start=null, end=null) {
   const startPoint = start || startCoordEntry?.value || "";
   const endPoint = end || endCoordEntry?.value || "";
 
-
   if (validateInputCoords(startPoint, endPoint) !== true) return;
 
   generatePathButton.disabled = true;
@@ -1052,14 +1068,17 @@ async function handleAutoRouteGeneration(start=null, end=null) {
     setLastKnownDistanceKm(routeStats.total_distance);
     setLastAutoRouteStats(routeStats);
     displayAutoRouteStats(getLastAutoRouteStats());
-
+    
+    resetElevationChart();
     initChartToggleListener();
     createElevationProfile(response.coordinates);
 
     if (saveContainer) saveContainer.style.display = "flex";
 
   } catch (error) {
-    throw new Error(data.message || "Sorry, there was an unexpected error when calculating your route, please try again later.")
+    throw new Error(error.message || "Sorry, there was an unexpected error when calculating your route, please try again later.");
+    showError("Sorry, there was an unexpected error when calculating your route, please try again later.");
+    return;
   } finally {
     generatePathButton.classList.remove("loading");
     generatePathButton.disabled = false;   
@@ -1067,22 +1086,30 @@ async function handleAutoRouteGeneration(start=null, end=null) {
 };
 
 function displayPath(data) {
+
+  try { 
   const map = getMap();
   const routeLayer = getRouteLayer();
   if (!map || !routeLayer) return null;
 
-  const source = routeLayer.getSource();
-  source.clear();
+  const routeLayerSource = routeLayer.getSource();
+  const interactivePointLayerSource = interactivePointLayer.getSource();
+
+  routeLayerSource.clear();
+  
+  interactivePointLayerSource.getFeatures()
+  .filter(feature => feature.get('type') === 'start' || feature.get('type') === 'end')
+  .forEach(feature => interactivePointLayerSource.removeFeature(feature))
 
   // this clears the hovered point feature to prevent the preserving of stale OL point features
   setHoverPointFeature(null);
 
-  const feature = new ol.format.GeoJSON().readFeature(data.pathGeoJSON, {
+  const pathFeature = new ol.format.GeoJSON().readFeature(data.pathGeoJSON, {
     dataProjection: "EPSG:3857",
     featureProjection: "EPSG:3857",
   });
 
-  source.addFeature(feature);
+  routeLayerSource.addFeature(pathFeature);
 
   const coordinates = data.coordinates;
 
@@ -1091,18 +1118,12 @@ function displayPath(data) {
     const startCoord = coordinates[0];
     const endCoord = coordinates[coordinates.length - 1];
 
-    const startPointFeature = new ol.Feature({
-      geometry: new ol.geom.Point([startCoord[0], startCoord[1]])
-    });
-    startPointFeature.setStyle(createManualPointStyle("Start", "#8145d4"));
+    // this creates and then displays (by adding them to the interactivePointLayerSource) the start and end point features
+    const startPointFeature = createPoint([startCoord[0], startCoord[1]], getSavedPointStyle("Start", "#074df0"), "start", "Start")
+    const endPointFeature = createPoint([endCoord[0], endCoord[1]], getSavedPointStyle("End", "#074df0"), "end", "End")
 
-    const endPointFeature = new ol.Feature({
-      geometry: new ol.geom.Point([endCoord[0], endCoord[1]])
-    });
-    endPointFeature.setStyle(createManualPointStyle("End", "#8145d4"));
-
-    source.addFeature(startPointFeature);
-    source.addFeature(endPointFeature);
+    interactivePointLayerSource.addFeature(startPointFeature)
+    interactivePointLayerSource.addFeature(endPointFeature)
 
   }
 
@@ -1110,14 +1131,19 @@ function displayPath(data) {
 
 
   setTimeout(() => {
-    map.getView().fit(source.getExtent(), {
-      padding: [50, 100, 100, 430],
+    map.getView().fit(routeLayerSource.getExtent(), {
+      padding: [300, 300, 300, 430],
       duration: 1200,
     });
     map.render();
   }, 100);
 
   return data.route_stats;
+  } 
+  catch(error) {
+    console.log(error.message);
+    showError('Sorry, there was an unexpected error when calculating your route, please try again later.')
+  }
 };
 
 function displayAutoRouteStats(routeStats) {
@@ -1389,6 +1415,103 @@ export function handleInitialTour() {
 
 //#endregion
 
+//#region POINT INTERACTION
+
+/**
+ * Adds a start/end point feature to a vector layer, removing any existing feature of the same type first
+ *
+ * @param {ol.Feature} pointFeature The point feature to add
+ * @param {ol.layer.Vector} vectorLayer The vector layer that will contain the feature
+ * @param {string} type Feature type identifier (e.g. `"start"` or `"end"`)
+ * @returns {void}
+ */
+function addStartEndPoint(pointFeature, vectorLayer, type) {
+  const vectorLayerSource = vectorLayer.getSource();
+
+  // this removes any existing features which are of the same type 
+  vectorLayerSource.getFeatures()
+  .filter(feature => feature.get('type') === type)
+  .forEach(feature => vectorLayerSource.removeFeature(feature))
+
+  vectorLayerSource.addFeature(pointFeature)
+}
+
+/**
+ * Creates an OpenLayers point feature.
+ *
+ * @param {Array<number>} coordinates Coordinates in EPSG:3857.
+ * @param {ol.style.Style} style Style to apply to the feature.
+ * @param {string} type Logical point type (e.g. "start", "end", "waypoint").
+ * @param {string} [label] Display label for the point.
+ * @returns {ol.Feature}
+ */
+export function createPoint(coordinates, style, type, label) {
+
+    const point = new ol.Feature({
+        geometry: new ol.geom.Point(coordinates)
+    });
+
+    point.set("type", type);
+    point.set("label", label);
+    point.setStyle(style);
+
+    return point;
+}
+
+/**
+ * Adds a translate interaction to start / end OpenLayers points
+ * 
+ * @param {Array} layers The layers that the interaction is to be applied upon 
+ * @returns {void}
+ */
+export function setUpPointInteraction(layers) {
+  const map = getMap();
+  if (!map || !layers) return;
+
+  const interactivePointLayerSource = interactivePointLayer.getSource();
+
+  // this removes any previous interaction
+  if (interactivePointLayerInteraction) {
+    map.removeInteraction(interactivePointLayerInteraction);
+  }
+
+  // this makes the OpenLayers interaction
+  interactivePointLayerInteraction = new ol.interaction.Translate({
+    layers: layers,
+    filter: (feature) => feature.getGeometry() instanceof ol.geom.Point // (only accounts for points)
+  });
+  
+  map.addInteraction(interactivePointLayerInteraction); 
+
+  interactivePointLayerInteraction.on('translateend', (event) => {
+    const movedFeature = event.features.item(0);
+    if (!movedFeature) return;
+
+    const newCoordinates = movedFeature.getGeometry().getCoordinates();
+    const pointType = movedFeature.get("type");
+    const rounded = roundCoords(newCoordinates, 0);
+    const coordString = `${rounded[0]}, ${rounded[1]}`;
+
+    // this updates the correct input
+    if (pointType === "start") {
+      startCoordEntry.value = coordString;
+    } else if (pointType === "end") {
+      endCoordEntry.value = coordString;
+    }
+
+    const startVal = startCoordEntry?.value?.trim();
+    const endVal = endCoordEntry?.value?.trim();
+
+    // this ensures routes are only recalculated if both points are present
+    if (startVal && endVal) {
+      handleAutoRouteGeneration(startVal, endVal);
+    }
+
+  });
+}
+
+//#endregion
+
 //#region DELETING POINTS
 
 function deselectSelectedPoint() {
@@ -1399,28 +1522,6 @@ function deselectSelectedPoint() {
   }
   return
 };
-
-function initPointDeleteHandlers() {
-  if (!deletePointModal) return;
-
-  // for hiding if clicking anywhere outside the modal
-  deletePointModal.addEventListener("click", (e) => {
-    dismissDeletePointModal(e);
-  });
-
-  // for deselecting the currently-selected point when the modal is closed 
-  deletePointModal.addEventListener("close", deselectSelectedPoint);
-
-  // for when the user clicks the 'exit' button on the modal
-  deletePointModalExitButton?.addEventListener("click", () => {
-    showDeletePointModal(false)
-  });
-
-  // for when the user clicks 'delete point' on the modal
-  deletePointModalDeleteButton?.addEventListener("click", () => {
-    deleteSavedPoint(selectedPoint)
-  });
-}
 
 //#endregion
 
@@ -1528,7 +1629,38 @@ function handleKeyboardShortcuts(e) {
 //#endregion
 
 
-//#region EVENT LISTENERS
+//#region EVENT LISTENERS / INIT
+
+function initInteractivePointLayer(map) {
+  interactivePointLayer = new ol.layer.Vector({
+    source: new ol.source.Vector(),
+    zIndex: 1000 // above the route layer 
+  });
+
+  map.addLayer(interactivePointLayer);
+}
+
+function initPointDeleteHandlers() {
+  if (!deletePointModal) return;
+
+  // for hiding if clicking anywhere outside the modal
+  deletePointModal.addEventListener("click", (e) => {
+    dismissDeletePointModal(e);
+  });
+
+  // for deselecting the currently-selected point when the modal is closed 
+  deletePointModal.addEventListener("close", deselectSelectedPoint);
+
+  // for when the user clicks the 'exit' button on the modal
+  deletePointModalExitButton?.addEventListener("click", () => {
+    showDeletePointModal(false)
+  });
+
+  // for when the user clicks 'delete point' on the modal
+  deletePointModalDeleteButton?.addEventListener("click", () => {
+    deleteSavedPoint(selectedPoint)
+  });
+}
 
 export function initUi() {
   const map = getMap();
@@ -1540,6 +1672,8 @@ export function initUi() {
 
   initSaveRoute();
   initPointDeleteHandlers();
+
+  initInteractivePointLayer(map);
 
 
   // initial tour (automatic routing and saving the first route)

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1438,7 +1438,7 @@ function toWebMercator(coords) {
 
   if (isLonLat(coords)) {
     // OpenLayers expects [longitude, latitude]
-    return ol.proj.fromLonLat(coords);
+    return ol.proj.fromLonLat([coords[1], coords[0]]);
   }
 
   // Already projected (EPSG:3857)

--- a/static/js/utils/routing-utils.js
+++ b/static/js/utils/routing-utils.js
@@ -71,11 +71,11 @@ export function isLonLat(coordinate) {
   };
 
   // this ensures that both lat and lon variables are numbers and can be used in the conditional checks to ensure they are valid WGS84 coordinates 
-  if (!typeof lat === 'number' || !Number.isFinite(lat)) {
+  if (typeof lat !== 'number' || !Number.isFinite(lat)) {
     console.warn('isLonLat(coord) : variable lat is either not a number or is infinite')
   }; 
 
-  if (!typeof lon === 'number' || !Number.isFinite(lon)) {
+  if (typeof lon !== 'number' || !Number.isFinite(lon)) {
     console.warn('isLonLat(coord) : variable lon is either not a number or is infinite')
   }; 
 

--- a/static/js/utils/ui-utils.js
+++ b/static/js/utils/ui-utils.js
@@ -33,6 +33,7 @@ export function parseCoordString(value) {
   const x = Number(parts[0]);
   const y = Number(parts[1]);
 
+  if (!x || !y) return null;
   if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
 
   return [x, y];

--- a/static/js/utils/ui-utils.js
+++ b/static/js/utils/ui-utils.js
@@ -1,6 +1,6 @@
 /**
  * This file is intended to hold all UI related helper functions
- * As of July 2026 this file hold the following functions:
+ * As of August 2026 this file hold the following functions:
  *      
  *      - moveMapToPosition(map, position = null, duration = 1200, zoom = 10.5)
  *      - showError(message, colour = "#ff4d4f")
@@ -9,11 +9,34 @@
  *      - createRouteCard(routeName, formattedDate, distanceInKm, ETA, elevDisplayValue)
  *      - createNoRouteCard()
  *      - createStatsPanel(distanceDisplay, etaDisplay, elevationGain)
+ *      - parseCoordString(value)
  */      
 
 
 
 // GENERAL 
+
+/**
+ * Parses a coordinate string in the form "X, Y" (or "X,Y").
+ * Returns [x, y] as numbers or null if the format is invalid.
+ * Never throws.
+ */
+export function parseCoordString(value) {
+  if (typeof value !== "string") return null;
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const parts = trimmed.split(/\s*,\s*/);
+  if (parts.length !== 2) return null;
+
+  const x = Number(parts[0]);
+  const y = Number(parts[1]);
+
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+
+  return [x, y];
+}
 
 /**
  * Function to move the map to a specific coordinate or the centre of the map via an animation


### PR DESCRIPTION
# Pull Request Template

## Summary

This PR aims to introduce improved representation of currently set start and end points during automatic routing. This ensures that there is clarity for users when choosing what points to generate a path between.

## Related Issue

Fixes abdlfc11/Crestr-Hiking-App#78

Closes abdlfc11/Crestr-Hiking-App#78

## Type of Change

Select all that apply:

- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (explain below)

## Description of Changes

* A function to create a point feature, `createPoint(coordinates, style, type, label`, as well as a function to add a point feature to the map, `addStartEndPoint(pointFeature, vectorLayer, type)` , were implemented and used when setting start and end coordinates in order to represent the currently set start and end points
* Another function was implemented in order to handle the addition of an OpenLayers interaction to the point's vector layer, `setUpPointInteraction(layers)`
* This allowed for the points to be interacted by the user and moved around, this was called whenever start/end points were added to the map
* The function included an event listener that generated a path if both points were present whenever one of the start/end points were moved
* Another function was implemented which handled when a change was detected in the start/end coordinate entries' values, adding a point to the map to represent the start/end point
* This also generated a path if it detected that there were values for both the start and end point coordinate entries

## Screenshots / Visuals (if applicable)\]

Below can be seen an example route with the start and end coordinate clearly represented by pin markers

![image](https://github.com/user-attachments/assets/bab7744c-395d-43ce-a9f0-f832500b07d7)

## Testing

* Generated a route by entering the start and end coordinate manually
* Generated a route by using the 'set coordinate' buttons, entering the start coordinate first
* Generated a route by using the 'set coordinate' buttons, entering the end coordinate first
* Moved start/end coordinate markers and observed the generation of a route between the new position of the pin/s
* Ensured that upon pressing the 'clear route' or 'reset' buttons, that both the path vector layer and the interactive points vector layer were removed

## Checklist

- [X] My code follows the project’s style guidelines
- [X] I have tested my changes
- [X] I have updated documentation if needed
- [X] I have referenced the related issue
- [X] This PR is scoped, focused, and ready for review

> **Note:**  <br>PRs for issues **not** tagged as contributor‑friendly may be closed without review.