### PR TITLE
PR feat: Update toasts to allow for different status (e.g info / success) and improve the design of toasts

### DIFF
--- a/src/Auth/auth_fastapi.py
+++ b/src/Auth/auth_fastapi.py
@@ -196,7 +196,7 @@ def register(
                 status_code=422,
                 detail={
                     "success": False,
-                    "message": "Passwords must have at least 12 characters"
+                    "message": "Passwords must have at least 11 characters"
                 }
             )
         

--- a/static/css/base/tokens.css
+++ b/static/css/base/tokens.css
@@ -68,6 +68,21 @@
     "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --font-system: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+
+  /* Toast tokens */
+  --toast-bg: rgba(255, 255, 255, 0.72);
+  --toast-blur: 12px;
+  --toast-text-primary: var(--ink-strong);
+  --toast-text-secondary: var(--muted);
+  --toast-error: #ef4444;
+  --toast-success: #22c55e;
+  --toast-warning: #f59e0b;
+  --toast-info: #3b82f6;
+  --toast-border: rgba(0, 0, 0, 0.08);
+  --toast-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+  --toast-radius: 12px;
+  --toast-padding: 14px 16px;
+  --toast-transition-speed: 0.3s;
 }
 
 /* DARK MODE */
@@ -107,4 +122,9 @@ html.dark {
 
   --shadow-surface: 0 10px 35px rgba(0, 0, 0, 0.3);
   --shadow-lift: 0 4px 12px rgba(59, 130, 246, 0.2);
+
+  /* Toast tokens */
+  --toast-bg: rgba(33, 34, 36, 0.72);
+  --toast-border: rgba(255, 255, 255, 0.1);
+  --toast-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
 }

--- a/static/css/components/error-toast.css
+++ b/static/css/components/error-toast.css
@@ -13,27 +13,183 @@
   flex-direction: column;
   gap: 10px;
   z-index: 9999;
+  max-width: 360px;
 }
 
-.error-toast {
-  background: var(--error-accent);
-  color: white;
-  padding: 12px 18px;
-  border-radius: 999px;
-  font-size: 14px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  opacity: 0;
-  transform: translateY(20px);
-  transition: opacity 0.25s ease, transform 0.25s ease;
+/* modal-scoped toast container (created dynamically by showToast() in utils/ui-utils.js ) */
+.toast-container--modal {
+  position: absolute;
+  bottom: 20px;
+  right: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  z-index: 2100;
+  max-width: 360px;
   pointer-events: none;
 }
 
-.error-toast.show {
-  opacity: 1;
-  transform: translateY(0);
+/* Toast Card */
+
+.toast {
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: var(--toast-padding);
+  border-radius: var(--toast-radius);
+  background: var(--toast-bg);
+  backdrop-filter: blur(var(--toast-blur));
+  -webkit-backdrop-filter: blur(var(--toast-blur));
+  border: 1px solid var(--toast-border);
+  box-shadow: var(--toast-shadow);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  color: var(--toast-text-primary);
+  overflow: hidden;
+  pointer-events: auto;
+
+  /* this defines the entry animation i.e slide in from the right + fade in */
+  opacity: 0;
+  transform: translateX(100%);
+  transition:
+    opacity var(--toast-transition-speed) ease,
+    transform var(--toast-transition-speed) cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-.error-toast.hide {
+.toast.show {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.toast.hide {
   opacity: 0;
-  transform: translateY(20px);
+  transform: translateX(100%);
+}
+
+/* Status icon */
+
+.toast-icon {
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+  margin-top: 1px;
+}
+
+/* this defines the status colours per type */
+.toast[data-type="error"] .toast-icon {
+  background: color-mix(in srgb, var(--toast-error) 18%, transparent);
+  color: var(--toast-error);
+}
+
+.toast[data-type="success"] .toast-icon {
+  background: color-mix(in srgb, var(--toast-success) 18%, transparent);
+  color: var(--toast-success);
+}
+
+.toast[data-type="warning"] .toast-icon {
+  background: color-mix(in srgb, var(--toast-warning) 18%, transparent);
+  color: var(--toast-warning);
+}
+
+.toast[data-type="info"] .toast-icon {
+  background: color-mix(in srgb, var(--toast-info) 18%, transparent);
+  color: var(--toast-info);
+}
+
+/* Content (title + message) */
+
+.toast-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.toast-title {
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--toast-text-primary);
+  line-height: 1.3;
+}
+
+.toast-message {
+  font-size: 13px;
+  color: var(--toast-text-secondary);
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+/* Dismiss (×) button */
+
+.toast-close {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--toast-text-secondary);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px 4px;
+  margin-top: -1px;
+  border-radius: 4px;
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.toast-close:hover {
+  color: var(--toast-error);
+  background-color: color-mix(in srgb, var(--toast-error) 10%, transparent);
+}
+
+.toast-close:focus-visible {
+  outline: 2px solid var(--toast-info);
+  outline-offset: 2px;
+}
+
+/* Auto-dismiss progress bar */
+
+.toast-progress {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  width: 100%;
+  transform-origin: left;
+  transform: scaleX(1);
+}
+
+/* this defines the progress bar colour per type */
+.toast[data-type="error"] .toast-progress {
+  background: var(--toast-error);
+}
+.toast[data-type="success"] .toast-progress {
+  background: var(--toast-success);
+}
+.toast[data-type="warning"] .toast-progress {
+  background: var(--toast-warning);
+}
+.toast[data-type="info"] .toast-progress {
+  background: var(--toast-info);
+}
+
+/* this shrinks the bar from 100% to 0 over 3s */
+.toast.show .toast-progress {
+  animation: toast-progress-shrink 3s linear forwards;
+}
+
+@keyframes toast-progress-shrink {
+  from {
+    transform: scaleX(1);
+  }
+  to {
+    transform: scaleX(0);
+  }
 }

--- a/static/js/auth/auth.js
+++ b/static/js/auth/auth.js
@@ -1,6 +1,6 @@
 //#region IMPORTS
 
-import { showError } from "../utils/ui-utils.js";
+import { showToast } from "../utils/ui-utils.js";
 import { 
   validatePassword,
   validateRegisterInput,
@@ -49,7 +49,7 @@ function switchToLoginFromRegister() {
 }
 
 export function switchToRegistering() {
-  window.location.href = "/register";
+  window.location.href = "/register-page";
 }
 
 
@@ -62,11 +62,7 @@ async function register() {
   const message = validateRegisterInput(username, password1, password2);
 
   if (message !== true) {
-    registerValidationLabel.innerText = message;
-    registerValidationLabel.style.opacity = "1";
-    setTimeout(() => {
-      registerValidationLabel.style.opacity = "0";
-    }, 3000);
+    showToast(message, "error", null);
     return;
   };
 
@@ -90,20 +86,19 @@ async function register() {
     const data = await response.json();
 
     if (!response.ok) {
-      userFeedback(registerValidationLabel, data.message, false);
+      showToast(data.message, "error", null);
       return;
     };
 
     if (data.success) {
       clearRegisterEntries(registerUsernameEntry, registerPasswordEntry1, registerPasswordEntry2);
       window.location.href = 'https://crestr.co.uk';
-      userFeedback(loginValidationLabel, data.message, true);
     } else {
-      userFeedback(registerValidationLabel, data.message, false);
+      showToast(data.message, "error", null);
     }
 } catch (error) {
     console.log(`ERROR: ${error}`);
-    userFeedback(registerValidationLabel, error.message, false);
+    showToast(error.message, "error", null);
 };
 
 };
@@ -132,7 +127,7 @@ export async function login() {
     const data = await response.json();
 
     if (!response.ok) {
-      userFeedback(loginValidationLabel, data.message, false);
+      showToast(data.message, "error", null);
       return;
     };
 
@@ -141,12 +136,12 @@ export async function login() {
       loginPasswordEntry.value = "";
       window.location.href = "/map"
     } else {
-      userFeedback(loginValidationLabel, data.message, false);
+      showToast(data.message, "error", null);
     }
   } 
   catch(error) {
     console.error("ERROR: ", error);
-    showError(error.message || "Sorry, there was an unexpected error whilst logging in, try again later.")
+    showToast(error.message || "Sorry, there was an unexpected error whilst logging in, try again later.")
   }
 
 }
@@ -198,12 +193,12 @@ export async function deleteAccount(skipConfirm = false) {
     const data = await response.json();
 
     if (!response.ok) {
-      showError("There was an unexpected error whilst deleting your account.")
+      showToast("There was an unexpected error whilst deleting your account.")
       return;
     };
 
     if (!data.success) {
-      showError("There was an unexpected error whilst deleting your account.")
+      showToast("There was an unexpected error whilst deleting your account.")
       return;
     };
 
@@ -211,7 +206,7 @@ export async function deleteAccount(skipConfirm = false) {
     window.location.href = 'https://crestr.co.uk'
   } catch(error) {
     console.log(`ERROR : ${error.message}`)
-    showError("There was an unexpected error whilst deleting your account.")
+    showToast("There was an unexpected error whilst deleting your account.")
     return;
   };
 }

--- a/static/js/importRoute.js
+++ b/static/js/importRoute.js
@@ -1,6 +1,6 @@
 
 import {
-    showError,
+    showToast,
     addClickListener,
     createRouteCard
 } from "./utils/ui-utils.js";
@@ -28,7 +28,7 @@ export async function processImportedRouteFile(file) {
     });
 
     if (!response.ok) {
-        showError(response.message || "There was an error on our end, try again later");
+        showToast(response.message || "There was an error on our end, try again later");
         throw new Error(`HTTP Error: ${response.status}`);
     }
 

--- a/static/js/importRoute.js
+++ b/static/js/importRoute.js
@@ -27,12 +27,12 @@ export async function processImportedRouteFile(file) {
         body: form
     });
 
+    const data = await response.json();
+
     if (!response.ok) {
-        showToast(response.message || "There was an error on our end, try again later");
+        showToast(data.message || "There was an error on our end, try again later");
         throw new Error(`HTTP Error: ${response.status}`);
     }
-
-    const data = await response.json();
 
     if (data.success) {
         return data;

--- a/static/js/routes/saveRoute.js
+++ b/static/js/routes/saveRoute.js
@@ -26,7 +26,7 @@ import { initSavedRoutesDashboard } from "./savedRoutesDashboard.js";
 import {
   createRouteCard,
   removeDOMElement,
-  showError
+  showToast
 } from "../utils/ui-utils.js"
 
 import {
@@ -92,7 +92,7 @@ function handleSaveRoute(e) {
 
     if (pathCoordinates.length === 0) {
       console.error("No coordinates found in pathCoords array")
-      showError("There was an error saving your route. Please try again later.");
+      showToast("There was an error saving your route. Please try again later.");
       return false;
     }
 
@@ -100,13 +100,13 @@ function handleSaveRoute(e) {
 
     if (rawDistanceKm === null || isNaN(rawDistanceKm)) {
       console.error("No valid route distance to save");
-      showError("There was an error saving your route. Please try again later.");
+      showToast("There was an error saving your route. Please try again later.");
       return false;
     }
   }
   catch (e) {
     console.error(`Error whilst saving route: ${e}`)
-    showError("There was an error saving your route. Please try again later.");
+    showToast("There was an error saving your route. Please try again later.");
     return false;
   }
 
@@ -122,7 +122,7 @@ function handleSaveRoute(e) {
   })
     .then((response) => {
       if (!response.ok) {
-        showError("There was an error saving your route. Please try again later.")
+        showToast("There was an error saving your route. Please try again later.")
         return response.json().then((errorData) => {
           throw new Error(
             errorData.message ||
@@ -161,12 +161,12 @@ function handleSaveRoute(e) {
         homeButtonFunction();
         updateSaveRouteContainer();
       } else {
-        showError( data.message || "There was an error saving your route. Please try again later.")
+        showToast( data.message || "There was an error saving your route. Please try again later.")
         return false;
       }
     })
     .catch((error) => {
-      showError("There was an error saving your route. Please try again later.")
+      showToast("There was an error saving your route. Please try again later.")
       console.error("Error saving route:", error);
       return false;
     })

--- a/static/js/routes/savedRoutesDashboard.js
+++ b/static/js/routes/savedRoutesDashboard.js
@@ -16,7 +16,7 @@ import { createElevationProfile, initChartToggleListener } from "../elevationCha
 import {
   addClickListener,
   createNoRouteCard,
-  showError
+  showToast
 } from "../utils/ui-utils.js"
 
 import { formatDistance } from "../utils/format-utils.js";
@@ -106,7 +106,7 @@ async function onDeleteClick(event) {
     }
   } catch (error) {
 
-    showError("Sorry, there was an unexpected error, try again later. ")
+    showToast("Sorry, there was an unexpected error, try again later. ")
   }
 
   event.preventDefault();
@@ -165,7 +165,7 @@ async function onDownloadClick(event, format, DOMElement) {
   
     logError("Downloading Route", error.message, null, "DOWNLOAD_ROUTE")
 
-    showError("Sorry, there was an unexpected error, try again later. ")
+    showToast("Sorry, there was an unexpected error, try again later. ")
   }
   finally {
     DOMElement.disabled = false;

--- a/static/js/routing/routing.js
+++ b/static/js/routing/routing.js
@@ -8,7 +8,7 @@ import { manualRouteState,
 } from "../routes/routeState.js";
 
 import {
-  showError
+  showToast
 } from "../utils/ui-utils.js"
 
 import {

--- a/static/js/saved_points/savedPoints.js
+++ b/static/js/saved_points/savedPoints.js
@@ -178,6 +178,6 @@ export async function deleteSavedPoint(selectedPoint) {
   }
   catch(error) {
     logError("Deleting Point", error.message, null, "DELETE_POINT")
-    showToast("There was an unexpected error whilst saving your point, try again later.")
+    showToast("There was an unexpected error whilst deleting your point, try again later.")
   }
 }

--- a/static/js/saved_points/savedPoints.js
+++ b/static/js/saved_points/savedPoints.js
@@ -1,7 +1,7 @@
 import { getSavedPointStyle } from "./style.js";
 import { getMap } from "../map.js";
 import { showLoginModal, showDeletePointModal } from "../ui.js";
-import { showError } from "../utils/ui-utils.js";
+import { showToast } from "../utils/ui-utils.js";
 import { logError } from "../utils/logError-utils.js";
 
 let savedPointsLayer = null;
@@ -80,7 +80,7 @@ export function loadAndDisplaySavedPoints() {
       .then(addLayerToMap)
       .catch(err => {
         logError("Getting Saved Points", err.message, null, "GET_SAVED_POINT")
-        showError("Sorry, there was an unexpected error whilst displaying saved points.");
+        showToast("Sorry, there was an unexpected error whilst displaying saved points.");
       })
 }
 
@@ -131,7 +131,7 @@ export async function saveNewPoint(coordinate, name) {
       return;
   }
   catch(error) {
-    showError(error.message || "There was an unexpected error whilst saving your point, try again later.");
+    showToast(error.message || "There was an unexpected error whilst saving your point, try again later.");
     return false;
   }
 }
@@ -178,6 +178,6 @@ export async function deleteSavedPoint(selectedPoint) {
   }
   catch(error) {
     logError("Deleting Point", error.message, null, "DELETE_POINT")
-    showError("There was an unexpected error whilst saving your point, try again later.")
+    showToast("There was an unexpected error whilst saving your point, try again later.")
   }
 }

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -440,9 +440,7 @@ export async function handleReportIssueSubmission(title, description) {
     } catch (error) {
       showToast("There was an unexpected error whilst submitting the issue report.", "error", reportIssueModal);
     } finally {
-      // This re-enables the submit button + closes the modal
       reportIssueModalSubmit.disabled = false;
-      showReportIssueModal(false);
     }
 }
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -19,7 +19,7 @@ import {
 
 import {
   moveMapToPosition,
-  showError,
+  showToast,
   addClickListener,
   removeDOMElement,
   createStatsPanel,
@@ -371,17 +371,17 @@ function dismissReportIssueModal(e) {
  */
 function validateReportIssueInput(title, description) {
     if (!title || !description) {
-        showError("Please fill in both the title and description fields.");
+        showToast("Please fill in both the title and description fields.", "error", reportIssueModal);
         return false;
     }
 
     if (title.length > 100) {
-        showError("Title cannot exceed 100 characters.");
+        showToast("Title cannot exceed 100 characters.", "error", reportIssueModal);
         return false;
     }
 
     if (description.length > 1000) {
-        showError("Description cannot exceed 1000 characters.");
+        showToast("Description cannot exceed 1000 characters.", "error", reportIssueModal);
         return false;
     }
 
@@ -430,7 +430,7 @@ export async function handleReportIssueSubmission(title, description) {
           return;
       }
 
-      // TOAST feedback to be added after it is redesigned 
+      showToast("Thank you, the issue was reported successfully. ", "success")
       
       // UI cleanup
       reportIssueTitleInput.value = '';
@@ -438,7 +438,7 @@ export async function handleReportIssueSubmission(title, description) {
       showReportIssueModal(false);
 
     } catch (error) {
-      showError("There was an unexpected error whilst submitting the issue report.");
+      showToast("There was an unexpected error whilst submitting the issue report.", "error", reportIssueModal);
     } finally {
       // This re-enables the submit button + closes the modal
       reportIssueModalSubmit.disabled = false;
@@ -495,7 +495,7 @@ function validateInputCoords(startPoint, endPoint) {
 
   // This ensures there are two coordinates
   if (startParts.length < 2 || endParts.length < 2) {
-    showError("Invalid coordinate format. Please Use Lat, Lon");
+    showToast("Invalid coordinate format. Please Use Lat, Lon");
     return false;
   }
 
@@ -510,14 +510,14 @@ function validateInputCoords(startPoint, endPoint) {
   const endLonLat = [endLon, endLat];
 
   if ( !isPointInPolygon(startLonLat)) {
-    showError("Please select a starting location within Cumbria.")
+    showToast("Please select a starting location within Cumbria.")
     startCoordEntry.value = '';
     showCoordInputError(startCoordEntry, "Please select a starting location within Cumbria.");
     return false
   }
 
   if (!isPointInPolygon(endLonLat)) {
-    showError("Please select a destination within Cumbria.");
+    showToast("Please select a destination within Cumbria.");
     endCoordEntry.value = ''
     showCoordInputError(endCoordEntry, "Please select a destination within Cumbria.");
     return false;
@@ -779,7 +779,7 @@ async function handleRouteImport() {
       data = await processImportedRouteFile(file); 
 
       if (!data || !data.coords) {
-        showError(data || "There was an error on our end. Please try again later.");
+        showToast(data || "There was an error on our end. Please try again later.");
         return false;
       }
 
@@ -799,7 +799,7 @@ async function handleRouteImport() {
       };
     }
     catch (error) {
-      showError("There was an error on our end. Please try again later.")
+      showToast("There was an error on our end. Please try again later.")
       console.error(`ERROR whilst importing route : ${error}`)
     }
 
@@ -815,13 +815,13 @@ async function handleRouteImport() {
       });
 
       if (!response.ok) {
-        showError("There was an error on our end. Please try again later.");
+        showToast("There was an error on our end. Please try again later.");
         return false;
       }
 
       const result = await response.json(); 
       if (!result.success) {
-        showError(result.message || "Failed to save route.");
+        showToast(result.message || "Failed to save route.");
         return false;
       }
 
@@ -831,7 +831,7 @@ async function handleRouteImport() {
       return true;
 
     } catch (err) {
-      showError("There was an error on our end. Please try again later.");
+      showToast("There was an error on our end. Please try again later.");
       console.error(`Error whilst trying to save imported route: ${err}`)
       return false;
     }
@@ -840,7 +840,7 @@ async function handleRouteImport() {
     const url = importRouteURLInput.value.trim();
 
     if (!URL.canParse(url)) {
-      showError("Please enter a valid URL to import.");
+      showToast("Please enter a valid URL to import.");
       return false;
     }
 
@@ -858,25 +858,25 @@ function validateFileInput(file) {
 
     // this checks if a file is selected
     if (!file) {
-        showError("Please select a file to import.");
+        showToast("Please select a file to import.");
         return false;
     }
 
     // this checks if the file is of the correct type
     if (!allowedFileTypes.some(type => file.name.endsWith(type))) {
-        showError("Please select a valid file to import.");
+        showToast("Please select a valid file to import.");
         return false;
     }
 
     // this checks if the file size is too large (greater than 5MB)
     if (file.size > 5 * 1024 * 1024) {
-        showError("File size is too large. Please select a file smaller than 5MB.");
+        showToast("File size is too large. Please select a file smaller than 5MB.");
         return false;
     }
 
     // this checks if the file is empty or not
     if (file.size === 0) {
-      showError("The selected file is empty.")
+      showToast("The selected file is empty.")
       return false;
     }
 
@@ -1125,7 +1125,7 @@ export function homeButtonFunction() {
 function searchArea() {
 
   if (!searchEntry) {
-    showError("Search entry not found.");
+    showToast("Search entry not found.");
     return;
   }
 
@@ -1167,7 +1167,7 @@ function searchArea() {
         });
       }
     })
-    .catch((error) => showError("There was an unexpected error, please try again later."));
+    .catch((error) => showToast("There was an unexpected error, please try again later."));
 };
 //#endregion
 
@@ -1204,7 +1204,7 @@ async function handleAutoRouteGeneration(start=null, end=null) {
     if (saveContainer) saveContainer.style.display = "flex";
 
   } catch (error) {
-    showError("Sorry, there was an unexpected error when calculating your route, please try again later.");
+    showToast("Sorry, there was an unexpected error when calculating your route, please try again later.");
     return;
   } finally {
     generatePathButton.classList.remove("loading");
@@ -1273,7 +1273,7 @@ function displayPath(data) {
   } 
   catch(error) {
     console.log(error.message);
-    showError('Sorry, there was an unexpected error when calculating your route, please try again later.')
+    showToast('Sorry, there was an unexpected error when calculating your route, please try again later.')
   }
 };
 
@@ -1494,7 +1494,7 @@ async function manualRouteClickHandler(event) {
       throw new Error(response?.message || "Sorry, there was an error whilst creating the path. ")
     }
   } catch (error) {
-    showError("Sorry, there was an error whilst creating the path.");
+    showToast("Sorry, there was an error whilst creating the path.");
     logError("Calculating Path", error.message || "Manual Route", null, "NO_PATH_FOUND");
     return;
   }
@@ -1583,7 +1583,7 @@ function handleCoordEntryChange(entry, type) {
 
   // returning prematurely if the point is not in Cumbria 
   if (!isPointInPolygon(ol.proj.toLonLat(mercatorCoords))) {
-    showError("Please choose a point within Cumbria.")
+    showToast("Please choose a point within Cumbria.")
     return;
   }
 

--- a/static/js/utils/ui-utils.js
+++ b/static/js/utils/ui-utils.js
@@ -3,7 +3,7 @@
  * As of August 2026 this file hold the following functions:
  *      
  *      - moveMapToPosition(map, position = null, duration = 1200, zoom = 10.5)
- *      - showError(message, colour = "#ff4d4f")
+ *      - showToast(message, type = "error", modal = null)
  *      - addClickListener(element, func, type)
  *      - removeDOMElement(element)
  *      - createRouteCard(routeName, formattedDate, distanceInKm, ETA, elevDisplayValue)
@@ -72,35 +72,129 @@ export function moveMapToPosition(map, position = null, duration = 1200, zoom = 
 };
 
 /**
- * Shows an error popup containing the passed in string 
- * 
- * @param {string} message The error message to be shown 
- * @param {*} colour The colour of the error popup, defaults to red 
+ * Shows a toast notification 
+ *
+ * @param {string} message The message to be shown in the toast body
+ * @param {("error"|"success"|"warning"|"info")} [type="error"] The toast type, controls the status icon and accent colour
+ * @param {HTMLDialogElement|boolean|null} [modal=null] If a dialog element is passed, the toast is rendered inside it, otherwise, if `null`/`false`, the main app toast container is used.
+ * @returns {void}
  */
-export function showError(message, colour = "#ff4d4f") {
-    const container = document.getElementById("error-toast-container");
+export function showToast(message, type = "error", modal = null) {
 
+    // this defines the status icons
+    const icons = {
+        error: "!",
+        success: "\u2713",
+        warning: "!",
+        info: "i",
+    };
+
+    // this defines the titles per toast type 
+    const titles = {
+        error: "Error",
+        success: "Success",
+        warning: "Warning",
+        info: "Info",
+    };
+
+    // this retrieves the modal element (if any) 
+    let modalElement = null;
+
+     if (modal instanceof HTMLElement) {
+        modalElement = modal;
+    }
+
+    // this determines the container i.e within a modal or the main app
+    let container;
+
+    if (modalElement) {
+        // this finds or creates the container 
+        container = modalElement.querySelector(".toast-container--modal");
+
+        if (!container) {
+            container = document.createElement("div");
+            container.className = "toast-container--modal";
+            modalElement.appendChild(container);
+        }
+    } else {
+        container = document.getElementById("error-toast-container");
+    }
+
+    if (!container) {
+        console.warn("showToast: no toast container found");
+        return;
+    }
+
+    // this builds the toast element 
     const toast = document.createElement("div");
-    toast.className = "error-toast";
-    toast.textContent = message;
-    toast.style.background = colour;
+    toast.className = "toast";
+    toast.setAttribute("data-type", type);
+    toast.setAttribute("role", "alert");
+    toast.setAttribute("aria-live", "assertive");
 
+    // this defines the status icon
+    const icon = document.createElement("span");
+    icon.className = "toast-icon";
+    icon.textContent = icons[type] || icons.error;
+    icon.setAttribute("aria-hidden", "true");
+
+    // this defines the content (title + message)
+    const content = document.createElement("div");
+    content.className = "toast-content";
+
+    const titleElement = document.createElement("span");
+    titleElement.className = "toast-title";
+    titleElement.textContent = titles[type] || titles.error;
+
+    const messageElement = document.createElement("span");
+    messageElement.className = "toast-message";
+    messageElement.textContent = message;
+
+    content.appendChild(titleElement);
+    content.appendChild(messageElement);
+
+    // this defines the dismisses (X) button
+    const closeButton = document.createElement("button");
+    closeButton.className = "toast-close";
+    closeButton.type = "button";
+    closeButton.setAttribute("aria-label", "Dismiss notification");
+    closeButton.innerHTML = "&times;";
+
+    // this defines the auto-dismiss progress bar
+    const progress = document.createElement("div");
+    progress.className = "toast-progress";
+
+    toast.appendChild(icon);
+    toast.appendChild(content);
+    toast.appendChild(closeButton);
+    toast.appendChild(progress);
     container.appendChild(toast);
 
-    // this triggers the slide in animation of the error popup
+    // this makes the popup hide after 3s
+    const hideTimeout = setTimeout(removeToast, 3000);
+
+    // Helper to remove the toast (used by both the timeout and the close button)
+    function removeToast() {
+        clearTimeout(hideTimeout);
+        toast.classList.add("hide");
+        toast.classList.remove("show");
+
+        // this removes it from the DOM once the hide animation is done
+        setTimeout(() => {
+            toast.remove();
+            // this cleans up a modal-scoped container if it is empty
+            if (container.classList.contains("toast-container--modal") && container.childElementCount === 0) {
+                container.remove();
+            }
+        }, 300);
+    } 
+
+    // this triggers the slide-in animation of the toast
     requestAnimationFrame(() => {
         toast.classList.add("show");
     });
 
-    // this makes the popup hide after 3s
-    setTimeout(() => {
-        toast.classList.add("hide");
-
-        // this removes it from the DOM once time is up
-        setTimeout(() => {
-            toast.remove();
-        }, 250);
-    }, 3000);
+    closeButton.addEventListener("click", removeToast);
 }
 
 // DOM RELATED 

--- a/templates/register.html
+++ b/templates/register.html
@@ -14,6 +14,7 @@
     <link rel="stylesheet" href="{{ url_for('static', path='css/layout/navbar.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='css/components/buttons.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='css/components/theme-toggle.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', path='css/components/error-toast.css') }}">
 
     <!-- Icons -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
@@ -22,6 +23,8 @@
     <link rel="icon" href="https://images.crestr.co.uk/Crest-Logo.png" type="image/png">
 </head>
 <body>
+
+    <div id="error-toast-container"></div>
 
     <!-- Navbar component -->
     <nav id="navbar" class="surface">


### PR DESCRIPTION
# Pull Request Template

## Summary

This PR aims to introduce updates towards both the design of toast messages as well as their use case, with the new changes involving a more modern design towards toast messages. The `showError()` function was also changed to A) have a new name and B) be more broader allowing toast messages to be used for success, warning, or informative toast messages.

## Related Issue

Closes abdlfc11/Crestr-Hiking-App#89

## Type of Change

Select all that apply:

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [X] Refactor
- [ ] Other (explain below)

## Description of Changes

* `showError()` was renamed to `showToast()` and a new parameter was added of which was type, allowing toast messages to be used for different purposes as opposed to only being shown for errors
* Toast messages were redesigned to appear more modern, as well as more integrated to the current theme of the app, rather than a bright red background against white text which did not integrate nicely with the dark theme

## Screenshots / Visuals (if applicable)

### Success toast message example

<img src="https://github.com/user-attachments/assets/2870229d-f0c0-4be0-8ab2-a9e3dcb1a1ff " alt="image" width="1470" data-linear-height="829" />

## Testing

* Triggered toast messages of all types to ensure that the toast messages were shown as expected with their own differing specific styles
* Grepped for the `showError()` function and replaced any instances of the function with the new `showToast()` function to ensure that there were no more mentions of the now old `showError()` function

## Checklist

- [X] My code follows the project’s style guidelines
- [X] I have tested my changes
- [X] I have updated documentation if needed
- [X] I have referenced the related issue
- [X] This PR is scoped, focused, and ready for review

> **Note:**  <br>PRs for issues **not** tagged as contributor‑friendly may be closed without review.