### PR TITLE
PR feat: Add SVG pins for start and end points for manual routing and loading routes

### DIFF
--- a/static/js/routes/loadRoute.js
+++ b/static/js/routes/loadRoute.js
@@ -20,6 +20,7 @@ import { clearLastLoadedRouteStats, getLastLoadedRouteStats, setCurrentPathData,
 import { deleteRoute, loadRoute } from "./routeApi.js";
 
 import { initChartToggleListener } from "../elevationChart.js";
+import { getSavedPointStyle } from "../saved_points/style.js";
 
 
 let routeList = null;
@@ -70,12 +71,12 @@ export function displayLoadedRouteOnMap(data) {
   const startFeature = new ol.Feature({
     geometry: new ol.geom.Point(startMercator)
   });
-  startFeature.setStyle(createManualPointStyle("Start", "#8145d4"));
+  startFeature.setStyle(getSavedPointStyle("Start", "#00A86B"));
 
   const endFeature = new ol.Feature({
     geometry: new ol.geom.Point(endMercator)
   });
-  endFeature.setStyle(createManualPointStyle("End", "#8145d4"));
+  endFeature.setStyle(getSavedPointStyle("End", "#D32F2F"));
 
 
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -267,12 +267,6 @@ function checkIfMobile() {
 
 //#endregion
 
-// this is for the 'create route' button on the panel shown on the saved routes dashboard when the user has no saved routes
-function noRouteCreateFunction() {
-  closeNav()
-  closeSavedRoutesDash()
-}
-
 //#region LOGIN MODAL
 
 /**
@@ -590,7 +584,7 @@ export function mapClickHandler(event) {
     setCoordEntry(startCoordEntry, event);
 
     // adding start point
-    const pointFeature = createPoint(event.coordinate, getSavedPointStyle("Start", "#074df0"), "start", "Start");
+    const pointFeature = createPoint(event.coordinate, getSavedPointStyle("Start", "#00A86B"), "start", "Start");
     addStartEndPoint(pointFeature, interactivePointLayer, "start");
     setUpPointInteraction([interactivePointLayer]);
 
@@ -604,7 +598,7 @@ export function mapClickHandler(event) {
     setCoordEntry(endCoordEntry, event);
 
     // adding end point 
-    const pointFeature = createPoint(event.coordinate, getSavedPointStyle("End", "#074df0"), "end", "End")
+    const pointFeature = createPoint(event.coordinate, getSavedPointStyle("End", "#D32F2F"), "end", "End")
     addStartEndPoint(pointFeature, interactivePointLayer, "end");
     setUpPointInteraction([interactivePointLayer]);
 
@@ -667,6 +661,12 @@ function openNav() {
 
 export function closeNav() {
   navBar.style.width = "0";
+}
+
+// this is for the 'create route' button on the panel shown on the saved routes dashboard when the user has no saved routes
+function noRouteCreateFunction() {
+  closeNav()
+  closeSavedRoutesDash()
 }
 
 function openSavedRoutesDash() {
@@ -1250,8 +1250,8 @@ function displayPath(data) {
     const endMercatorCoord = ol.proj.fromLonLat([endCoord[0], endCoord[1]]);
 
     // this creates and then displays (by adding them to the interactivePointLayerSource) the start and end point features
-    const startPointFeature = createPoint(startMercatorCoord, getSavedPointStyle("Start", "#074df0"), "start", "Start")
-    const endPointFeature = createPoint(endMercatorCoord, getSavedPointStyle("End", "#074df0"), "end", "End")
+    const startPointFeature = createPoint(startMercatorCoord, getSavedPointStyle("Start", "#00A86B"), "start", "Start")
+    const endPointFeature = createPoint(endMercatorCoord, getSavedPointStyle("End", "#D32F2F"), "end", "End")
 
     interactivePointLayerSource.addFeature(startPointFeature)
     interactivePointLayerSource.addFeature(endPointFeature)
@@ -1373,11 +1373,11 @@ export function updateManualRoute() {
         const isEnd = index === userClicks.length - 1;
 
         if (isSnappedToEnd) {
-          if (isStart) return createManualPointStyle("Start/End", "#8145d4");
-          if (isEnd) return createManualPointStyle("", "#8145d4", 0);
+          if (isStart) return getSavedPointStyle("Start/End", "#00A86B");
+          if (isEnd) return getSavedPointStyle("", "#00A86B");
         }
-        if (isStart) return createManualPointStyle("Start", "#8145d4");
-        if (isEnd) return createManualPointStyle("End", "#8145d4");
+        if (isStart) return getSavedPointStyle("Start", "#00A86B");
+        if (isEnd) return getSavedPointStyle("End", "#D32F2F");
         return createManualPointStyle("", "#000", 6.5);
       }
       return new ol.style.Style({


### PR DESCRIPTION
# Pull Request Template

## Summary

This PR aims to solve the inconsistency between automatically generated routes and loaded / manually plotted routes. Automatically generated routes had the new SVG pins set as start and end points, whereas routes that had been loaded or manually plotted had the old, purple, OpenLayers generated circles to identify start and end points.

This PR replaces these circles with the new SVG pins (and also changes the colour of the SVG pins in automatic routing, with the start point being green and the end point being red)

## Related Issue

closes abdlfc11/Crestr-Hiking-App#85

closes abdlfc11/Crestr-Hiking-App#85

## Type of Change

Select all that apply:

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (explain below)

## Description of Changes

* The colour scheme of SVG pins was changed from blue to green for the start pin and red for the end pin
* Loaded and manually plotted routes now have SVG pins on their start and end points

## Screenshots / Visuals (if applicable)

### Loaded / Automatically Generated Routes

![SCR-20260803-izpn](https://github.com/user-attachments/assets/dc19c224-0cfa-46ec-8e39-f34b86d14615)

### Manually Plotted Routes

![SCR-20260803-izuu](https://github.com/user-attachments/assets/399a5811-0c2c-4e03-b523-94abc1e94f3d)

## Testing

* Created routes in both automatic and manual mode
* Saved and then loaded routes to ensure that SVG pins were also being shown for loaded routes

## Checklist

- [X] My code follows the project’s style guidelines
- [X] I have tested my changes
- [X] I have updated documentation if needed
- [X] I have referenced the related issue
- [X] This PR is scoped, focused, and ready for review

> **Note:**  <br>PRs for issues **not** tagged as contributor‑friendly may be closed without review.