### PR TITLE
feat: Refactor app to ensure that data sent between the backend and f…

### DIFF
--- a/src/Points/points_fastapi.py
+++ b/src/Points/points_fastapi.py
@@ -14,7 +14,7 @@ from sqlalchemy.exc import IntegrityError
 
 # Local Modules
 from src.db import engine
-from src.extensions import log_action, get_current_user
+from src.extensions import service, log_action, get_current_user
 from src.models import Point, User
 from .points_schemas import PointSchema
 
@@ -42,19 +42,27 @@ def get_saved_points(user: User | None = Depends(get_current_user)):
     if not points:
         return {"success": False, "message": "No points found", "points": []}
 
-    web_mercator_points = []
+    wgs84_points = []
     for point in points:
         try:
-            web_mercator_x, web_mercator_y = json.loads(point.coordinates)
-            web_mercator_points.append({
+            coord_x, coord_y = json.loads(point.coordinates)
+
+            # converts coordinates to Lat/Lon if it detects web mercator coordinates (not Lat/Lon)
+            if abs(coord_x) > 181 or abs(coord_y) > 181:
+                coord_x, coord_y = service.convert_web_mercator_to_wgs84(coord_x, coord_y)
+
+            wgs84_points.append({
                 "name": point.name,
-                "coordinates": [web_mercator_x, web_mercator_y]
+                "coordinates": [coord_x, coord_y]
             })
         except Exception as e:
             short_traceback = "".join(format_exception_only(type(e), e)).strip()
             log_action('Getting Saved Points', False, short_traceback, None, 'GET_SAVED_POINT')
 
-    return {"success": True, "points": web_mercator_points}
+    return {
+        "success": True,
+        "points": wgs84_points
+    }
 
 # route which saves a user-chosen point on the map
 @router.post(
@@ -79,13 +87,22 @@ def save_point(
     # this retrieves the details of the point from the pydantic base model
 
     point_name = point.point_name
-    web_mercator_x = point.web_mercator_x
-    web_mercator_y = point.web_mercator_y
+    lon = point.lon
+    lat = point.lat
     
     try:
-              
-        # coords are used to save the chosen point
-        coords = json.dumps([float(web_mercator_x), float(web_mercator_y)])
+
+        # this validates that lat/lon are present
+        if lon is None or lat is None:
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "success": False,
+                    "message": "Invalid coordinate format. Point must include lon and lat."
+                }
+            )
+
+        coords = json.dumps([float(lon), float(lat)])
 
         with Session(engine) as db:
             new_point = Point(name=point_name, coordinates=coords, user_id=user.id) 

--- a/src/Points/points_fastapi.py
+++ b/src/Points/points_fastapi.py
@@ -47,7 +47,7 @@ def get_saved_points(user: User | None = Depends(get_current_user)):
         try:
             coord_x, coord_y = json.loads(point.coordinates)
 
-            # converts coordinates to Lat/Lon if it detects web mercator coordinates (not Lat/Lon)
+            # converts coordinates to Lon/Lat if it detects web mercator coordinates (via not Lon/Lat condition)
             if abs(coord_x) > 181 or abs(coord_y) > 181:
                 coord_x, coord_y = service.convert_web_mercator_to_wgs84(coord_x, coord_y)
 

--- a/src/Points/points_schemas.py
+++ b/src/Points/points_schemas.py
@@ -3,5 +3,5 @@ from pydantic import BaseModel
 
 class PointSchema(BaseModel):
     point_name: str
-    web_mercator_x: float | None = None
-    web_mercator_y: float | None = None
+    lon: float | None = None
+    lat: float | None = None

--- a/src/Points/points_schemas.py
+++ b/src/Points/points_schemas.py
@@ -1,7 +1,18 @@
-from pydantic import BaseModel
+from typing import Annotated
+import math
+from pydantic import BaseModel, AfterValidator, Field
+
+# better validation for coordinates to ensure that erroneous coordinates are caught before they hit FastAPI routes 
+def check_finite(value: float) -> float:
+    if not math.isfinite(value):
+        raise ValueError("Coordinates must be finite. ")
+    return value
+    
+Longitude = Annotated[float, AfterValidator(check_finite), Field(ge=-180, le=180)]
+Latitude = Annotated[float, AfterValidator(check_finite), Field(ge=-90, le=90)]
 
 
 class PointSchema(BaseModel):
     point_name: str
-    lon: float | None = None
-    lat: float | None = None
+    lon: Longitude | None = None
+    lat: Latitude | None = None

--- a/src/Routes/helpers.py
+++ b/src/Routes/helpers.py
@@ -45,7 +45,7 @@ def normalise_route(coordinates: list, avg_speed_kmh: float = 4.5) -> dict:
 
     Parameters:
 
-        - coordinates (list): A nested list of points, e.g., [[Lat, Lon, elev], ...]
+        - coordinates (list): A nested list of points, e.g., [[Lon, Lat, elev], ...]
 
         - avg_speed_kmh (float): The average speed used for ETA calculations, defaults to 4.5 (average hiking speed)
 

--- a/src/Routes/helpers.py
+++ b/src/Routes/helpers.py
@@ -23,9 +23,9 @@ def isRoughlyInCumbria(x: float, y: float) -> bool:
 
     return x >= MIN_X and x <= MAX_X and y >= MIN_Y and y <= MAX_Y 
 
-def haversine(x1: float, y1: float, x2: float, y2: float):
+def haversine(x1: float, y1: float, x2: float, y2: float) -> float:
 
-    # NOTE : coords need to be in lon/lat, make sure to convert coords
+    # NOTE : coords need to be in lon/lat 
 
     R = 6371000
 
@@ -40,25 +40,23 @@ def haversine(x1: float, y1: float, x2: float, y2: float):
 
     return R * c
 
-def normalise_route(coordinates: list, avg_speed_kmh: float = 4.5):
-    """
-    This function converts raw route geometry into metrics e.g ETA and elevation data (if present)
+def normalise_route(coordinates: list, avg_speed_kmh: float = 4.5) -> dict:
+    """Converts raw route geometry into metrics like ETA and elevation data.
+
+    Parameters:
+
+        - coordinates (list): A nested list of points, e.g., [[Lat, Lon, elev], ...]
+
+        - avg_speed_kmh (float): The average speed used for ETA calculations, defaults to 4.5 (average hiking speed)
+
+    Returns:
+        dict: Information associated with the path, including ETA, elevation gain, and distance.
     """
 
     converted_coords = []
 
     if not coordinates or len(coordinates) < 2:
         return({"success": False, "message": "Route is too small"})
-    
-    start_coord = coordinates[0]
-
-    
-    # this checks the first coord to check if it is in lat/lon format, if not it converts coords to lat/lon format
-    if not (abs(start_coord[0]) <= 180 and abs(start_coord[1]) <= 90):
-        print("DEBUG STATEMENT\nFUNCTION : normalise_route()\nDetected projection that is NOT Lat/Lon for start point. Converting to Lat/Lon")
-        for coord in coordinates:
-            converted_coord = service.convert_web_mercator_to_wgs84(coord[0], coord[1])
-            converted_coords.append(converted_coord)
 
     total_distance_m = 0.0
     total_elevation_gain_m = 0.0
@@ -70,10 +68,10 @@ def normalise_route(coordinates: list, avg_speed_kmh: float = 4.5):
         x2, y2 = coordinates[i + 1][0], coordinates[i + 1][1]
 
         # distance calculation
-        if not converted_coords or converted_coords == []:
-            total_distance_m += haversine(x1, y1, x2, y2)
-        else:
+        if converted_coords and converted_coords != []:
             total_distance_m += haversine(converted_coords[i][0], converted_coords[i][1], converted_coords[i + 1][0], converted_coords[i + 1][1])
+        else:
+            total_distance_m += haversine(x1, y1, x2, y2)
 
         # elevation gain (only if available)
         if has_elevation:
@@ -104,14 +102,18 @@ def get_xy(coord: list):
         return coord[0], coord[1]
     return coord
 
-# if a coord is over 180 degrees then it is definitely not wgs84 (181 used as buffer for edge cases)
-# this helper thus returns true if a coord is web mercator and false if it isn't (and thus is wgs84)
-def check_web_mercator(coord: list):
+def check_web_mercator(coord: list) -> bool:
+    """
+    Returns True if the inputted coordinate is in Web Mercator and false otherwise  
+    """
     if coord is None:
         return False
     return abs(coord[0]) > 181 or abs(coord[1]) > 181
 
-def parse_elevation(elevation_string: str):
+def parse_elevation(elevation_string: str) -> float | None:
+    """
+    Converts an elevation value in string format into a float value to be used in calculations 
+    """
     if not elevation_string:
         return None
     try:
@@ -119,8 +121,10 @@ def parse_elevation(elevation_string: str):
     except Exception:
         return None
 
-# helper function used in creation of gpx / geojson files which converts hrs and minutes to seconds 
-def parse_eta_to_seconds(eta_string: str):
+def parse_eta_to_seconds(eta_string: str) -> float | None:
+    """
+    Converts ETA string (of hours and minutes) into a float value to be used in calculations
+    """
     if not eta_string:
         return None
     try:
@@ -138,7 +142,10 @@ def parse_eta_to_seconds(eta_string: str):
 
 #region GEOSPATIAL FILE PROCESSING HELPER FUNCTIONS
 
-def generate_geojson(route: object):
+def generate_geojson(route: object) -> str:
+    """
+    Generates a GeoJSON file content using the given route, which includes elevation
+    """
 
     raw_coordinates_str = route.coordinates
 
@@ -153,16 +160,28 @@ def generate_geojson(route: object):
     corrected_coords = []
     
     has_elevation = check_elevation(raw_coords)
+
+    # if the stored coords are Web Mercator (legacy), convert to lat/lon
+    is_legacy_mercator = check_web_mercator(raw_coords[0]) if raw_coords else False
         
     for coord in raw_coords:
+
         if has_elevation:
             x, y, elevation = coord
-            lon, lat = service.convert_web_mercator_to_wgs84(x, y)
-            corrected_coords.append([lon, lat, elevation])
         else:
             x, y = coord
+            elevation = None
+
+        # coords stored as lat/lon going forward; legacy mercator rows are converted on the fly
+        if is_legacy_mercator:
             lon, lat = service.convert_web_mercator_to_wgs84(x, y)
-            corrected_coords.append([x, y])
+        else:
+            lon, lat = x, y
+
+        if elevation is not None:
+            corrected_coords.append([lon, lat, elevation])
+        else:
+            corrected_coords.append([lon, lat])
 
         
     # constructs the geojson dict
@@ -182,7 +201,11 @@ def generate_geojson(route: object):
     # returns as JSON string
     return json.dumps(geojson_feature)
 
-def generate_gpx(route: object):
+def generate_gpx(route: object) -> str:
+    """
+    Generates a GPX file content using the given route, which includes elevation
+    """
+
     gpx = gpxpy.gpx.GPX() # initialises container
     track = gpxpy.gpx.GPXTrack(name=route.name) # creates a track (the entire route) and adds it to the container (next line)
     gpx.tracks.append(track) 
@@ -193,18 +216,30 @@ def generate_gpx(route: object):
 
     has_elevation = check_elevation(coords)
 
+    # if the stored coords are Web Mercator (legacy), convert to lat/lon
+    is_legacy_mercator = check_web_mercator(coords[0]) if coords else False
+
     for coord in coords: # loops through each coord in one sub array in the coords array
+
         if has_elevation:
             x, y, elevation = coord
-            lon, lat = service.convert_web_mercator_to_wgs84(x, y) # converts to lat and lon (needed for gpx)
+        else:
+            x, y = coord
+            elevation = None
+
+        # coords stored as lat/lon going forward; legacy mercator rows are converted on the fly
+        if is_legacy_mercator:
+            lon, lat = service.convert_web_mercator_to_wgs84(x, y)
+        else:
+            lon, lat = x, y
+
+        if elevation is not None:
             segment.points.append(gpxpy.gpx.GPXTrackPoint(
                 latitude=lat,
                 longitude=lon,
                 elevation=elevation
             ))
         else:
-            x, y = coord
-            lon, lat = service.convert_web_mercator_to_wgs84(x, y)
             segment.points.append(gpxpy.gpx.GPXTrackPoint(
                 latitude=lat,
                 longitude=lon

--- a/src/Routes/routes_fastapi.py
+++ b/src/Routes/routes_fastapi.py
@@ -223,7 +223,20 @@ def calculate_path(
         
         start_coords = web_mercator_coordinates[0]
         end_coords = web_mercator_coordinates[-1]
-        
+
+        # builds the coordinate array of [lon, lat, elev] points
+        # this is what is returned when the API is called 
+        wgs84_coordinates = [] 
+        for coord in web_mercator_coordinates:
+            lon, lat = service.convert_web_mercator_to_wgs84(coord[0], coord[1])
+            if len(coord) >= 3:
+                wgs84_coordinates.append([lon, lat, coord[2]])
+            else:
+                wgs84_coordinates.append([lon, lat])
+
+        start_coords = wgs84_coordinates[0]
+        end_coords = wgs84_coordinates[-1]
+
         # This calculates distance and eta statistics
         total_distance = service.calculate_route_distance(path)
         total_distance_km = total_distance / 1000
@@ -234,12 +247,14 @@ def calculate_path(
 
         path_geojson = {
             "type": "Feature",
-            "geometry": {"type": "LineString", "coordinates": web_mercator_coordinates},
+            "geometry": {"type": "LineString", "coordinates": wgs84_coordinates},
             "properties": {"color": "#2563eb"}
         } 
         
-        # This calculates optimal map centre and zoom
-        map_centre, map_zoom = service.calculate_map_center_and_zoom(web_mercator_coordinates)
+        # calculates optimal map centre + zoom using internal Web Mercator
+        # then converts centre to lat/lon to send to the frontend
+        map_centre_mercator, map_zoom = service.calculate_map_center_and_zoom(web_mercator_coordinates)
+        map_centre = list(service.convert_web_mercator_to_wgs84(map_centre_mercator[0], map_centre_mercator[1]))
 
         route_stats = {
             "start_elevation": start_elevation,
@@ -270,7 +285,7 @@ def calculate_path(
             "map_centre": map_centre,
             "map_zoom": map_zoom,
             "route_stats": route_stats,
-            "coordinates": web_mercator_coordinates,
+            "coordinates": wgs84_coordinates,
             "startCoord": start_coords,
             "endCoord": end_coords
         }
@@ -326,7 +341,7 @@ def save_route(
             )
 
         route_name = data.route_name
-        coordinates = data.coordinates
+        coordinates = data.coordinates # these are in Lon, Lat format
 
         if not route_name or not route_name.strip():
 
@@ -455,7 +470,7 @@ def load_route(
 
     route = db.exec(
         select(Route)
-        .where( (Route.name == route_name) & (Route.user_id==user.id))
+        .where(Route.name == route_name, Route.user_id==user.id)
     ).first()
 
     if not route:
@@ -470,35 +485,29 @@ def load_route(
     
     json_coords = json.loads(route.coordinates)
 
-    
-    # success, coordinates, file_type = db_manager.load_route(route_name)
     coordinates = json_coords
 
     has_elevation = check_elevation(coordinates)
     
     try:
-        # converts wgs84 coordinates to web mercator for display
-        web_mercator_coordinates = []
+        wgs84_coordinates = []
 
+        # routes saved prior to switch to Lat/Lon projection for storing routes will have coordinates stored in Web Mercator projection
+        # this checks these coordinates and converts them to Lon/Lat if Web Mercator coordinates are found
         if check_web_mercator(coordinates[0]):
-            # already in web mercator so this block just normalises the lengths
             for coord in coordinates:
                 x, y = coord[0], coord[1]
                 z = coord[2] if len(coord) >= 3 else 0   # default elevation = 0
-                web_mercator_coordinates.append([x, y, z])
+                lon, lat = service.convert_web_mercator_to_wgs84(x, y)
+                wgs84_coordinates.append([lon, lat, z])
         else:
-            # this block converts wgs84 to web mercator
+            # already lat/lon: normalise lengths
             for coord in coordinates:
-                if has_elevation and len(coord) >= 3:
-                    lon, lat, elevation = coord[:3]
-                    web_x, web_y = service.convert_wgs84_to_web_mercator(lon, lat)
-                    web_mercator_coordinates.append([web_x, web_y, elevation])
-                else:
-                    lon, lat = coord[:2]
-                    web_x, web_y = service.convert_wgs84_to_web_mercator(lon, lat)
-                    web_mercator_coordinates.append([web_x, web_y, 0])
+                x, y = coord[0], coord[1]
+                z = coord[2] if len(coord) >= 3 else 0
+                wgs84_coordinates.append([x, y, z])
 
-        if not web_mercator_coordinates:
+        if not wgs84_coordinates:
 
             log_action('Loading Route', False, "No coordinates found in the route", None, 'LOAD_ROUTE')
 
@@ -515,14 +524,14 @@ def load_route(
             "type": "FeatureCollection",
             "features": [{
                 "type": "Feature",
-                "geometry": {"type": "LineString", "coordinates": web_mercator_coordinates},
+                "geometry": {"type": "LineString", "coordinates": wgs84_coordinates},
                 "properties": {"color": "#2563eb"}
             }]
         }
         
         
         # calculates midpoint for map centring
-        midpoint = web_mercator_coordinates[len(web_mercator_coordinates)//2] if web_mercator_coordinates else DEFAULT_CENTRE
+        midpoint = wgs84_coordinates[len(wgs84_coordinates)//2] if wgs84_coordinates else DEFAULT_CENTRE
 
         # data collected directly from database values
         eta_seconds = route.eta_seconds
@@ -543,7 +552,7 @@ def load_route(
             "message": f"Route '{route_name}' loaded successfully",
             "pathGeoJSON": path_geojson,
             "map_centre": midpoint,
-            "coordinates": web_mercator_coordinates,
+            "coordinates": wgs84_coordinates,
             "route_stats": route_stats
         }
 
@@ -755,9 +764,7 @@ async def import_route(
                 
                 lat, lon, ele = point[0], point[1], point[2]
 
-                web_mercator_coords = service.convert_wgs84_to_web_mercator(lon, lat)
-
-                converted_points.append([web_mercator_coords[0], web_mercator_coords[1], ele])
+                converted_points.append([lon, lat, ele])
 
             log_action('Importing Route', True, ext, None, 'IMPORT_ROUTE')
 
@@ -790,9 +797,7 @@ async def import_route(
                 
                 lat, lon = coord[0], coord[1]
 
-                web_mercator_coords = service.convert_wgs84_to_web_mercator(lon, lat)
-
-                converted_coords.append([web_mercator_coords[0], web_mercator_coords[1]])
+                converted_coords.append([lon, lat])
 
             log_action('Importing Route', True, ext, None, 'IMPORT_ROUTE')
 
@@ -808,7 +813,14 @@ async def import_route(
             await route_file.seek(0)
 
             doc = KML.parse(route_file.file, strict=False)
-            coords = extract_kml_coords(doc)
+            kml_coords = extract_kml_coords(doc)
+
+            # extract_kml_coords returns [lat, lon, ele] (KML native)
+            # this normalises to the app's [lon, lat, ele] format.
+            coords = [
+                [c[1], c[0], c[2]] if len(c) >= 3 else [c[1], c[0]]
+                for c in kml_coords
+            ]
             
             # logging is commented out as KML imports are not fully supported --> prevents false positives 
             # log_action('Importing Route', True, ext, None, 'IMPORT_ROUTE')
@@ -886,8 +898,7 @@ async def import_route(
                         lat = coord[1]
                         ele = coord[2] if len(coord) > 2 else 0
 
-                        web_mercator_x, web_mercator_y = service.convert_wgs84_to_web_mercator(lon, lat)
-                        coords.append([web_mercator_x, web_mercator_y, ele])
+                        coords.append([lon, lat, ele])
             
             log_action('Importing Route', True, ext, None, 'IMPORT_ROUTE')
 

--- a/src/Routes/routes_fastapi.py
+++ b/src/Routes/routes_fastapi.py
@@ -818,7 +818,7 @@ async def import_route(
             # extract_kml_coords returns [lat, lon, ele] (KML native)
             # this normalises to the app's [lon, lat, ele] format.
             coords = [
-                [c[1], c[0], c[2]] if len(c) >= 3 else [c[1], c[0]]
+                [c[1], c[0], c[2]] if len(c) >= 3 else [c[1], c[0], 0]
                 for c in kml_coords
             ]
             

--- a/src/Search/search_fastapi.py
+++ b/src/Search/search_fastapi.py
@@ -60,9 +60,7 @@ def search_area(
 
             print(f"Latitude: {latitude}\nLongitude: {longitude}")
 
-            web_mercator_x, web_mercator_y = service.convert_wgs84_to_web_mercator(longitude, latitude)
-
-            coords = [web_mercator_x, web_mercator_y]
+            coords = [float(longitude), float(latitude)]
 
             print(coords)
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,14 +1,19 @@
-# Default map centre (web_mercator coordinates)
-DEFAULT_CENTRE = [-356034, 7258806]
+# Default map centre (EPSG:4326 lat/lon).
+DEFAULT_CENTRE = [-3.198308, 54.465458]
+
+# Default map centre in Web Mercator (EPSG:3857).
+# Only used internally by the routing engine / OpenLayers view.
+DEFAULT_CENTRE_MERCATOR = [-356034, 7258806]
 
 # Open Layers zoom level
 DEFAULT_ZOOM = 10.5
 
 # Hardcoded Web Mercator (EPSG:3857) bounds for Cumbria
-MIN_X = -411900
-MAX_X = -241500
-MIN_Y = 7187000
-MAX_Y = 7390000
+# used for the graph / routing bounds 
+MIN_X = -425000  
+MAX_X = -233000 
+MIN_Y = 7170000  
+MAX_Y = 7395000  
 
 # Auth related constants 
 SPECIAL_CHARACTERS = ["@", "#", "$", "%", "^", "&", "*", "(", ")", "_", "+", "-", "=", "[", "]", "{", "}", "|", ";", ":", ",", ".", "<", ">", "?", "/"]

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,4 +1,4 @@
-# Default map centre (EPSG:4326 lat/lon).
+# Default map centre (EPSG:4326 lon/lat).
 DEFAULT_CENTRE = [-3.198308, 54.465458]
 
 # Default map centre in Web Mercator (EPSG:3857).

--- a/static/js/elevationChart.js
+++ b/static/js/elevationChart.js
@@ -1,9 +1,18 @@
-import { getDistance } from 'https://cdn.jsdelivr.net/npm/ol@v10.3.1/sphere.js';
-import { toLonLat } from 'https://cdn.jsdelivr.net/npm/ol@v10.3.1/proj.js';
 import { normaliseCoordLength, getCurrentPathData } from './routes/routeState.js';
 import { getRouteLayer } from './map.js';
 import { getTheme, getDistanceUnit } from './settingsState.js';
 import { createManualPointStyle } from './utils/style-utils.js';
+
+/**
+ * Returns true if the coord is in EPSG:4326 projection and false otherwise
+ * 
+ * @param {Array} coord The coordinate array in format [X, Y] or [Lon, Lat]
+ * @returns {bool} True if the coordinate is in EPSG:4326 projection and false otherwise 
+ */
+function isLonLatCoord(coord) {
+  return Array.isArray(coord) && coord.length >= 2 &&
+    Math.abs(coord[0]) <= 180 && Math.abs(coord[1]) <= 90;
+}
 
 let elevationChart = null;
 let currentCoordinates = null;
@@ -34,7 +43,11 @@ function updateMapHoverPoint(coordinate) {
   if (!routeLayer) return;
   const source = routeLayer.getSource();
 
-  const coord = [coordinate[0], coordinate[1]];
+  // converts coordinates into web mercator to display the point feature on the map (which has projection of Web Mercator)
+  let coord = [coordinate[0], coordinate[1]];
+  if (isLonLatCoord(coord)) {
+    coord = ol.proj.fromLonLat(coord);
+  }
 
   if (!hoverPointFeature) {
     hoverPointFeature = new ol.Feature({
@@ -113,10 +126,15 @@ export function createElevationProfile(coordinates) {
 
     currentCoordinates = coordinates;
 
-    // this transforms all coordinates from EPSG:3857 (Web Mercator) to standard Lat/Lon (wgs84)
+    // converts manually plotted coordinates to lon lat (auto routing uses lat lon already) 
     const geoCoordinates = coordinates.map(coord => {
-        const lonLat = toLonLat([coord[0], coord[1]]);
-        return [lonLat[0], lonLat[1], coord[2] || 0]; // Keep elevation at index 2
+        let lonLat;
+        if (isLonLatCoord(coord)) {
+          lonLat = [coord[0], coord[1]];
+        } else {
+          lonLat = ol.proj.toLonLat([coord[0], coord[1]]);
+        }
+        return [lonLat[0], lonLat[1], coord[2] || 0];
     });
 
     const chartData = []; // {x: distance, y: elevation}
@@ -132,7 +150,7 @@ export function createElevationProfile(coordinates) {
         const p2 = geoCoordinates[i];
 
          
-        const segmentMeters = getDistance([p1[0], p1[1]], [p2[0], p2[1]]);
+        const segmentMeters = ol.sphere.getDistance([p1[0], p1[1]], [p2[0], p2[1]]);
         const segmentKm = segmentMeters / 1000;
 
         if (distanceUnit === "miles") {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -42,9 +42,10 @@ export function initMap() {
 }
 
 function createMap() {
-  const initialCenter = Array.isArray(window.appConfig?.mapInitialCenter)
-    ? window.appConfig.mapInitialCenter
-    : [-211507, 7118524];
+  const initialCentreLatLon = Array.isArray(window.appConfig?.mapInitialCentre)
+    ? window.appConfig.mapInitialCentre
+    : [-3.198308, 54.465458];
+  const initialCentre = ol.proj.fromLonLat(initialCentreLatLon);
   const initialZoom = window.appConfig?.mapInitialZoom ?? 10.5;
 
   map = new ol.Map({
@@ -59,7 +60,7 @@ function createMap() {
       projection: "EPSG:3857",
       maxZoom: 17,
       minZoom: 0,
-      center: initialCenter,
+      center: initialCentre,
       zoom: initialZoom,
     }),
   });

--- a/static/js/routes/loadRoute.js
+++ b/static/js/routes/loadRoute.js
@@ -45,7 +45,7 @@ export function displayLoadedRouteOnMap(data) {
 
   const format = new ol.format.GeoJSON();
   const features = format.readFeatures(data.pathGeoJSON, {
-    dataProjection: "EPSG:3857",
+    dataProjection: "EPSG:4326",
     featureProjection: "EPSG:3857",
   });
 
@@ -63,14 +63,17 @@ export function displayLoadedRouteOnMap(data) {
   const startCoord = coordinates[0];
   const endCoord = coordinates[coordinates.length - 1]
 
+  // converts lon lat to Web Mercator to display features on OpenLayer map (which has Web Mercator projection) 
+  const startMercator = ol.proj.fromLonLat([startCoord[0], startCoord[1]]);
+  const endMercator = ol.proj.fromLonLat([endCoord[0], endCoord[1]]);
 
   const startFeature = new ol.Feature({
-    geometry: new ol.geom.Point([startCoord[0], startCoord[1]])
+    geometry: new ol.geom.Point(startMercator)
   });
   startFeature.setStyle(createManualPointStyle("Start", "#8145d4"));
 
   const endFeature = new ol.Feature({
-    geometry: new ol.geom.Point([endCoord[0], endCoord[1]])
+    geometry: new ol.geom.Point(endMercator)
   });
   endFeature.setStyle(createManualPointStyle("End", "#8145d4"));
 

--- a/static/js/routes/saveRoute.js
+++ b/static/js/routes/saveRoute.js
@@ -80,6 +80,14 @@ function handleSaveRoute(e) {
       pathCoordinates = getCurrentPathData() || getLoadedRouteCoordinates() || []; // coords in these arrays may now have elevation data
     }
 
+    // manually plotted points converted to lon lat as they are stored in web mercator (auto / loaded routes aren't)
+    if (mode === "manual" && manualRouteState.pathCoords.length > 0) {
+      pathCoordinates = pathCoordinates.map(coord => {
+        const lonLat = ol.proj.toLonLat([coord[0], coord[1]]);
+        return coord.length >= 3 ? [lonLat[0], lonLat[1], coord[2]] : lonLat;
+      });
+    }
+
     pathCoordinates = normaliseCoordLength(pathCoordinates);
 
     if (pathCoordinates.length === 0) {

--- a/static/js/routing/index.js
+++ b/static/js/routing/index.js
@@ -1,0 +1,4 @@
+export {
+    calculatePath,
+    addManualPoint
+} from './routing.js'

--- a/static/js/routing/routing.js
+++ b/static/js/routing/routing.js
@@ -84,6 +84,7 @@ export async function getPathSegment(start, end) {
   });
 
   if (!response.ok) {
+    logError("Calculating Path", response, null, "NO_PATH_FOUND")
     throw new Error("Sorry, there was an unexpected error whilst calculating the path.");
   }
 
@@ -92,6 +93,7 @@ export async function getPathSegment(start, end) {
   if (data.success) {
     return data;
   }
+  // no logging needed as the backend already logs errors if data.success if False 
   throw new Error("Sorry, there was an unexpected error whilst calculating the path.");
 }
 

--- a/static/js/routing/routing.js
+++ b/static/js/routing/routing.js
@@ -11,10 +11,29 @@ import {
   showError
 } from "../utils/ui-utils.js"
 
+import {
+  updateManualRoute
+} from '../ui.js'
+import { logError } from "../utils/logError-utils.js";
+
+/**
+ * Function used to calculate and return a path (and associated information) between two given points in projection EPSG: 4326 (Lon, Lat)
+ * Specific to automatic routing
+ * 
+ * @param {String} startPoint Coordinate in the form "Lat, Lon"
+ * @param {String} endPoint Coordinate in the form "Lat, Lon"
+ * @returns 
+ */
 export async function calculatePath(startPoint, endPoint) {
   const url = window.appConfig.apiCalculatePathUrl;
-  const startArray = startPoint.split(",").map((num) => Number(num.trim()));
-  const endArray = endPoint.split(",").map((num) => Number(num.trim()));
+
+  // forms an array of the first and end coordinate in the format [Lat, Lon]
+  const rawStart = startPoint.split(",").map((num) => Number(num.trim()));
+  const rawEnd = endPoint.split(",").map((num) => Number(num.trim()));
+
+  // API expects [Lon, Lat] but coordinate is in [Lat, Lon]
+  const startArray = [rawStart[1], rawStart[0]];
+  const endArray = [rawEnd[1], rawEnd[0]];
 
   try {
 
@@ -40,12 +59,18 @@ export async function calculatePath(startPoint, endPoint) {
     throw new Error(data.message || "Sorry, there was an unexpected error when calculating your route, please try again later.");
   }
   catch(error) {
-    throw error
+    logError("Calculating Path", error.message, null, "NO_PATH_FOUND");
+    throw error;
   };
 };
 
-window.calculatePath = calculatePath; // To test the calculation of paths i.e how long it takes
-
+/**
+ * Calculates and returns information associated with a path between two given points (specific to manual routing)
+ * 
+ * @param {Number} start Coordinate in the format [Lon, Lat]
+ * @param {Number} end Coordinate in the format [Lon, Lat]
+ * @returns {Object} Information of and information associated with the path that is calculated
+ */
 export async function getPathSegment(start, end) {
   const url = window.appConfig.apiCalculatePathUrl;
 
@@ -59,7 +84,7 @@ export async function getPathSegment(start, end) {
   });
 
   if (!response.ok) {
-    throw new Error(`HTTP error: ${response.status}`);
+    throw new Error("Sorry, there was an unexpected error whilst calculating the path.");
   }
 
   const data = await response.json();
@@ -67,9 +92,16 @@ export async function getPathSegment(start, end) {
   if (data.success) {
     return data;
   }
-  throw new Error(data.message || "Error whilst calculating manual path segment");
+  throw new Error("Sorry, there was an unexpected error whilst calculating the path.");
 }
 
+/**
+ * Adds the entered point into the appropriate data structures and updates the UI
+ * 
+ * @param {Number} x X coordinate of clicked-on point in Web Mercator (as this is retrieved directly from a click on the map, and map's projection is Web Mercator)
+ * @param {Number} y Y coordinate of clicked-on point in Web Mercator
+ * @returns {Object} Object formed of success and message keys (message only if failed)
+ */
 export async function addManualPoint(x, y) {
   const { userClicks, pathCoords, segmentCache } = manualRouteState;
   const currentClick = [x, y];
@@ -84,10 +116,10 @@ export async function addManualPoint(x, y) {
   // this restores the redo stack
   manualRouteState.redoStack = [];
 
+  // returns prematurely after adding coord to the relevant arrays and updating manual route state if coord is the first one
   if (userClicks.length === 0) {
     userClicks.push(currentClick);
     pathCoords.push(currentClick);
-    const { updateManualRoute } = await import("../ui.js");
     updateManualRoute();
     return {"success": true};
   }
@@ -100,11 +132,12 @@ export async function addManualPoint(x, y) {
   if (userClicks.length >= 3) {
     const thresholdDistance = 50;
 
+    // lon lat used to calculate distance (Web Mercator projection has distortion risk over long distances)
     const startLonLat = ol.proj.toLonLat(start);
     const endLonLat = ol.proj.toLonLat(end);
-
     const distance = ol.sphere.getDistance(startLonLat, endLonLat);
 
+    // if points are close enough snap the final point to the first point
     if (distance < thresholdDistance) {
       finalClick = start;
     }
@@ -123,17 +156,31 @@ export async function addManualPoint(x, y) {
 
   try {
 
-    if (segmentCache[key]) { // this checks if the segment already exists in cache 
-      segment = segmentCache[key];
+    if (segmentCache[key]) { // this checks if the segment already exists in cache
+      segment = segmentCache[key]; // if yes, it just retrieves it
     }
+    // otherwise, it calculates it and adds it to the cache 
     else {
-      const data = await getPathSegment(lastClickedPoint, finalClick);
+      // conversion to lon lat as the API expects coordinates in the form [Lon, Lat]
+      const lastLonLat = ol.proj.toLonLat(lastClickedPoint);
+      const finalLonLat = ol.proj.toLonLat(finalClick);
+      const data = await getPathSegment(lastLonLat, finalLonLat);
 
       if (!data.success) {
-        return {"success": false, "message": "Sorry, we not find a path to that location"};;
-      }
+        return {
+          "success": false,
+          "message": "Sorry, we could not find a path to that location."
+        };
+      };
 
       segment = data.coordinates;
+
+      // conversion to Web Mercator as the API sends coords in the form: [Lon, Lat], whereas OpenLayers map is in Web Mercator projection
+      segment = segment.map(coord =>
+        coord.length >= 3
+          ? [...ol.proj.fromLonLat([coord[0], coord[1]]), coord[2]]
+          : ol.proj.fromLonLat([coord[0], coord[1]])
+      );
 
       // this stores the segment in cache 
       segmentCache[key] = segment;
@@ -144,7 +191,8 @@ export async function addManualPoint(x, y) {
     }
   }
   catch (error) {
-    throw error
+    logError("Calculating Path", error.message, null, "NO_PATH_FOUND");
+    throw error;
   }
 
   // this appends the segment to pathCoords (skips first point to prevent duplication)
@@ -153,8 +201,6 @@ export async function addManualPoint(x, y) {
   userClicks.push(finalClick);
   manualRouteState.isSnapped = true;
 
-  // this updates the UI
-  const { updateManualRoute } = await import("../ui.js");
   updateManualRoute();
 
   return {"success": true};

--- a/static/js/saved_points/savedPoints.js
+++ b/static/js/saved_points/savedPoints.js
@@ -21,8 +21,11 @@ function clearOldSavedPointsLayer() {
 
 function convertPointsToFeatures(data) {
     return data.points.map(point => {
+
+        // converts to Web Mercator (API sends coords in [Lon, Lat] format)
+        const mercatorCoords = ol.proj.fromLonLat(point.coordinates);
         return new ol.Feature({
-            geometry: new ol.geom.Point(point.coordinates),
+            geometry: new ol.geom.Point(mercatorCoords),
             name: point.name
         });
     });
@@ -90,8 +93,12 @@ export async function saveNewPoint(coordinate, name) {
   }
 
   const url = window.appConfig.apiSavePointUrl;
-  const x = coordinate[0];
-  const y = coordinate[1];
+
+  // converts coordinates to lon lat if they aren't already in that projection
+  const lonLat =
+    Math.abs(coordinate[0]) <= 180 && Math.abs(coordinate[1]) <= 90
+      ? [coordinate[0], coordinate[1]]
+      : ol.proj.toLonLat([coordinate[0], coordinate[1]]);
 
   try {
 
@@ -102,8 +109,8 @@ export async function saveNewPoint(coordinate, name) {
         },
         body: JSON.stringify({
           point_name: name,
-          web_mercator_x: x,
-          web_mercator_y: y,
+          lon: lonLat[0],
+          lat: lonLat[1],
         }),
       })
       

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1,10 +1,9 @@
 //#region IMPORTS
 
 import {
-  roundCoords,
   calculateEta,
   calculateTotalDistance,
-  isLonLat
+  formatLatLon
 } from "./utils/routing-utils.js";
 
 import {
@@ -27,7 +26,7 @@ import {
   parseCoordString
 } from "./utils/ui-utils.js";
 
-import { calculatePath, addManualPoint } from "./routing/routing.js";
+import { calculatePath, addManualPoint } from "./routing/index.js";
 
 import {
   getMap,
@@ -114,9 +113,9 @@ import { logError } from "./utils/logError-utils.js";
 
 //#region VAR / CONST DECLARATIONS
 
-export const defaultCentre = Array.isArray(window.appConfig?.mapInitialCenter)
-  ? window.appConfig.mapInitialCenter
-  : [-211507, 7118524];
+export const defaultCentre = Array.isArray(window.appConfig?.mapInitialCentre)
+  ? window.appConfig.mapInitialCentre
+  : [-3.198308, 54.465458];
 
 const autoModeOption = document.getElementById("auto-mode-option");
 const manualModeOption = document.getElementById("manual-mode-option");
@@ -380,43 +379,31 @@ function validateInputCoords(startPoint, endPoint) {
 
   // This ensures there are two coordinates
   if (startParts.length < 2 || endParts.length < 2) {
-    showError("Invalid coordinate format. Please Use X, Y");
+    showError("Invalid coordinate format. Please Use Lat, Lon");
     return false;
   }
 
-  // This parses the full string into numbers 
-  const startX = parseFloat(startParts[0].trim());
-  const startY = parseFloat(startParts[1].trim());
-  const endX = parseFloat(endParts[0].trim());
-  const endY = parseFloat(endParts[1].trim());
+  // this parses the full string into numbers
+  const startLat = parseFloat(startParts[0].trim());
+  const startLon = parseFloat(startParts[1].trim());
+  const endLat = parseFloat(endParts[0].trim());
+  const endLon = parseFloat(endParts[1].trim());
 
-  let startLonLat
-  let endLonLat
-
-  // conditional logic to ensure that if values are already in lon lat they are not incorrectly passed into ol.proj.toLonLat()
-  if (isLonLat([startX, startY]) && isLonLat([endX, endY])) {
-    startLonLat = [startX, startY];
-    endLonLat = [endX, endY];
-    
-    console.log('LonLat detected ')
-    console.log(startLonLat)
-  }
-  else {
-    startLonLat = ol.proj.toLonLat([startX, startY]);
-    endLonLat = ol.proj.toLonLat([endX, endY]);
-  }
+  // this re-orders coordinates to [lon, lat] for the Cumbria ray-casting check (array of Cumbria boundary has coords in [lon, lat] format)
+  const startLonLat = [startLon, startLat];
+  const endLonLat = [endLon, endLat];
 
   if ( !isPointInPolygon(startLonLat)) {
-    showError("Please enter start coordinates within Cumbria.")
+    showError("Please select a starting location within Cumbria.")
     startCoordEntry.value = '';
-    showCoordInputError(startCoordEntry, "Please enter start coordinates within Cumbria.");
+    showCoordInputError(startCoordEntry, "Please select a starting location within Cumbria.");
     return false
   }
 
   if (!isPointInPolygon(endLonLat)) {
-    showError("Please enter end/destination coordinates within Cumbria.");
+    showError("Please select a destination within Cumbria.");
     endCoordEntry.value = ''
-    showCoordInputError(endCoordEntry, "Please enter end/destination coordinates within Cumbria.");
+    showCoordInputError(endCoordEntry, "Please select a destination within Cumbria.");
     return false;
   }
 
@@ -457,9 +444,10 @@ function setEndCoord() {
 }
 
 function setCoordEntry(entry, event) {
-  const coordinate = event.coordinate;
-  const rounded = roundCoords(coordinate, 0);
-  entry.value = `${rounded[0]}, ${rounded[1]}`;
+  // event.coordinate is in Web Mercator
+  // this means conversion to lat/lon is required for display
+  const lonLat = ol.proj.toLonLat(event.coordinate);
+  entry.value = formatLatLon(lonLat, 6);
   entry.placeholder = "Coordinates";
   entry.classList.remove("input-error");
   setCoordInputActiveState(startCoordEntry, false);
@@ -533,13 +521,16 @@ export function mapClickHandler(event) {
     selectedPoint.setStyle(getSelectedPointStyle(pointName));
     deletePointModalNameDisplay.textContent = pointName;
     showDeletePointModal(true);
-  } else if (!featureClicked) {
+  } 
+  else if (!featureClicked) {
     const coordinate = event.coordinate;
-    const [lon, lat] = ol.proj.toLonLat(coordinate);
-    const roundedLatLon = roundCoords([lat, lon], 6);
+    const lonLat = ol.proj.toLonLat(coordinate);
+
+    // TO BE CHANGED TO CUSTOM MODAL 
     const pointName = prompt(
-      `Do you want to save this coordinate: ${roundedLatLon[0]}, ${roundedLatLon[1]}? \nEnter a name to save it:`,
+      `Do you want to save this coordinate: ${formatLatLon(lonLat, 6)}? \nEnter a name to save it:`,
     );
+
     if (pointName) saveNewPoint(coordinate, pointName);
   }
 }
@@ -1033,19 +1024,22 @@ function searchArea() {
       if (!data.success) return;
 
       const view = map.getView();
+
+      // this converts the received coordinates into web mercator (as search API sends coords in [lon, lat] format)
+      const searchCenter = ol.proj.fromLonLat(data.coordinates);
       if (view.getZoom() >= 7) {
         view.animate(
           { center: view.getCenter(), duration: 1000, zoom: 10 },
           () =>
             view.animate({
-              center: data.coordinates,
+              center: searchCenter,
               duration: 1000,
               zoom: 14,
             }),
         );
       } else {
         view.animate({
-          center: data.coordinates,
+          center: searchCenter,
           duration: 1000,
           zoom: 14,
         });
@@ -1116,7 +1110,7 @@ function displayPath(data) {
   setHoverPointFeature(null);
 
   const pathFeature = new ol.format.GeoJSON().readFeature(data.pathGeoJSON, {
-    dataProjection: "EPSG:3857",
+    dataProjection: "EPSG:4326",
     featureProjection: "EPSG:3857",
   });
 
@@ -1129,16 +1123,20 @@ function displayPath(data) {
     const startCoord = coordinates[0];
     const endCoord = coordinates[coordinates.length - 1];
 
+    // this converts coordinates into Web Mercator format, as the backend sends the path back in [Lon, Lat] format (Web Mercator is the OpenLayers map projection)
+    const startMercatorCoord = ol.proj.fromLonLat([startCoord[0], startCoord[1]]);
+    const endMercatorCoord = ol.proj.fromLonLat([endCoord[0], endCoord[1]]);
+
     // this creates and then displays (by adding them to the interactivePointLayerSource) the start and end point features
-    const startPointFeature = createPoint([startCoord[0], startCoord[1]], getSavedPointStyle("Start", "#074df0"), "start", "Start")
-    const endPointFeature = createPoint([endCoord[0], endCoord[1]], getSavedPointStyle("End", "#074df0"), "end", "End")
+    const startPointFeature = createPoint(startMercatorCoord, getSavedPointStyle("Start", "#074df0"), "start", "Start")
+    const endPointFeature = createPoint(endMercatorCoord, getSavedPointStyle("End", "#074df0"), "end", "End")
 
     interactivePointLayerSource.addFeature(startPointFeature)
     interactivePointLayerSource.addFeature(endPointFeature)
 
   }
 
-  setCurrentPathData(data.coordinates); // data.coordinates may be either 2 elements (x and y) or 3 elements (x, y and elevation)
+  setCurrentPathData(data.coordinates); // data.coordinates are [lon, lat, elev] (EPSG:4326)
 
 
   setTimeout(() => {
@@ -1399,7 +1397,7 @@ export function updateSaveRouteContainer() {
 //#region DRIVER.JS
 
 async function handleSaveRouteTour() {
-  await handleAutoRouteGeneration('-363769, 7256750', '-357507, 7256649');
+  await handleAutoRouteGeneration('54.454722, -3.267793', '54.454195, -3.211540');
 
   setTimeout(() => {
     savingRoutesTourDriver = createSavingRoutesTour(homeButtonFunction);
@@ -1429,17 +1427,17 @@ export function handleInitialTour() {
 //#region POINT INTERACTION
 
 /**
- * Ensures the coordinate is in EPSG:3857 (Web Mercator)
+ * Converts a human-entered [latitude, longitude] pair into Web Mercator (EPSG: 3857)
+ * coordinates for OpenLayers.
+ *
+ * @param {[number, number]} latLon - An array containing latitude and longitude as [lat, lon].
+ * @returns {ol.coordinate.Coordinate | null} The converted Web Mercator coordinate [x, y], or null if invalid.
  */
-function toWebMercator(coords) {
-  if (!coords) return null;
+function toWebMercator(latLon) {
+  if (!latLon || latLon.length < 2) return null;
 
-  if (isLonLat(coords)) {
-    // reversed coords as OpenLayers expects [longitude, latitude]
-    return ol.proj.fromLonLat([coords[1], coords[0]]);
-  }
-
-  return coords;
+  // OpenLayers expects [longitude, latitude]
+  return ol.proj.fromLonLat([latLon[1], latLon[0]]);
 }
 
 /**
@@ -1461,10 +1459,13 @@ function handleCoordEntryChange(entry, type) {
     "#074df0"
   );
 
+  // returning prematurely if the point is not in Cumbria 
   if (!isPointInPolygon(ol.proj.toLonLat(mercatorCoords))) {
+    showError("Please choose a point within Cumbria.")
     return;
   }
 
+  // this creates the point feature 
   const pointFeature = createPoint(
     mercatorCoords,
     style,
@@ -1472,6 +1473,7 @@ function handleCoordEntryChange(entry, type) {
     type === "start" ? "Start" : "End"
   );
 
+  // this adds the point feature and adds the OpenLayers interaction to it
   addStartEndPoint(pointFeature, interactivePointLayer, type);
   setUpPointInteraction([interactivePointLayer]);
 
@@ -1485,7 +1487,7 @@ function handleCoordEntryChange(entry, type) {
     handleAutoRouteGeneration(startVal, endVal);
   }
   else {
-    moveMapToPosition(map, mercatorCoords, 1200, 12);
+    moveMapToPosition(map, [parsed[1], parsed[0]], 1200, 12); // reversed order as moveMap expects coords in [Lon, Lat format], whereas parsed is in [Lat, Lon] format
   }
 }
 
@@ -1561,14 +1563,14 @@ export function setUpPointInteraction(layers) {
 
     const newCoordinates = movedFeature.getGeometry().getCoordinates();
     const pointType = movedFeature.get("type");
-    const rounded = roundCoords(newCoordinates, 0);
-    const coordString = `${rounded[0]}, ${rounded[1]}`;
+    const newLonLatCoordinate = ol.proj.toLonLat(newCoordinates);
+    const coordinateString = formatLatLon(newLonLatCoordinate, 6);
 
     // this updates the correct input
     if (pointType === "start") {
-      startCoordEntry.value = coordString;
+      startCoordEntry.value = coordinateString;
     } else if (pointType === "end") {
-      endCoordEntry.value = coordString;
+      endCoordEntry.value = coordinateString;
     }
 
     const startVal = startCoordEntry?.value?.trim();
@@ -1706,7 +1708,7 @@ function handleKeyboardShortcuts(e) {
 function initInteractivePointLayer(map) {
   interactivePointLayer = new ol.layer.Vector({
     source: new ol.source.Vector(),
-    zIndex: 1000 // above the route layer 
+    zIndex: 1100 // above the route layer + saved points layer 
   });
 
   map.addLayer(interactivePointLayer);

--- a/static/js/utils/routing-utils.js
+++ b/static/js/utils/routing-utils.js
@@ -1,9 +1,11 @@
 /**
  * This file all route-associated helper functions 
- * As of July 2026 it has the following functions:
+ * As of August 2026 it has the following functions:
  * 
  *      - roundCoords(coordArray, decimals)
  *      - isLonLat(coordinate)
+ *      - isMercatorCoord(coordinate)
+ *      - formatLatLon(lonLat)
  *      - calculateTotalDistance(points)
  *      - CalculateEta(distanceKm)
  */
@@ -35,7 +37,7 @@ export function roundCoords (coordArray, decimals) {
 /**
  * Validates whether the input is a valid WGS84 (lat / lon) coordinate 
  * 
- * @param {LatLonObject | [number, number] | null | undefined} coord - The coordinate data to validate NOTE it is in lon lat format 
+ * @param {LatLonObject | [number, number] | null | undefined} coord The coordinate data to validate NOTE it is in lon lat format 
  * @returns {boolean} True if the input represents a valid latitude and longitude, false otherwise.
  * 
  * @example
@@ -81,6 +83,32 @@ export function isLonLat(coordinate) {
 
   // this returns true if lat is between -90 and 90 and if lon is between -180 and 180, and returns false otherwise
   return lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180;
+}
+
+/**
+ * Detects whether a coordinate is in Web Mercator (EPSG:3857) based on magnitude
+ * Lat/lon values are always within [-180, 180] / [-90, 90]
+ * 
+ * @param {Array<number>} coordinate A coordinate as [x, y]
+ * @returns {boolean} True if the coordinate is Web Mercator
+ */
+export function isMercatorCoord(coordinate) {
+  if (!Array.isArray(coordinate) || coordinate.length < 2) return false;
+  return Math.abs(coordinate[0]) > 181 || Math.abs(coordinate[1]) > 181;
+}
+
+/**
+ * Formats a [lon, lat] coordinate into a user-friendly "lat, lon" string
+ * 
+ * @param {Array<number>} lonLat Coordinate as [longitude, latitude]
+ * @param {number} decimals Number of decimal places (default 6)
+ * @returns {string} Formatted "lat, lon" string
+ */
+export function formatLatLon(lonLat, decimals = 6) {
+  if (!Array.isArray(lonLat) || lonLat.length < 2) return "";
+  const [lon, lat] = lonLat;
+  const round = (value) => Number(value).toFixed(decimals);
+  return `${round(lat)}, ${round(lon)}`;
 }
 
 /**

--- a/static/js/utils/ui-utils.js
+++ b/static/js/utils/ui-utils.js
@@ -42,8 +42,11 @@ export function parseCoordString(value) {
 /**
  * Function to move the map to a specific coordinate or the centre of the map via an animation
  * 
- * @param {} map OL map instance 
- * @param {Array} position The specific coordinate to move the map to, if not entered it defaults to the map centre  
+ * Position is expected in EPSG:4326 ( [Lon, Lat] )
+ * It is converted to Web Mercator before animating the map movement (OpenLayers map is in a Web Mercator projection)
+ * 
+ * @param {ol.Map} map OL map instance 
+ * @param {Array} position The specific coordinate to move the map to in [Lon, Lat] format, if not entered it defaults to the map centre  
  * @param {number} duration How long the animation to move the map takes
  * @param {number} zoom Zoom level used by open layers 
  * @returns {void}
@@ -54,9 +57,12 @@ export function moveMapToPosition(map, position = null, duration = 1200, zoom = 
     return;
   }
 
-  const targetPosition = Array.isArray(position) && position.length === 2
+  const targetLatLon = Array.isArray(position) && position.length === 2
     ? position
-    : (Array.isArray(window.appConfig?.mapInitialCenter) ? window.appConfig.mapInitialCenter : [-211507, 7118524]);
+    : (Array.isArray(window.appConfig?.mapInitialCentre) ? window.appConfig.mapInitialCentre : [-3.198308, 54.465458]);
+
+  // this converts [Lon, Lat] coordinates into Web Mercator coordinates that the OpenLayers map can use 
+  const targetPosition = ol.proj.fromLonLat(targetLatLon);
 
   map.getView().animate({
     center: targetPosition,
@@ -66,7 +72,7 @@ export function moveMapToPosition(map, position = null, duration = 1200, zoom = 
 };
 
 /**
- * Function used to show an error popup containing the passed in string 
+ * Shows an error popup containing the passed in string 
  * 
  * @param {string} message The error message to be shown 
  * @param {*} colour The colour of the error popup, defaults to red 

--- a/templates/map.html
+++ b/templates/map.html
@@ -541,7 +541,7 @@
     <script>
         window.appConfig = {
             loggedIn: {{ logged_in }},
-            mapInitialCenter: {{ map_centre | tojson }},
+            mapInitialCentre: {{ map_centre | tojson }},
             mapInitialZoom: {{ map_zoom | default(10) }},
             initialCurrentPath: {% if current_path %}{{ current_path | tojson }}{% else %}null{% endif %},
             initialSavedPointsLookup: {


### PR DESCRIPTION
# Pull Request Template

## Summary

This PR aims to amend a long-standing issue with the application in that users would have to set start and end coordinates in Web Mercator projection (EPSG:3857). This is inaccurate compared to how mapping usually works and is not the industry standard. To solve this, this PR standardises projections such that:

* All user displayed coordinates are in the format \[Lat, Lon\]
* All coordinates sent between the frontend and the backend is in the format \[Lon, Lat\]
* All coordinates associated with OpenLayers, including the Map as well as Point and Route features is in the format \[X, Y\] (Web Mercator Projection)

## Related Issue

Fixes abdlfc11/Crestr-Hiking-App#80  <br>Closes abdlfc11/Crestr-Hiking-App#80

## Type of Change

Select all that apply:

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [X] Refactor
- [ ] Other (explain below)

## Description of Changes

* Added conversion utility functions (`toLonLat` / `fromLonLat`, wrapping OpenLayers' `ol/proj` helpers) to centralise all projection transforms rather than converting at each call site
* Updated all frontend input fields and coordinate displays to accept and show `[Lat, Lon]`, converting to `[Lon, Lat]` only at the point of sending data to the backend
* Updated API request/response schemas to expect and return `[Lon, Lat]` consistently, replacing the previous implicit Web Mercator format
* Updated FastAPI routes to convert  incoming `[Lon, Lat]` coordinates to Web Mercator internally before running igraph pathfinding, and convert results back to `[Lon, Lat]` before returning
* Updated OpenLayers map, Point, and Route feature construction to consistently use `[X, Y]` Web Mercator internally, converting only at the UI/API boundary
* Added coordinate validation on input to detect values that are clearly Web Mercator (large magnitude, outside ±90/±180 range) and return a clear error prompting the user to enter `Lat, Lon` instead
* Added a backward-compatibility path for loading previously saved routes or points stored in Web Mercator, so existing user data doesn't break
* Fixed related call sites where start/end point conversion was previously being applied inconsistently

## Screenshots / Visuals (if applicable)

N/A

## Testing

* Loaded pre-existing routes which consisted of Web Mercator coordinates to ensure that loading routes that were saved prior to this PR was still successful
* Saved and loaded new routes to ensure that the new Lon, Lat coordinate format in the backend and frontend worked as expected
* Calculated paths via points (i.e. start and end point markers) as well as the coordinate entries themselves to ensure that path creation was valid no matter the way it occurred
* Entered Web Mercator coordinates to ensure that an error was produced showing users that they needed to enter coordinates in the form: Lat, Lon

## Checklist

- [X] My code follows the project's style guidelines
- [X] I have tested my changes
- [X] I have updated documentation if needed
- [X] I have referenced the related issue
- [X] This PR is scoped, focused, and ready for review

> **Note:**  <br>PRs for issues not tagged as contributor‑friendly may be closed without review.