### PR TITLE
PR feat: Add dedicated privacy policy page

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,4 @@
-app.crestr.co.uk {
+http://localhost {
     reverse_proxy web-fastapi:5000
 }
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,4 @@
-http://localhost {
+app.crestr.co.uk {
     reverse_proxy web-fastapi:5000
 }
 

--- a/src/fastapi_app.py
+++ b/src/fastapi_app.py
@@ -137,7 +137,15 @@ def login_page(request: Request):
 def register_page(request: Request):
     return templates.TemplateResponse(
         request=request,
-    name='register.html',
+        name='register.html',
+        context={'request': request}
+    )
+
+@app.get('/privacy-policy', response_class=HTMLResponse)
+def privacy_policy(request: Request):
+    return templates.TemplateResponse(
+        request=request,
+        name='privacy-policy.html',
         context={'request': request}
     )
 

--- a/src/fastapi_app.py
+++ b/src/fastapi_app.py
@@ -125,14 +125,6 @@ if os.getenv("LOAD_GRAPH_ON_IMPORT", "1").lower() not in ("0", "false", "no"):
 def root_url():
     return RedirectResponse(url="/map")
 
-@app.get("/report-an-issue", response_class=HTMLResponse)
-def report_issue(request: Request):
-    return templates.TemplateResponse(
-        request=request,
-        name="report-issue.html",
-        context={"request": request},
-    )
-
 @app.get("/login-page", response_class=HTMLResponse)
 def login_page(request: Request):
     return templates.TemplateResponse(

--- a/static/css/pages/privacy-policy.css
+++ b/static/css/pages/privacy-policy.css
@@ -1,0 +1,223 @@
+/* Self-contained styles for the Crestr privacy policy page. */
+
+/* Mini reset */
+*,
+*::before,
+*::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI",
+    Roboto, Helvetica, Arial, sans-serif;
+  line-height: 1.6;
+  color: var(--pp-ink);
+  background-color: var(--pp-bg);
+  min-height: 100vh;
+  gap: .5rem;
+}
+
+a {
+  transition: all 0.15s ease-in-out;
+  display: inline-block;
+}
+
+/* Theme tokens */
+
+/* Light */
+:root,
+:root[data-theme="light"] {
+  --pp-bg: #f5f5f4; 
+  --pp-surface: #ffffff;
+  --pp-ink: #1f2937;
+  --pp-muted: #64748b;
+  --pp-border: #e2e8f0;
+  --pp-accent: #2563eb;
+  --pp-accent-hover: #1d4ed8;
+  --pp-shadow: 0 10px 35px rgba(15, 23, 42, 0.06);
+  --pp-surface-glass: rgba(255, 255, 255, 0.7);
+}
+
+/* Dark */
+:root[data-theme="dark"] {
+  --pp-bg: #212224; 
+  --pp-surface: #1e2024;
+  --pp-ink: #f8fafc;
+  --pp-muted: #94a3b8;
+  --pp-border: #374151;
+  --pp-accent: #3b82f6;
+  --pp-accent-hover: #60a5fa;
+  --pp-shadow: 0 10px 35px rgba(0, 0, 0, 0.3);
+  --pp-surface-glass: rgba(30, 32, 36, 0.75);
+}
+
+/* Navbar */
+.pp-navbar {
+
+  /* ensures the nav stays at the top of the page */  
+  position: sticky;
+  top: 0;
+  z-index: 999;  
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 2rem;
+  border-bottom: 1px solid var(--pp-border);
+  box-shadow: var(--pp-shadow);
+
+  /* glassmorphism (blurry) */
+  background-color: var(--pp-surface-glass);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+}
+
+.pp-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.pp-brand img {
+  width: 32px;
+  height: 32px;
+}
+
+.pp-brand-name {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--pp-ink);
+  letter-spacing: -0.02em;
+}
+
+/* Back link */
+.pp-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--pp-muted);
+  padding: 0.4rem 0.75rem;
+  border-radius: 8px;
+  transition: all 0.15s ease-in-out;
+}
+
+.pp-back-link:hover {
+  color: var(--pp-accent);
+  background-color: rgba(37, 99, 235, 0.06);
+}
+
+.pp-back-link svg {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+/* Theme toggle */
+.pp-theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: transparent;
+  border: 1px solid var(--pp-border);
+  border-radius: 9999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--pp-muted);
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.pp-theme-toggle:hover {
+  color: var(--pp-accent);
+  border-color: var(--pp-accent);
+}
+
+.pp-theme-toggle svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* Content */
+.pp-content {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 5rem;
+}
+
+.pp-title {
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--pp-ink);
+  margin-bottom: 0.5rem;
+}
+
+.pp-last-updated {
+  font-size: 0.875rem;
+  color: var(--pp-muted);
+  margin-bottom: 2.5rem;
+}
+
+.pp-link {
+  text-decoration: underline;
+  color: var(--pp-accent);
+}
+
+.pp-section {
+  margin-bottom: 2rem;
+}
+
+.pp-section h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--pp-ink);
+  margin-bottom: 0.6rem;
+}
+
+.pp-section p {
+  color: var(--pp-ink);
+  margin-bottom: 0.75rem;
+}
+
+.pp-section ul {
+  margin: 1.2rem 0 1.75rem 1.5rem;
+  color: var(--pp-ink);
+}
+
+.pp-section li {
+  margin-bottom: 0.35rem;
+}
+
+.disclaimer-notice {
+  /* Vertical left bar */
+  border-left: 4px solid var(--pp-border); 
+  padding-left: 16px;
+
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
+  color: var(--pp-muted);
+  margin: 16px 0;
+}
+
+.disclaimer-notice strong {
+  color: var(--pp-muted);
+  font-weight: 600;
+}
+
+/* ----- Footer ----- */
+.pp-footer {
+  text-align: center;
+  padding: 2rem 1.5rem;
+  font-size: 0.85rem;
+  color: var(--pp-muted);
+  border-top: 1px solid var(--pp-border);
+}

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -83,7 +83,7 @@ export function createTileLayer() {
     source: new ol.source.XYZ({
       url: "https://{a-c}.tile.opentopomap.org/{z}/{x}/{y}.png",
       attributions: `
-      <a href="https://docs.crestr.co.uk/privacy-policy/privacy_policy/" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
+      <a href="/privacy-policy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
       |
       Map data: © <a href="https://www.openstreetmap.org/copyright/">OpenStreetMap</a>,
       SRTM

--- a/static/js/privacy-policy.js
+++ b/static/js/privacy-policy.js
@@ -1,0 +1,130 @@
+/**
+ * Self-contained theme controller for the Crestr privacy policy page.
+ */
+
+(function () {
+  "use strict";
+
+    /** Theme toggle to be used by the user */
+    const toggle = document.getElementById("pp-theme-toggle");
+
+    const label = document.getElementById("pp-theme-label");
+
+    /** localStorage key used exclusively by this page */
+    const STORAGE_KEY = "privacy-policy-theme";
+
+    /** Valid theme values */
+    const VALID_THEMES = ["system", "light", "dark"];
+
+    /**
+     * Reads the stored theme from localStorage.
+     * Falls back to "system" if the key is missing or invalid.
+     *
+     * @returns {string} "system" or "light" or "dark"
+     */
+    function getStoredTheme() {
+        try {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (stored && VALID_THEMES.indexOf(stored) !== -1) {
+            return stored;
+        }
+        } catch (e) {
+        /* this ensures that those in private mode / storage disabled falls through to default value (system) */
+        }
+        return "system";
+    }
+
+    /**
+     * Persists the theme choice to localStorage.
+     *
+     * @param {string} theme "system" | "light" | "dark"
+     */
+    function setStoredTheme(theme) {
+        try {
+        localStorage.setItem(STORAGE_KEY, theme);
+        } catch (e) {
+            // ignores those who have storage disabled 
+        }
+    }
+
+    /**
+     * Returns the effective theme to use (i.e if light or dark, returns, if system, it queries the OS for the current system setting)
+     *
+     * @param {string} preference "system" or "light" or "dark"
+     * @returns {string} "light" or "dark"
+     */
+    function resolveEffective(preference) {
+        if (preference === "system") {
+        return window.matchMedia("(prefers-color-scheme: dark)").matches
+            ? "dark"
+            : "light";
+        }
+        return preference;
+    }
+
+    /**
+     * Applies the effective theme to the document root
+     *
+     * @param {string} preference "system" | "light" | "dark"
+     */
+    function applyTheme(preference) {
+        const effective = resolveEffective(preference);
+        document.documentElement.setAttribute("data-theme", effective);
+    }
+
+    /**
+     * Updates the toggle button label to reflect the current preference.
+     *
+     * @param {string} preference "system" | "light" | "dark"
+     */
+    function updateToggleLabel(preference) {
+        if (!label) return;
+
+        if (preference === "dark") {
+        label.textContent = "Dark";
+        } else if (preference === "light") {
+        label.textContent = "Light";
+        } else {
+        label.textContent = "System";
+        }
+    }
+
+    /**
+     * Cycles through themes e.g system to light to dark to system
+     */
+    function cycleTheme() {
+        let current = getStoredTheme();
+        let next;
+
+        if (current === "system") {
+        next = "light";
+        } else if (current === "light") {
+        next = "dark";
+        } else {
+        next = "system";
+        }
+
+        setStoredTheme(next);
+        applyTheme(next);
+        updateToggleLabel(next);
+    }
+
+    //  Initialisation
+
+    const preference = getStoredTheme();
+    applyTheme(preference);
+    updateToggleLabel(preference);
+
+    if (toggle) {
+        toggle.addEventListener("click", cycleTheme);
+    }
+
+    // This ensures the page responds to a change to the OS's change in theme if the user has set the theme to system 
+    window
+        .matchMedia("(prefers-color-scheme: dark)")
+        .addEventListener("change", function () {
+            if (getStoredTheme() === "system") {
+                applyTheme("system");
+            }
+        });
+})();

--- a/templates/privacy-policy.html
+++ b/templates/privacy-policy.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title>Crestr: Privacy Policy</title>
+
+    <link rel="stylesheet" href="{{ url_for('static', path='css/pages/privacy-policy.css') }}">
+    <link rel="icon" href="https://images.crestr.co.uk/Crest-Logo.png" type="image/png">
+</head>
+<body>
+
+    <!-- Navbar -->
+    <nav class="pp-navbar">
+        <div class="pp-brand">
+            <a href="https://crestr.co.uk"><img src="https://images.crestr.co.uk/Crest-Logo.png" alt="Crestr logo"></a>
+            <span class="pp-brand-name">Crestr</span>
+        </div>
+        <div style="display: flex; align-items: center; gap: 0.75rem;">
+
+            <!-- Theme toggle -->
+            <button id="pp-theme-toggle" class="pp-theme-toggle" aria-label="Toggle theme">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <circle cx="12" cy="12" r="4"/>
+                    <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/>
+                </svg>
+                <span id="pp-theme-label">System</span>
+            </button>
+
+            <!-- Back link with left arrow -->
+            <a href="https://crestr.co.uk" class="pp-back-link" aria-label="Back to Crestr">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M15 18l-6-6 6-6"/>
+                </svg>
+                back to Crestr
+            </a>
+
+        </div>
+    </nav>
+
+    <!-- Privacy policy content -->
+    <main class="pp-content">
+        <h1 class="pp-title">Privacy Policy</h1>
+        <p class="pp-last-updated">Last updated: 3 August 2026</p>
+
+        <section class="pp-section">
+            <h2>1. Introduction</h2>
+            <p>
+                This Privacy Policy governs the data collection and privacy practices of Crestr, an open-source hiking route planner for Cumbria.
+                We are committed to maintaining robust privacy protections for our users.
+                Our data collection is strictly limited to the minimum telemetry necessary to authenticate users and optimise application performance.
+            </p>
+        </section>
+
+        <section class="pp-section">
+            <h2>2. Information Collection and Processing</h2>
+            <p>We process two categories of data:</p>
+            <ul>
+                <li>
+                    <b>Authentication Credentials:</b> The Application utilises a localised authentication system rather than third-party OAuth providers.
+                    To establish an account, <b>we collect a username and password</b>.
+                    Passwords are encrypted using secure cryptographic hashing algorithms and are utilised solely to authenticate your identity upon login.
+                </li>
+                <li>
+                    <b>Aggregated Operational Telemetry:</b> We utilise Umami, a privacy-focused, open-source web analytics platform, to monitor general application usage.
+                    Additionally, we generate custom server-side action logs to monitor critical performance indicators,
+                    such as pathfinding latency (e.g., generation time in milliseconds) and route distances.
+                </li>
+            </ul>
+            <div class="disclaimer-notice">
+                <strong>Data Isolation Notice:</strong> All operational telemetry and performance metrics are processed in a completely anonymised state. We do not collect, store, or associate real-world geographic coordinates, device identifiers, or network metadata with your account credentials.
+            </div>
+        </section>
+
+        <section class="pp-section">
+            <h2>3. Cookies</h2>
+            <p>
+                Crestr uses only <strong>strictly necessary cookies</strong> required for authentication and to keep you logged in.
+                These cookies are essential for the core functionality of the service and cannot be disabled.
+            </p>
+            <ul>
+                <li>
+                    <b>Authentication / Session Cookies:</b> Used solely to maintain your logged-in state after you sign in. They contain no personal data beyond what is required to identify your authenticated session.
+                </li>
+            </ul>
+            <p>
+                We do <strong>not</strong> use advertising cookies, tracking cookies, analytics cookies, or any third-party cookies.
+                No non-essential cookies are set.
+            </p>
+        </section>
+
+        <section class="pp-section">
+            <h2>4. Legal Basis and Purpose of Processing</h2>
+            <p>We process your data under the following legal frameworks:</p>
+            <ul>
+                <li>
+                    <b>Contractual Necessity:</b> Processing account credentials is required to provide the core account management services you request.
+                </li>
+                <li>
+                    <b>Legitimate Interests:</b> Processing anonymous diagnostics allows us to monitor infrastructure health, debug routing algorithms,
+                    and improve application stability.
+                </li>
+            </ul>
+        </section>
+
+        <section class="pp-section">
+            <h2>5. Data Retention and Third-Party Disclosure</h2>
+            <ul>
+                <li>
+                    <b>Third-Party Transfers:</b> We do not sell, lease, or distribute user data to third-party commercial entities, marketing networks, or data brokers.
+                </li>
+                <li>
+                    <b>Data Retention:</b> Authentication data is retained indefinitely to maintain your account access.
+                    You may execute a data deletion request at any time to permanently purge your credentials from our active databases.
+                </li>
+            </ul>
+        </section>
+
+        <section class="pp-section">
+            <h2>6. Your Rights</h2>
+            <p>
+                You have the right to access, correct, or delete your personal data. You may
+                also request a copy of your data or withdraw consent for data processing at
+                any time by contacting us.
+            </p>
+        </section>
+
+        <section class="pp-section">
+            <h2>7. Contact Us</h2>
+            <p>
+                If you have any questions about this Privacy Policy, please contact us
+                through the in-app report issue feature or email
+                <a class="pp-link" href="mailto:dev@crestr.co.uk">support@crestr.co.uk</a>.
+            </p>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="pp-footer">
+        &copy; 2026 Crestr. All rights reserved.
+    </footer>
+
+    <!-- Self-contained theme controller -->
+    <script src="{{ url_for('static', path='js/privacy-policy.js') }}"></script>
+</body>
+</html>

--- a/templates/privacy-policy.html
+++ b/templates/privacy-policy.html
@@ -3,22 +3,20 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
-    <title>Crestr: Privacy Policy</title>
-
+    <title>Privacy Policy | Crestr</title>
+    <!-- Page-specific CSS (self-contained) -->
     <link rel="stylesheet" href="{{ url_for('static', path='css/pages/privacy-policy.css') }}">
+    <!-- Favicon -->
     <link rel="icon" href="https://images.crestr.co.uk/Crest-Logo.png" type="image/png">
 </head>
 <body>
-
     <!-- Navbar -->
     <nav class="pp-navbar">
         <div class="pp-brand">
-            <a href="https://crestr.co.uk"><img src="https://images.crestr.co.uk/Crest-Logo.png" alt="Crestr logo"></a>
+            <img src="https://images.crestr.co.uk/Crest-Logo.png" alt="Crestr logo">
             <span class="pp-brand-name">Crestr</span>
         </div>
         <div style="display: flex; align-items: center; gap: 0.75rem;">
-
             <!-- Theme toggle -->
             <button id="pp-theme-toggle" class="pp-theme-toggle" aria-label="Toggle theme">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -27,7 +25,6 @@
                 </svg>
                 <span id="pp-theme-label">System</span>
             </button>
-
             <!-- Back link with left arrow -->
             <a href="https://crestr.co.uk" class="pp-back-link" aria-label="Back to Crestr">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -35,7 +32,6 @@
                 </svg>
                 back to Crestr
             </a>
-
         </div>
     </nav>
 
@@ -55,12 +51,17 @@
 
         <section class="pp-section">
             <h2>2. Information Collection and Processing</h2>
-            <p>We process two categories of data:</p>
+            <p>We process the following categories of data:</p>
             <ul>
                 <li>
                     <b>Authentication Credentials:</b> The Application utilises a localised authentication system rather than third-party OAuth providers.
                     To establish an account, <b>we collect a username and password</b>.
-                    Passwords are encrypted using secure cryptographic hashing algorithms and are utilised solely to authenticate your identity upon login.
+                    Passwords are hashed with a secure password-hashing algorithm and are utilised solely to authenticate your identity upon login.
+                </li>
+                <li>
+                    <b>Preferred Name:</b> During registration we also collect a preferred name.
+                    This is stored on your user record and is used solely to personalise the greeting shown on the saved-routes page.
+                    It is retained for as long as your account remains active and is permanently deleted when you request account deletion.
                 </li>
                 <li>
                     <b>Aggregated Operational Telemetry:</b> We utilise Umami, a privacy-focused, open-source web analytics platform, to monitor general application usage.
@@ -95,7 +96,7 @@
             <p>We process your data under the following legal frameworks:</p>
             <ul>
                 <li>
-                    <b>Contractual Necessity:</b> Processing account credentials is required to provide the core account management services you request.
+                    <b>Contractual Necessity:</b> Processing account credentials and preferred name is required to provide the core account management and personalisation services you request.
                 </li>
                 <li>
                     <b>Legitimate Interests:</b> Processing anonymous diagnostics allows us to monitor infrastructure health, debug routing algorithms,
@@ -111,8 +112,8 @@
                     <b>Third-Party Transfers:</b> We do not sell, lease, or distribute user data to third-party commercial entities, marketing networks, or data brokers.
                 </li>
                 <li>
-                    <b>Data Retention:</b> Authentication data is retained indefinitely to maintain your account access.
-                    You may execute a data deletion request at any time to permanently purge your credentials from our active databases.
+                    <b>Data Retention:</b> Authentication data and preferred name are retained indefinitely to maintain your account access and personalisation.
+                    You may execute a data deletion request at any time to permanently purge your credentials and preferred name from our active databases.
                 </li>
             </ul>
         </section>

--- a/templates/register.html
+++ b/templates/register.html
@@ -100,7 +100,7 @@
 
             <p id="register-privacy-notice">
                 By registering, you agree to our
-                <a href="https://docs.crestr.co.uk/privacy-policy/privacy_policy/" target="_blank" rel="noopener noreferrer">Privacy Policy</a>.
+                <a href="/privacy-policy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>.
             </p>
         </div>
 


### PR DESCRIPTION
# Pull Request Template

## Summary

This PR aims to implement a privacy policy page inside the Crestr app as opposed to linking all links associated with a privacy policy to the [docs page](<https://docs.crestr.co.uk>). It also adds the Cookie Policy to the privacy policy page which was not present in the docs version

## Related Issue

closes abdlfc11/Crestr-Hiking-App#77

closes abdlfc11/Crestr-Hiking-App#77

## Type of Change

Select all that apply:

- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (explain below)

## Description of Changes

* Added a privacy policy template named `privacy-policy.html` alongside the corresponding CSS and JS files `privacy-policy.css` and `privacy-policy.js`)
* Ensured that the privacy policy page was self-contained, meaning that the JS file did not import anything from separate JS files and that the CSS file did not use any tokens from the `tokens.css` file used app-wide
* Changed any links to the privacy policy to point to this new page as opposed to the one in the docs

## Screenshots / Visuals (if applicable)

### Privacy Policy Page

![image](https://github.com/user-attachments/assets/bf0a33da-1e58-4db4-8582-1d0925970d7f)

## Testing

* Observed the privacy policy page to ensure that it looked as expected
* Clicked the links pointing to the privacy policy page to ensure that it linked the user to the new page as opposed to the privacy policy on the docs page

## Checklist

- [X] My code follows the project’s style guidelines
- [X] I have tested my changes
- [X] I have updated documentation if needed
- [X] I have referenced the related issue
- [X] This PR is scoped, focused, and ready for review

> **Note:**  <br>PRs for issues **not** tagged as contributor‑friendly may be closed without review.