### PR TITLE
PR feat: Add vite build step to replace CDNs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,20 +6,46 @@ venv/
 __pycache__/
 *.pyc
 
+
+# Node / npm / Vite
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.pnpm-store/
+
+# Vite build output 
+static/dist/
+dist/
+.vite/
+*.local
+
 # environment variables
 .env
 
-# OS junk
+# IDEs and Editors 
 .DS_Store
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+Thumbs.db
+*.code-workspace
 
-# flask
-instance/
 
-# logs
+# logs and temp 
 *.log
-
-# SQLite databases 
-*.db
+logs/
+tmp/
+temp/
+.coverage
+htmlcov/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
 
 # old graph files and graph making files
 *.tif
@@ -34,5 +60,3 @@ testing_stuff.py
 AGENTS.md
 
 .wiki/
-
-*.code-workspace

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,4 @@
-app.crestr.co.uk {
+http://localhost {
     reverse_proxy web-fastapi:5000
 }
 

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,4 @@
-http://localhost {
+app.crestr.co.uk {
     reverse_proxy web-fastapi:5000
 }
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,16 @@
-# Use official Python image
+# This builds the frontend 
+
+FROM node:22-slim AS frontend
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
 FROM python:3.11-slim-bookworm
 
-
-# Set working directory
 WORKDIR /app
 
 # copies the requirements for parsing the file of unrequired libraries
@@ -25,6 +33,9 @@ RUN mkdir -p /app/Pathfinding
 
 # this copies python backend 
 COPY src/ /app/src/
+
+# copies the built frontend assets
+COPY --from=frontend /app/static/dist /app/static/dist
 
 # this puts my js, html and css into the container 
 COPY templates/ templates/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1063 @@
+{
+  "name": "crestr-hiking-app",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "crestr-hiking-app",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "chart.js": "^4.5.1",
+        "driver.js": "^1.8.0",
+        "lucide": "^1.30.0",
+        "ol": "^10.10.0"
+      },
+      "devDependencies": {
+        "@fortawesome/fontawesome-free": "^7.3.1",
+        "vite": "^8.2.1"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.3.1.tgz",
+      "integrity": "sha512-wmglKKPDIkgV3aWlZzWECCPoGIkYCulzBwxG9+w7rc5BGapZ6cPMpoPOT8k36J0Ni7PPX6c/rsoMWfS4d1MUMg==",
+      "dev": true,
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@petamoriken/float16": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.3.tgz",
+      "integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/rbush": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz",
+      "integrity": "sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ==",
+      "license": "MIT"
+    },
+    "node_modules/@zarrita/storage": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.2.0.tgz",
+      "integrity": "sha512-855ZXqtnds7spnT8vNvD+MXa3QExP1m2GqShe8yt7uZXHnQLgJHgkpVwFjE1B0KDDRO0ki09hmk6OboTaIfPsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "reference-spec-reader": "^0.2.0",
+        "unzipit": "2.0.0"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/driver.js": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/driver.js/-/driver.js-1.8.0.tgz",
+      "integrity": "sha512-+8/IO7h1v14IzWh2GP60N7T3PFZweXwdn5e5POuxRSBoCYUojsBxzqawPeXh3YZIibRy7EehYNEyxe7slwwtdg==",
+      "license": "MIT"
+    },
+    "node_modules/earcut": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+      "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
+      "license": "ISC"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/geotiff": {
+      "version": "3.1.0-beta.0",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-3.1.0-beta.0.tgz",
+      "integrity": "sha512-wbVwOaQYuN+ywly5NoMXn37nHslwkQg5EFHqMeUTtjDACrSag0EEVlFsc+2DK3Pzmmp6XzJW2RTZOamPsBM6ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@petamoriken/float16": "^3.9.3",
+        "lerc": "^3.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "quick-lru": "^6.1.1",
+        "web-worker": "^1.5.0",
+        "xml-utils": "^1.10.2",
+        "zstddec": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=10.19"
+      }
+    },
+    "node_modules/lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lucide": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/lucide/-/lucide-1.30.0.tgz",
+      "integrity": "sha512-K6fsjKaZmzrvDATXHpKdRRNresG/z5/RnGK6OPJRoZ5Pu4A/OOJRFM/BlGpDsUeRZl12Hj3ULmXqz1qObs6x3A==",
+      "license": "ISC"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/numcodecs": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.3.2.tgz",
+      "integrity": "sha512-6YSPnmZgg0P87jnNhi3s+FVLOcIn3y+1CTIgUulA3IdASzK9fJM87sUFkpyA+be9GibGRaST2wCgkD+6U+fWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.8.0"
+      }
+    },
+    "node_modules/ol": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-10.10.0.tgz",
+      "integrity": "sha512-tLPKn6zl+6uWdPufYlqG/lQzuVUTVmfwahQqVr5+wZNyZecyAtIhMTyOtKpu7ooNDLY2sEjKZNXw9HL+sOjC1A==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/rbush": "4.0.0",
+        "earcut": "^3.0.0",
+        "geotiff": "^3.1.0-beta.0",
+        "pbf": "5.1.2",
+        "rbush": "^4.0.0",
+        "zarrita": "^0.7.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/openlayers"
+      }
+    },
+    "node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/parse-headers": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
+      "license": "MIT"
+    },
+    "node_modules/pbf": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-5.1.2.tgz",
+      "integrity": "sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
+    },
+    "node_modules/quick-lru": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
+    "node_modules/rbush": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
+      "integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^3.0.0"
+      }
+    },
+    "node_modules/reference-spec-reader": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/reference-spec-reader/-/reference-spec-reader-0.2.0.tgz",
+      "integrity": "sha512-q0mfCi5yZSSHXpCyxjgQeaORq3tvDsxDyzaadA/5+AbAUwRyRuuTh0aRQuE/vAOt/qzzxidJ5iDeu1cLHaNBlQ==",
+      "license": "MIT"
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.143.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.3",
+        "@rolldown/binding-darwin-arm64": "1.2.3",
+        "@rolldown/binding-darwin-x64": "1.2.3",
+        "@rolldown/binding-freebsd-x64": "1.2.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
+        "@rolldown/binding-linux-arm64-musl": "1.2.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-musl": "1.2.3",
+        "@rolldown/binding-openharmony-arm64": "1.2.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
+        "@rolldown/binding-win32-x64-msvc": "1.2.3"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/unzipit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-2.0.0.tgz",
+      "integrity": "sha512-DVeVIWUZCAQPNzm5sB0hpsG1GygTTdBnzNtYYEpInkttx5evkyqRgZi6rTczoySqp8hO5jHVKzrH0f23X8FZLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/xml-utils": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
+      "integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/zarrita": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.7.4.tgz",
+      "integrity": "sha512-NChufj86SceFj45z4CYjndmI98dphaG7hU8Wj0UGpMyT21o0V3HTY6zo87aSobYWts1tNFivSXzH2AR1AkaWjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@zarrita/storage": "^0.2.0",
+        "numcodecs": "^0.3.2"
+      }
+    },
+    "node_modules/zstddec": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.2.0.tgz",
+      "integrity": "sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==",
+      "license": "MIT AND BSD-3-Clause"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "crestr-hiking-app",
+  "version": "1.0.0",
+  "description": "[![GitHub stars](https://img.shields.io/github/stars/abdlfc11/Crest-Hiking-App?style=social)](https://github.com/abdlfc11/Crest-Hiking-App/stargazers) [![GitHub forks](https://img.shields.io/github/forks/abdlfc11/Crest-Hiking-App?style=social)](https://github.com/abdlfc11/Crest-Hiking-App/network/members) [![GitHub last commit](https://img.shields.io/github/last-commit/abdlfc11/Crest-Hiking-App)](https://github.com/abdlfc11/Crest-Hiking-App/commits/main) [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/abdlfc11/Crest-Hiking-App)](https://github.com/abdlfc11/Crest-Hiking-App/commits/main) [![GitHub release](https://img.shields.io/github/v/release/abdlfc11/Crest-Hiking-App)](https://github.com/abdlfc11/Crest-Hiking-App/releases) [![GitHub issues](https://img.shields.io/github/issues/abdlfc11/Crest-Hiking-App)](https://github.com/abdlfc11/Crest-Hiking-App/issues) [![GitHub pull requests](https://img.shields.io/github/issues-pr/abdlfc11/Crest-Hiking-App)](https://github.com/abdlfc11/Crest-Hiking-App/pulls)",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/abdlfc11/Crestr-Hiking-App.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/abdlfc11/Crestr-Hiking-App/issues"
+  },
+  "homepage": "https://github.com/abdlfc11/Crestr-Hiking-App#readme",
+  "dependencies": {
+    "chart.js": "^4.5.1",
+    "driver.js": "^1.8.0",
+    "lucide": "^1.30.0",
+    "ol": "^10.10.0"
+  },
+  "devDependencies": {
+    "@fortawesome/fontawesome-free": "^7.3.1",
+    "vite": "^8.2.1"
+  }
+}
+

--- a/src/fastapi_app.py
+++ b/src/fastapi_app.py
@@ -14,8 +14,6 @@ from fastapi.templating import Jinja2Templates
 from starlette.exceptions import HTTPException as StarletteHTTPException
 import traceback
 from sqlmodel import Session, select
-from pathlib import Path
-from functools import lru_cache
 
 # Local Module Imports
 from src.extensions import service, get_current_user, log_action
@@ -63,30 +61,6 @@ templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
 #endregion
 
-@lru_cache
-def _load_manifest():
-    path = Path("static/dist/.vite/manifest.json")  # adjust if needed
-    if not path.exists():
-        return {}
-    return json.loads(path.read_text())
-
-def vite_asset(entry: str, asset_type: str = "js") -> str:
-    """
-    entry: 'map' (the name you give in rollupOptions.input)
-    asset_type: 'js' or 'css'
-    """
-    manifest = _load_manifest()
-    # Vite manifest keys are usually the original source path or the entry name
-    key = next((k for k in manifest if k.endswith(f"{entry}.js") or k == entry), None)
-    if not key:
-        return ""  # or raise in production
-
-    info = manifest[key]
-    if asset_type == "css":
-        css_files = info.get("css", [])
-        return css_files[0] if css_files else ""
-    return info.get("file", "")
-
 #region JINJA TEMPLATES 
 
 def format_distance(
@@ -123,7 +97,6 @@ templates.env.filters["format_distance"] = format_distance
 templates.env.filters["format_elevation"] = format_elevation
 templates.env.filters["format_eta"] = format_eta
 templates.env.filters["strftime"] = strftime_filter
-templates.env.globals["vite_asset"] = vite_asset
 
 #endregion
 

--- a/src/fastapi_app.py
+++ b/src/fastapi_app.py
@@ -14,6 +14,8 @@ from fastapi.templating import Jinja2Templates
 from starlette.exceptions import HTTPException as StarletteHTTPException
 import traceback
 from sqlmodel import Session, select
+from pathlib import Path
+from functools import lru_cache
 
 # Local Module Imports
 from src.extensions import service, get_current_user, log_action
@@ -61,6 +63,30 @@ templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
 
 #endregion
 
+@lru_cache
+def _load_manifest():
+    path = Path("static/dist/.vite/manifest.json")  # adjust if needed
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text())
+
+def vite_asset(entry: str, asset_type: str = "js") -> str:
+    """
+    entry: 'map' (the name you give in rollupOptions.input)
+    asset_type: 'js' or 'css'
+    """
+    manifest = _load_manifest()
+    # Vite manifest keys are usually the original source path or the entry name
+    key = next((k for k in manifest if k.endswith(f"{entry}.js") or k == entry), None)
+    if not key:
+        return ""  # or raise in production
+
+    info = manifest[key]
+    if asset_type == "css":
+        css_files = info.get("css", [])
+        return css_files[0] if css_files else ""
+    return info.get("file", "")
+
 #region JINJA TEMPLATES 
 
 def format_distance(
@@ -97,6 +123,7 @@ templates.env.filters["format_distance"] = format_distance
 templates.env.filters["format_elevation"] = format_elevation
 templates.env.filters["format_eta"] = format_eta
 templates.env.filters["strftime"] = strftime_filter
+templates.env.globals["vite_asset"] = vite_asset
 
 #endregion
 

--- a/static/css/base/reset.css
+++ b/static/css/base/reset.css
@@ -13,6 +13,13 @@ body {
   overflow: hidden;
 }
 
+/* this disables interaction with the entire app during the tour */
+body.tour-active, 
+body.tour-active * {
+  pointer-events: none !important;
+  cursor: default !important;
+}
+
 /* Overriding browser autofill colour */
 input:-webkit-autofill {
   -webkit-box-shadow: 0 0 0px 1000px white inset !important;

--- a/static/css/pages/map.css
+++ b/static/css/pages/map.css
@@ -246,11 +246,6 @@
   border: 1px solid #e2e8f0;
 }
 
-.ol-control {
-  right: 8px;
-  left: auto;
-}
-
 /* SAVE / LOAD ROUTE PANEL */
 
 #save-route-container {

--- a/static/css/vendor/tours.css
+++ b/static/css/vendor/tours.css
@@ -12,13 +12,19 @@
   --tour-shadow: 0 10px 30px rgba(16, 24, 40, 0.14), 0 2px 6px rgba(16, 24, 40, 0.08);
 }
 
+/* this ensures that interaction is allowed for DriverJS popover controls */
+body.tour-active .driver-popover,
+body.tour-active .driver-popover * {
+  pointer-events: auto !important;
+}
+
 /* Popover wrapper */
 .driver-popover.app-tour-theme {
-  background: #ffffff;
-  color: var(--tour-text-dark);
-  border-radius: var(--tour-radius);
-  border: 1px solid var(--tour-border);
-  box-shadow: var(--tour-shadow);
+  background: var(--bg);
+  color: var(--ink);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-surface);
   padding: 20px 22px;
   max-width: 340px;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -26,42 +32,42 @@
 
 /* Arrows */
 .app-tour-theme .driver-popover-arrow-side-left.driver-popover-arrow {
-  border-left-color: #ffffff;
+  border-left-color: var(--bg);
 }
 .app-tour-theme .driver-popover-arrow-side-right.driver-popover-arrow {
-  border-right-color: #ffffff;
+  border-right-color: var(--bg);
 }
 .app-tour-theme .driver-popover-arrow-side-top.driver-popover-arrow {
-  border-top-color: #ffffff;
+  border-top-color: var(--bg);
 }
 .app-tour-theme .driver-popover-arrow-side-bottom.driver-popover-arrow {
-  border-bottom-color: #ffffff;
+  border-bottom-color: var(--bg);
 }
 
 /* Title + Description */
 .app-tour-theme .driver-popover-title {
   font-size: 17px;
   font-weight: 700;
-  color: var(--tour-text-dark);
+  color: var(--ink);
   margin-bottom: 6px;
 }
 
 .app-tour-theme .driver-popover-description {
   font-size: 14px;
   line-height: 1.5;
-  color: var(--tour-text-gray);
+  color: var(--muted);
 }
 
 /* Close button */
 .app-tour-theme .driver-popover-close-btn {
-  color: var(--tour-text-gray);
+  color: var(--ink) !important;
   font-size: 16px;
   top: 16px;
   right: 16px;
   transition: all .15s ease-in-out;
 }
 .app-tour-theme .driver-popover-close-btn:hover {
-  color: var(--tour-text-red);
+  color: var(--error-accent) !important;
   transform: translateY(-1.5px);
 }
 
@@ -71,15 +77,15 @@
 }
 
 .app-tour-theme .driver-popover-progress-text {
-  color: var(--tour-text-gray);
+  color: var(--muted);
   font-size: 12px;
   font-weight: 500;
 }
 
 /* Buttons */
 .app-tour-theme .driver-popover-footer-btn {
-  background: var(--tour-blue);
-  color: #ffffff;
+  background: var(--blue);
+  color: var(--ink);
   border: none;
   border-radius: 10px;
   padding: 9px 18px;
@@ -91,33 +97,28 @@
 }
 
 .app-tour-theme .driver-popover-footer-btn:hover {
-  background: var(--tour-blue-hover);
+  background: var(--blue-dark);
   transform: translateY(-1px);
 }
 
 /* Previous buttons */
 .app-tour-theme .driver-popover-prev-btn {
-  background: #f3f4f6;
-  color: var(--tour-text-dark);
+  background:var(--btn-bg);
+  color: var(--ink);
 }
 .app-tour-theme .driver-popover-prev-btn:hover {
-  background: #e5e7eb;
+  background: var(--btn-bg-hover);
 }
 
 /* Makes done button slightly darker blue */
 .app-tour-theme .driver-popover-next-btn.driver-popover-done-btn {
-  background: var(--tour-blue-hover);
+  background: var(--blue);
 }
 .app-tour-theme .driver-popover-next-btn.driver-popover-done-btn:hover {
-  background: #1e40af;
+  background: var(--blue-dark);
 }
 
 /* Highlighted element */
 .driver-active-element {
-  border-radius: 10px;
-}
-
-/* Adds subtle blue glow */
-.driver-active-element.driver-no-interaction {
-  box-shadow: 0 0 0 4px var(--tour-blue-light), 0 0 0 1px var(--tour-blue);
+  border-radius: var(--radius-md);
 }

--- a/static/js/elevationChart.js
+++ b/static/js/elevationChart.js
@@ -2,6 +2,10 @@ import { normaliseCoordLength, getCurrentPathData } from './routes/routeState.js
 import { getRouteLayer } from './map.js';
 import { getTheme, getDistanceUnit } from './settingsState.js';
 import { createManualPointStyle } from './utils/style-utils.js';
+import { fromLonLat, toLonLat } from 'ol/proj.js';
+import { Feature } from 'ol';
+import { Point } from 'ol/geom.js';
+import { getDistance } from 'ol/sphere.js'
 
 /**
  * Returns true if the coord is in EPSG:4326 projection and false otherwise
@@ -46,12 +50,12 @@ function updateMapHoverPoint(coordinate) {
   // converts coordinates into web mercator to display the point feature on the map (which has projection of Web Mercator)
   let coord = [coordinate[0], coordinate[1]];
   if (isLonLatCoord(coord)) {
-    coord = ol.proj.fromLonLat(coord);
+    coord = fromLonLat(coord);
   }
 
   if (!hoverPointFeature) {
-    hoverPointFeature = new ol.Feature({
-      geometry: new ol.geom.Point(coord)
+    hoverPointFeature = new Feature({
+      geometry: new Point(coord)
     });
 
     hoverPointFeature.setStyle(createManualPointStyle("", "#FFFFFF", 7.5, "#0a45e7"));
@@ -132,7 +136,7 @@ export function createElevationProfile(coordinates) {
         if (isLonLatCoord(coord)) {
           lonLat = [coord[0], coord[1]];
         } else {
-          lonLat = ol.proj.toLonLat([coord[0], coord[1]]);
+          lonLat = toLonLat([coord[0], coord[1]]);
         }
         return [lonLat[0], lonLat[1], coord[2] || 0];
     });
@@ -150,7 +154,7 @@ export function createElevationProfile(coordinates) {
         const p2 = geoCoordinates[i];
 
          
-        const segmentMeters = ol.sphere.getDistance([p1[0], p1[1]], [p2[0], p2[1]]);
+        const segmentMeters = getDistance([p1[0], p1[1]], [p2[0], p2[1]]);
         const segmentKm = segmentMeters / 1000;
 
         if (distanceUnit === "miles") {

--- a/static/js/elevationChart.js
+++ b/static/js/elevationChart.js
@@ -1,11 +1,17 @@
+// Local Imports 
 import { normaliseCoordLength, getCurrentPathData } from './routes/routeState.js';
 import { getRouteLayer } from './map.js';
 import { getTheme, getDistanceUnit } from './settingsState.js';
 import { createManualPointStyle } from './utils/style-utils.js';
+
+// OpenLayers imports 
 import { fromLonLat, toLonLat } from 'ol/proj.js';
 import { Feature } from 'ol';
 import { Point } from 'ol/geom.js';
 import { getDistance } from 'ol/sphere.js'
+
+// Chart.js imports 
+import Chart from 'chart.js/auto';
 
 /**
  * Returns true if the coord is in EPSG:4326 projection and false otherwise
@@ -81,9 +87,13 @@ function clearMapHoverPoint() {
 };
 
 export function resetElevationChart() {
+    const ctx = document.getElementById('elevation-chart');
+    
+    // this destroys the chart via reference or via Chart.js canvas registry
+    const existingChart = elevationChart || (ctx ? Chart.getChart(ctx) : null);
 
-    if (elevationChart) {
-        elevationChart.destroy();
+    if (existingChart) {
+        existingChart.destroy();
         elevationChart = null;
     }
     currentCoordinates = null;
@@ -177,8 +187,8 @@ export function createElevationProfile(coordinates) {
 
     const text = isDark ? "#ffffff" : "#1f2937";
     const grid = isDark ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.08)";
-    const border = isDark ? "#2563eb" : "#1d4ed8";
-    const fill = isDark ? "rgba(37,99,235,0.25)" : "rgba(37,99,235,0.15)";
+    const border = isDark ? '#60a5fa' : '#1d4ed8';
+    const fill = isDark ? 'rgba(96, 165, 250, 0.2)' : 'rgba(29, 78, 216, 0.12)';
     
     const white = '#FFFFFF'
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -21,9 +21,34 @@ import VectorSource from "ol/source/Vector.js";
 import Style from "ol/style/Style.js";
 import Stroke from "ol/style/Stroke.js";
 
+// Lucide Icons
+import {
+  createIcons,
+  RotateCcw,
+  ChevronDown,
+  Waypoints,
+  Import,
+  Settings,
+  Bug,
+  Heart
+} from 'lucide';
+
 export let map = null;
 export let tileLayer = null;
 export let routeLayer = null;
+
+// Icon initialisation
+createIcons({
+  icons: {
+    RotateCcw,
+    ChevronDown,
+    Waypoints,
+    Import,
+    Settings,
+    Bug,
+    Heart
+  }
+});
 
 let mapInitialised = false;
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -1,6 +1,25 @@
-import {
-  getRouteStrokeStyle
-} from "./utils/style-utils.js"
+import "ol/ol.css?inline"
+
+import { getRouteStrokeStyle } from "./utils/style-utils.js";
+
+// OpenLayers Core & Views
+import Map from "ol/Map.js";
+import View from "ol/View.js";
+import { defaults as defaultControls } from "ol/control.js";
+import { fromLonLat } from "ol/proj.js";
+
+// OpenLayers Layers
+import Tile from "ol/layer/Tile.js";
+import VectorLayer from "ol/layer/Vector.js";
+
+// OpenLayers Sources
+import OSM from "ol/source/OSM.js";
+import XYZ from "ol/source/XYZ.js";
+import VectorSource from "ol/source/Vector.js";
+
+// OpenLayers Styles
+import Style from "ol/style/Style.js";
+import Stroke from "ol/style/Stroke.js";
 
 export let map = null;
 export let tileLayer = null;
@@ -45,18 +64,18 @@ function createMap() {
   const initialCentreLatLon = Array.isArray(window.appConfig?.mapInitialCentre)
     ? window.appConfig.mapInitialCentre
     : [-3.198308, 54.465458];
-  const initialCentre = ol.proj.fromLonLat(initialCentreLatLon);
+  const initialCentre = fromLonLat(initialCentreLatLon);
   const initialZoom = window.appConfig?.mapInitialZoom ?? 10.5;
 
-  map = new ol.Map({
+  map = new Map({
     layers: [tileLayer],
     target: "map",
-    controls: ol.control.defaults.defaults({
+    controls: defaultControls({
       attributionOptions: {
         collapsible: false
       }
     }),
-    view: new ol.View({
+    view: new View({
       projection: "EPSG:3857",
       maxZoom: 17,
       minZoom: 0,
@@ -79,8 +98,8 @@ export function onMapRenderComplete(handler) {
 }
 
 export function createTileLayer() {
-  tileLayer = new ol.layer.Tile({
-    source: new ol.source.XYZ({
+  tileLayer = new Tile({
+    source: new XYZ({
       url: "https://{a-c}.tile.opentopomap.org/{z}/{x}/{y}.png",
       attributions: `
       <a href="/privacy-policy" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
@@ -96,10 +115,10 @@ export function createTileLayer() {
 }
 
 export function createRouteLayer() {
-  routeLayer = new ol.layer.Vector({
-    source: new ol.source.Vector(),
-    style: new ol.style.Style({
-      stroke: new ol.style.Stroke(getRouteStrokeStyle()),
+  routeLayer = new VectorLayer({
+    source: new VectorSource(),
+    style: new Style({
+      stroke: new Stroke(getRouteStrokeStyle()),
     }),
     zIndex: 999,
   });

--- a/static/js/routes/loadRoute.js
+++ b/static/js/routes/loadRoute.js
@@ -1,5 +1,15 @@
 import { getMap, getRouteLayer, getPathColour } from "../map.js";
 
+import GeoJSON from "ol/format/GeoJSON.js";
+import Stroke from "ol/style/Stroke.js";
+import Style from "ol/style/Style.js";
+import Point from "ol/geom/Point.js"
+import Feature from "ol/Feature.js"
+import {
+  toLonLat,
+  fromLonLat
+} from "ol/proj.js"
+
 import {
   formatDistance,
   formatElevation,
@@ -44,7 +54,7 @@ export function displayLoadedRouteOnMap(data) {
   const vectorSource = routeLayer.getSource();
   vectorSource.clear();
 
-  const format = new ol.format.GeoJSON();
+  const format = new GeoJSON();
   const features = format.readFeatures(data.pathGeoJSON, {
     dataProjection: "EPSG:4326",
     featureProjection: "EPSG:3857",
@@ -53,8 +63,8 @@ export function displayLoadedRouteOnMap(data) {
 
   features.forEach((feature) => {
     feature.setStyle(
-      new ol.style.Style({
-        stroke: new ol.style.Stroke(getRouteStrokeStyle()),
+      new Style({
+        stroke: new Stroke(getRouteStrokeStyle()),
       }),
     );
   });
@@ -65,16 +75,16 @@ export function displayLoadedRouteOnMap(data) {
   const endCoord = coordinates[coordinates.length - 1]
 
   // converts lon lat to Web Mercator to display features on OpenLayer map (which has Web Mercator projection) 
-  const startMercator = ol.proj.fromLonLat([startCoord[0], startCoord[1]]);
-  const endMercator = ol.proj.fromLonLat([endCoord[0], endCoord[1]]);
+  const startMercator = fromLonLat([startCoord[0], startCoord[1]]);
+  const endMercator = fromLonLat([endCoord[0], endCoord[1]]);
 
-  const startFeature = new ol.Feature({
-    geometry: new ol.geom.Point(startMercator)
+  const startFeature = new Feature({
+    geometry: new Point(startMercator)
   });
   startFeature.setStyle(getSavedPointStyle("Start", "#00A86B"));
 
-  const endFeature = new ol.Feature({
-    geometry: new ol.geom.Point(endMercator)
+  const endFeature = new Feature({
+    geometry: new Point(endMercator)
   });
   endFeature.setStyle(getSavedPointStyle("End", "#D32F2F"));
 

--- a/static/js/routes/saveRoute.js
+++ b/static/js/routes/saveRoute.js
@@ -34,6 +34,7 @@ import {
   formatElevation,
   formatETA
 } from "../utils/format-utils.js"
+import { toLonLat } from "ol/proj.js";
 
 let saveRouteForm = null;
 const allRoutesContainer = document.getElementById("all-routes-container");
@@ -83,7 +84,7 @@ function handleSaveRoute(e) {
     // manually plotted points converted to lon lat as they are stored in web mercator (auto / loaded routes aren't)
     if (mode === "manual" && manualRouteState.pathCoords.length > 0) {
       pathCoordinates = pathCoordinates.map(coord => {
-        const lonLat = ol.proj.toLonLat([coord[0], coord[1]]);
+        const lonLat = toLonLat([coord[0], coord[1]]);
         return coord.length >= 3 ? [lonLat[0], lonLat[1], coord[2]] : lonLat;
       });
     }

--- a/static/js/routing/routing.js
+++ b/static/js/routing/routing.js
@@ -16,6 +16,9 @@ import {
 } from '../ui.js'
 import { logError } from "../utils/logError-utils.js";
 
+import { fromLonLat, toLonLat } from "ol/proj.js";
+import { getDistance } from "ol/sphere.js";
+
 /**
  * Function used to calculate and return a path (and associated information) between two given points in projection EPSG: 4326 (Lon, Lat)
  * Specific to automatic routing
@@ -109,7 +112,7 @@ export async function addManualPoint(x, y) {
   const currentClick = [x, y];
 
   // The below code uses a more computationally expensive but much more accurate way of finding out if a point is in Cumbria
-  const lonLatCoords = ol.proj.toLonLat(currentClick);
+  const lonLatCoords = toLonLat(currentClick);
   const isInCumbria = isPointInPolygon(lonLatCoords, cumbriaBoundary);
   if (!isInCumbria) {
       return {"success": false, "message": "Please click on a point within Cumbria"};
@@ -135,9 +138,9 @@ export async function addManualPoint(x, y) {
     const thresholdDistance = 50;
 
     // lon lat used to calculate distance (Web Mercator projection has distortion risk over long distances)
-    const startLonLat = ol.proj.toLonLat(start);
-    const endLonLat = ol.proj.toLonLat(end);
-    const distance = ol.sphere.getDistance(startLonLat, endLonLat);
+    const startLonLat = toLonLat(start);
+    const endLonLat = toLonLat(end);
+    const distance = getDistance(startLonLat, endLonLat);
 
     // if points are close enough snap the final point to the first point
     if (distance < thresholdDistance) {
@@ -164,8 +167,8 @@ export async function addManualPoint(x, y) {
     // otherwise, it calculates it and adds it to the cache 
     else {
       // conversion to lon lat as the API expects coordinates in the form [Lon, Lat]
-      const lastLonLat = ol.proj.toLonLat(lastClickedPoint);
-      const finalLonLat = ol.proj.toLonLat(finalClick);
+      const lastLonLat = toLonLat(lastClickedPoint);
+      const finalLonLat = toLonLat(finalClick);
       const data = await getPathSegment(lastLonLat, finalLonLat);
 
       if (!data.success) {
@@ -180,8 +183,8 @@ export async function addManualPoint(x, y) {
       // conversion to Web Mercator as the API sends coords in the form: [Lon, Lat], whereas OpenLayers map is in Web Mercator projection
       segment = segment.map(coord =>
         coord.length >= 3
-          ? [...ol.proj.fromLonLat([coord[0], coord[1]]), coord[2]]
-          : ol.proj.fromLonLat([coord[0], coord[1]])
+          ? [...fromLonLat([coord[0], coord[1]]), coord[2]]
+          : fromLonLat([coord[0], coord[1]])
       );
 
       // this stores the segment in cache 

--- a/static/js/saved_points/savedPoints.js
+++ b/static/js/saved_points/savedPoints.js
@@ -3,6 +3,11 @@ import { getMap } from "../map.js";
 import { showLoginModal, showDeletePointModal } from "../ui.js";
 import { showToast } from "../utils/ui-utils.js";
 import { logError } from "../utils/logError-utils.js";
+import { fromLonLat, toLonLat } from "ol/proj.js";
+import { Feature } from "ol";
+import { Point } from "ol/geom.js";
+import VectorLayer from "ol/layer/Vector.js";
+import VectorSource from "ol/source/Vector.js";
 
 let savedPointsLayer = null;
 
@@ -23,17 +28,17 @@ function convertPointsToFeatures(data) {
     return data.points.map(point => {
 
         // converts to Web Mercator (API sends coords in [Lon, Lat] format)
-        const mercatorCoords = ol.proj.fromLonLat(point.coordinates);
-        return new ol.Feature({
-            geometry: new ol.geom.Point(mercatorCoords),
+        const mercatorCoords = fromLonLat(point.coordinates);
+        return new Feature({
+            geometry: new Point(mercatorCoords),
             name: point.name
         });
     });
 };
 
 function createSavedPointsLayer(features) {
-    return new ol.layer.Vector({
-        source: new ol.source.Vector({ features }),
+    return new VectorLayer({
+        source: new VectorSource({ features }),
         style: f => getSavedPointStyle(f.get("name")),
         zIndex: 1000
     });
@@ -98,7 +103,7 @@ export async function saveNewPoint(coordinate, name) {
   const lonLat =
     Math.abs(coordinate[0]) <= 180 && Math.abs(coordinate[1]) <= 90
       ? [coordinate[0], coordinate[1]]
-      : ol.proj.toLonLat([coordinate[0], coordinate[1]]);
+      : toLonLat([coordinate[0], coordinate[1]]);
 
   try {
 

--- a/static/js/saved_points/style.js
+++ b/static/js/saved_points/style.js
@@ -1,5 +1,11 @@
 //#region 
 
+import Fill from "ol/style/Fill"
+import Icon from "ol/style/Icon"
+import Stroke from "ol/style/Stroke"
+import Style from "ol/style/Style"
+import Text from "ol/style/Text"
+
 const UNSELECTED_FILL = "#11617c"
 const UNSELECTED_STROKE = "#FFFFFF"
 const UNSELECTED_TEXT_FONT = "bold 12px system-ui"
@@ -44,10 +50,10 @@ function createPinSvg(fillColor, strokeColor = "#FFFFFF") {
  * @returns {ol.style.Style} OpenLayers Style object for standard points
  */
 export function getSavedPointStyle(name, fill) {
-  return new ol.style.Style({
+  return new Style({
 
     // icon
-    image: new ol.style.Icon({
+    image: new Icon({
       src: createPinSvg(fill || UNSELECTED_FILL), 
 
       // anchor in order to place the icon above the point slightly rather than directly on-top of the point 
@@ -59,16 +65,16 @@ export function getSavedPointStyle(name, fill) {
     }),
 
     // text (name of point)
-    text: new ol.style.Text({
+    text: new Text({
       text: name,
       
       font: UNSELECTED_TEXT_FONT,
 
-      fill: new ol.style.Fill({
+      fill: new Fill({
         color: TEXT_FILL,
       }),
 
-      stroke: new ol.style.Stroke({
+      stroke: new Stroke({
         color: TEXT_STROKE,
         width: 3
       }),
@@ -84,10 +90,10 @@ export function getSavedPointStyle(name, fill) {
  * @returns {ol.style.Style} OpenLayers Style object for selected points
  */
 export function getSelectedPointStyle(name) {
-  return new ol.style.Style({
+  return new Style({
 
     // icon
-    image: new ol.style.Icon({
+    image: new Ico({
       src: createPinSvg(SELECTED_FILL), 
 
       // anchor in order to place the icon above the point slightly rather than directly on-top of the point 
@@ -99,16 +105,16 @@ export function getSelectedPointStyle(name) {
     }),
 
     // text (name of point)
-    text: new ol.style.Text({
+    text: new Text({
       text: name,
 
       font: SELECTED_TEXT_FONT,
 
-      fill: new ol.style.Fill({
+      fill: new Fill({
         color: TEXT_FILL,
       }),
 
-      stroke: new ol.style.Stroke({
+      stroke: new StrokeStroke({
         color: TEXT_STROKE,
         width: 3 
       }),

--- a/static/js/tours/tours.js
+++ b/static/js/tours/tours.js
@@ -1,4 +1,5 @@
-const driver = window.driver.js.driver;
+import { driver } from "driver.js";
+import "driver.js/dist/driver.css";
 
 /**
  * This function is responsible for creating and returning the tour for the manual routing mode 
@@ -95,6 +96,18 @@ export function createSavedRouteDashboardTour() {
 export function createAutomaticRoutingTour(onTourEnd) {
     return driver({
         popoverClass: 'app-tour-theme',
+        disableActiveInteraction: true,
+
+        // injects active class to body upon starting the tour
+        onInit: () => {
+            document.body.classList.add("tour-active");
+        },
+        
+        // 2. removes active class from body when the tour ends 
+        onDestroyStarted: () => {
+            document.body.classList.remove("tour-active");
+        },
+
         onDoneClick: async (element, step, options) => {
             options.driver.destroy();
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1,20 +1,12 @@
 //#region IMPORTS
 
 // Open Layers Imports
-
-import { 
-  toLonLat, 
-  fromLonLat
-} from "ol/proj.js";
-
+import { toLonLat, fromLonLat } from "ol/proj.js";
 import { Point, LineString } from "ol/geom.js"
 import VectorSource from "ol/source/Vector.js";
 import VectorLayer from "ol/layer/Vector.js";
 import Feature from "ol/Feature.js";
-
 import GeoJSON from "ol/format/GeoJSON.js"
-
-
 import { Translate } from "ol/interaction.js"
 
 // Local File Imports
@@ -1748,9 +1740,12 @@ function deselectSelectedPoint() {
 export function applyTheme(theme) {
   const effective = theme === "system" ? getTheme() : theme;
   document.documentElement.classList.toggle("dark", effective === "dark");
+
+  const currentCoordinates =  getCurrentMode() === "auto" ? getCurrentPathData() : manualRouteState.pathCoords
+
   resetElevationChart();
-  if (getCurrentPathData()) {
-    createElevationProfile(getCurrentPathData());
+  if (currentCoordinates) {
+    createElevationProfile(currentCoordinates);
     initChartToggleListener();
   };
 }

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1,5 +1,24 @@
 //#region IMPORTS
 
+// Open Layers Imports
+
+import { 
+  toLonLat, 
+  fromLonLat
+} from "ol/proj.js";
+
+import { Point, LineString } from "ol/geom.js"
+import VectorSource from "ol/source/Vector.js";
+import VectorLayer from "ol/layer/Vector.js";
+import Feature from "ol/Feature.js";
+
+import GeoJSON from "ol/format/GeoJSON.js"
+
+
+import { Translate } from "ol/interaction.js"
+
+// Local File Imports
+
 import {
   calculateEta,
   calculateTotalDistance,
@@ -18,13 +37,14 @@ import {
 } from "./utils/format-utils.js";
 
 import {
-  moveMapToPosition,
   showToast,
   addClickListener,
   removeDOMElement,
   createStatsPanel,
   parseCoordString
 } from "./utils/ui-utils.js";
+
+import { moveMapToPosition } from "./utils/map-utils.js";
 
 import { calculatePath, addManualPoint } from "./routing/index.js";
 
@@ -108,6 +128,9 @@ import {
 
 import { logout } from "./auth/auth.js";
 import { logError } from "./utils/logError-utils.js";
+import { Vector } from "ol/source.js";
+import Style from "ol/style/Style.js";
+import Stroke from "ol/style/Stroke.js";
 
 //#endregion
 
@@ -560,7 +583,7 @@ function setEndCoord() {
 function setCoordEntry(entry, event) {
   // event.coordinate is in Web Mercator
   // this means conversion to lat/lon is required for display
-  const lonLat = ol.proj.toLonLat(event.coordinate);
+  const lonLat = toLonLat(event.coordinate);
   entry.value = formatLatLon(lonLat, 6);
   entry.placeholder = "Coordinates";
   entry.classList.remove("input-error");
@@ -621,7 +644,7 @@ export function mapClickHandler(event) {
   map.forEachFeatureAtPixel(event.pixel, (feature, layer) => {
     if (
       layer === savedPointsLayer &&
-      feature.getGeometry() instanceof ol.geom.Point
+      feature.getGeometry() instanceof Point
     ) {
       newSelection = feature;
       featureClicked = true;
@@ -638,7 +661,7 @@ export function mapClickHandler(event) {
   } 
   else if (!featureClicked) {
     const coordinate = event.coordinate;
-    const lonLat = ol.proj.toLonLat(coordinate);
+    const lonLat = toLonLat(coordinate);
 
     // TO BE CHANGED TO CUSTOM MODAL 
     const pointName = prompt(
@@ -1020,7 +1043,7 @@ export function clearAutoRoute() {
   // this clears any other temporary vector layers (but leaves saved-points + interactive + route alone)
   map.getLayers().getArray().slice().forEach((layer) => {
     if (
-      layer instanceof ol.layer.Vector &&
+      layer instanceof VectorLayer &&
       layer !== getSavedPointsLayer() &&
       layer !== getRouteLayer() &&
       layer !== interactivePointLayer
@@ -1093,7 +1116,7 @@ export function homeButtonFunction() {
   // Keep: routeLayer, interactivePointLayer, saved-points layer
   map.getLayers().getArray().slice().forEach((layer) => {
     if (
-      layer instanceof ol.layer.Vector &&
+      layer instanceof VectorLayer &&
       layer !== getRouteLayer() &&
       layer !== interactivePointLayer &&
       layer !== getSavedPointsLayer()
@@ -1146,7 +1169,7 @@ function searchArea() {
       const view = map.getView();
 
       // this converts the received coordinates into web mercator (as search API sends coords in [lon, lat] format)
-      const searchCenter = ol.proj.fromLonLat(data.coordinates);
+      const searchCenter = fromLonLat(data.coordinates);
       if (view.getZoom() >= 7) {
         view.animate(
           { center: view.getCenter(), duration: 1000, zoom: 10 },
@@ -1229,7 +1252,7 @@ function displayPath(data) {
   // this clears the hovered point feature to prevent the preserving of stale OL point features
   setHoverPointFeature(null);
 
-  const pathFeature = new ol.format.GeoJSON().readFeature(data.pathGeoJSON, {
+  const pathFeature = new GeoJSON().readFeature(data.pathGeoJSON, {
     dataProjection: "EPSG:4326",
     featureProjection: "EPSG:3857",
   });
@@ -1244,8 +1267,8 @@ function displayPath(data) {
     const endCoord = coordinates[coordinates.length - 1];
 
     // this converts coordinates into Web Mercator format, as the backend sends the path back in [Lon, Lat] format (Web Mercator is the OpenLayers map projection)
-    const startMercatorCoord = ol.proj.fromLonLat([startCoord[0], startCoord[1]]);
-    const endMercatorCoord = ol.proj.fromLonLat([endCoord[0], endCoord[1]]);
+    const startMercatorCoord = fromLonLat([startCoord[0], startCoord[1]]);
+    const endMercatorCoord = fromLonLat([endCoord[0], endCoord[1]]);
 
     // this creates and then displays (by adding them to the interactivePointLayerSource) the start and end point features
     const startPointFeature = createPoint(startMercatorCoord, getSavedPointStyle("Start", "#00A86B"), "start", "Start")
@@ -1344,8 +1367,8 @@ export function updateManualRoute() {
   setLastKnownDistanceKm(totalDistanceKm);
 
   userClicks.forEach((point, index) => {
-    const feature = new ol.Feature({
-      geometry: new ol.geom.Point(point),
+    const feature = new Feature({
+      geometry: new Point(point),
       type: "point",
     });
     feature.set("index", index);
@@ -1354,15 +1377,15 @@ export function updateManualRoute() {
 
   if (pathCoords.length > 1) {
     features.push(
-      new ol.Feature({
-        geometry: new ol.geom.LineString(pathCoords),
+      new Feature({
+        geometry: new LineString(pathCoords),
         type: "line",
       }),
     );
   }
 
-  manualRouteLayer = new ol.layer.Vector({
-    source: new ol.source.Vector({ features }),
+  manualRouteLayer = new VectorLayer({
+    source: new VectorSource({ features }),
     style(feature) {
       const featureType = feature.get("type");
       if (featureType === "point") {
@@ -1378,8 +1401,8 @@ export function updateManualRoute() {
         if (isEnd) return getSavedPointStyle("End", "#D32F2F");
         return createManualPointStyle("", "#000", 6.5);
       }
-      return new ol.style.Style({
-        stroke: new ol.style.Stroke(getRouteStrokeStyle()),
+      return new Style({
+        stroke: new Stroke(getRouteStrokeStyle()),
       });
     },
   });
@@ -1557,7 +1580,7 @@ function toWebMercator(latLon) {
   if (!latLon || latLon.length < 2) return null;
 
   // OpenLayers expects [longitude, latitude]
-  return ol.proj.fromLonLat([latLon[1], latLon[0]]);
+  return fromLonLat([latLon[1], latLon[0]]);
 }
 
 /**
@@ -1580,7 +1603,7 @@ function handleCoordEntryChange(entry, type) {
   );
 
   // returning prematurely if the point is not in Cumbria 
-  if (!isPointInPolygon(ol.proj.toLonLat(mercatorCoords))) {
+  if (!isPointInPolygon(toLonLat(mercatorCoords))) {
     showToast("Please choose a point within Cumbria.")
     return;
   }
@@ -1641,8 +1664,8 @@ function addStartEndPoint(pointFeature, vectorLayer, type) {
  */
 export function createPoint(coordinates, style, type, label) {
 
-    const point = new ol.Feature({
-        geometry: new ol.geom.Point(coordinates)
+    const point = new Feature({
+        geometry: new Point(coordinates)
     });
 
     point.set("type", type);
@@ -1670,9 +1693,9 @@ export function setUpPointInteraction(layers) {
   }
 
   // this makes the OpenLayers interaction
-  interactivePointLayerInteraction = new ol.interaction.Translate({
+  interactivePointLayerInteraction = new Translate({
     layers: layers,
-    filter: (feature) => feature.getGeometry() instanceof ol.geom.Point // (only accounts for points)
+    filter: (feature) => feature.getGeometry() instanceof Point // (only accounts for points)
   });
   
   map.addInteraction(interactivePointLayerInteraction); 
@@ -1683,7 +1706,7 @@ export function setUpPointInteraction(layers) {
 
     const newCoordinates = movedFeature.getGeometry().getCoordinates();
     const pointType = movedFeature.get("type");
-    const newLonLatCoordinate = ol.proj.toLonLat(newCoordinates);
+    const newLonLatCoordinate = toLonLat(newCoordinates);
     const coordinateString = formatLatLon(newLonLatCoordinate, 6);
 
     // this updates the correct input
@@ -1826,8 +1849,8 @@ function handleKeyboardShortcuts(e) {
 //#region EVENT LISTENERS / INIT
 
 function initInteractivePointLayer(map) {
-  interactivePointLayer = new ol.layer.Vector({
-    source: new ol.source.Vector(),
+  interactivePointLayer = new VectorLayer({
+    source: new VectorSource(),
     zIndex: 1100 // above the route layer + saved points layer 
   });
 

--- a/static/js/utils/map-utils.js
+++ b/static/js/utils/map-utils.js
@@ -1,0 +1,40 @@
+/**
+ * This file is intended to hold all OpenLayers map related helper functions
+ * As of August 2026 this file hold the following functions:
+ *      
+ *      - moveMapToPosition(map, position = null, duration = 1200, zoom = 10.5)
+ */
+
+import { fromLonLat } from "ol/proj";
+
+/**
+ * Function to move the map to a specific coordinate or the centre of the map via an animation
+ * 
+ * Position is expected in EPSG:4326 ( [Lon, Lat] )
+ * It is converted to Web Mercator before animating the map movement (OpenLayers map is in a Web Mercator projection)
+ * 
+ * @param {ol.Map} map OL map instance 
+ * @param {Array} position The specific coordinate to move the map to in [Lon, Lat] format, if not entered it defaults to the map centre  
+ * @param {number} duration How long the animation to move the map takes
+ * @param {number} zoom Zoom level used by open layers 
+ * @returns {void}
+ */
+export function moveMapToPosition(map, position = null, duration = 1200, zoom = 10.5) {
+  if (!map) {
+    console.warn("No map, returning");
+    return;
+  }
+
+  const targetLatLon = Array.isArray(position) && position.length === 2
+    ? position
+    : (Array.isArray(window.appConfig?.mapInitialCentre) ? window.appConfig.mapInitialCentre : [-3.198308, 54.465458]);
+
+  // this converts [Lon, Lat] coordinates into Web Mercator coordinates that the OpenLayers map can use 
+  const targetPosition = fromLonLat(targetLatLon);
+
+  map.getView().animate({
+    center: targetPosition,
+    zoom: zoom,
+    duration: duration
+  })
+};

--- a/static/js/utils/routing-utils.js
+++ b/static/js/utils/routing-utils.js
@@ -10,6 +10,9 @@
  *      - CalculateEta(distanceKm)
  */
 
+import { toLonLat } from "ol/proj.js";
+import { getDistance } from "ol/sphere.js"
+
 /**
  * Rounds coordinates to a specific decimal point 
  * 
@@ -120,9 +123,9 @@ export function formatLatLon(lonLat, decimals = 6) {
 export function calculateTotalDistance(points) {
   let totalDistance = 0;
   for (let i = 1; i < points.length; i++) {
-    const previous = ol.proj.toLonLat(points[i - 1]);
-    const current = ol.proj.toLonLat(points[i]);
-    totalDistance += ol.sphere.getDistance(previous, current)
+    const previous = toLonLat(points[i - 1]);
+    const current = toLonLat(points[i]);
+    totalDistance += getDistance(previous, current)
   }
   return totalDistance;
 }

--- a/static/js/utils/style-utils.js
+++ b/static/js/utils/style-utils.js
@@ -7,6 +7,11 @@
  * 
  */
 
+import Fill from "ol/style/Fill"
+import Stroke from "ol/style/Stroke"
+import Circle from "ol/style/Circle"
+import Style from "ol/style/Style"
+
 
 
 /**
@@ -18,24 +23,24 @@
  * @returns {Object} The styling to be applied to the point via OL
  */
 export function createManualPointStyle(label, colour, radius=7.5, strokeBorderColor="#FFFFFF") {
-  return new ol.style.Style({
-    image : new ol.style.Circle({
+  return new Style({
+    image : new Circle({
       radius : radius,
-      fill : new ol.style.Fill({
+      fill : new Fill({
         color : colour
       }),
-      stroke : new ol.style.Stroke({
+      stroke : new Stroke({
         color : strokeBorderColor,
         width : 3
       })
     }),
-    text : label ? new ol.style.Text({
+    text : label ? new Text({
       text : label,
       font : "bold 12px sans-serif",
-      fill : new ol.style.Fill({
+      fill : new Fill({
         color : "black"
       }),
-      stroke : new ol.style.Stroke({
+      stroke : new Stroke({
         color : strokeBorderColor,
         width : 3
       }),

--- a/static/js/utils/ui-utils.js
+++ b/static/js/utils/ui-utils.js
@@ -2,7 +2,6 @@
  * This file is intended to hold all UI related helper functions
  * As of August 2026 this file hold the following functions:
  *      
- *      - moveMapToPosition(map, position = null, duration = 1200, zoom = 10.5)
  *      - showToast(message, type = "error", modal = null)
  *      - addClickListener(element, func, type)
  *      - removeDOMElement(element)
@@ -10,7 +9,8 @@
  *      - createNoRouteCard()
  *      - createStatsPanel(distanceDisplay, etaDisplay, elevationGain)
  *      - parseCoordString(value)
- */      
+ */
+      
 
 
 
@@ -38,38 +38,6 @@ export function parseCoordString(value) {
 
   return [x, y];
 }
-
-/**
- * Function to move the map to a specific coordinate or the centre of the map via an animation
- * 
- * Position is expected in EPSG:4326 ( [Lon, Lat] )
- * It is converted to Web Mercator before animating the map movement (OpenLayers map is in a Web Mercator projection)
- * 
- * @param {ol.Map} map OL map instance 
- * @param {Array} position The specific coordinate to move the map to in [Lon, Lat] format, if not entered it defaults to the map centre  
- * @param {number} duration How long the animation to move the map takes
- * @param {number} zoom Zoom level used by open layers 
- * @returns {void}
- */
-export function moveMapToPosition(map, position = null, duration = 1200, zoom = 10.5) {
-  if (!map) {
-    console.warn("No map, returning");
-    return;
-  }
-
-  const targetLatLon = Array.isArray(position) && position.length === 2
-    ? position
-    : (Array.isArray(window.appConfig?.mapInitialCentre) ? window.appConfig.mapInitialCentre : [-3.198308, 54.465458]);
-
-  // this converts [Lon, Lat] coordinates into Web Mercator coordinates that the OpenLayers map can use 
-  const targetPosition = ol.proj.fromLonLat(targetLatLon);
-
-  map.getView().animate({
-    center: targetPosition,
-    zoom: zoom,
-    duration: duration
-  })
-};
 
 /**
  * Shows a toast notification 

--- a/templates/map.html
+++ b/templates/map.html
@@ -49,7 +49,6 @@
 
     <!-- ICONS -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-    <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
 
     <!-- Umami Analytics -->
     <!-- SELF HOSTERS: Change values in you .env file -->
@@ -615,8 +614,6 @@
     <script type="module" src="{{ url_for('static', path='dist/js/map.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='dist/js/savedRoutes.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='dist/js/importRoute.js') }}"></script>
-
-    <script>lucide.createIcons();</script>
 
 </body>
 </html>

--- a/templates/map.html
+++ b/templates/map.html
@@ -51,12 +51,6 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
 
-    <!-- Driver.js -->
-
-    
-    <!-- Chart.js -->
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js"></script>
-
     <!-- Umami Analytics -->
     <!-- SELF HOSTERS: Change values in you .env file -->
     <!-- Umami Analytics -->
@@ -618,7 +612,7 @@
     </script>
 
     <!-- Vite builds (asset paths resolved from the Vite build manifest) -->
-    <script type="module" src="{{ url_for('static', path='dist/' + vite_asset('map', 'js')) }}"></script>
+    <script type="module" src="{{ url_for('static', path='dist/js/map.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='dist/js/savedRoutes.js') }}"></script>
     <script type="module" src="{{ url_for('static', path='dist/js/importRoute.js') }}"></script>
 

--- a/templates/map.html
+++ b/templates/map.html
@@ -9,8 +9,12 @@
     <link rel="icon" href="https://images.crestr.co.uk/Crest-Logo.png" type="image/png">
 
     <!-- OpenLayers -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ol@v10.5.0/ol.css" />
-    <script src="https://cdn.jsdelivr.net/npm/ol@v10.5.0/dist/ol.js"></script>
+
+    <!-- Despite moving to using npm packages, the server-rendered html + vite caused issues in loading the ol.css file -->
+    <!-- so the choice has been made to load the css via cdn instead of via npm. -->
+    <!-- However, JS / TS is still loaded via npm packages. -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ol@v10.9.0/ol.css">
+
 
     <!-- #region CSS FILES -->
 
@@ -48,8 +52,7 @@
     <script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js"></script>
 
     <!-- Driver.js -->
-    <script src="https://cdn.jsdelivr.net/npm/driver.js@latest/dist/driver.js.iife.js"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/driver.js@latest/dist/driver.css"/>
+
     
     <!-- Chart.js -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js"></script>
@@ -614,9 +617,11 @@
         };
     </script>
 
-    <script type="module" src="{{ url_for('static', path='js/map.js') }}"></script>
-    <script type="module" src="{{ url_for('static', path='js/routes/savedRoutesDashboard.js') }}"></script>
-    <script type="module" src="{{ url_for('static', path='js/importRoute.js') }}"></script>
+    <!-- Vite builds (asset paths resolved from the Vite build manifest) -->
+    <script type="module" src="{{ url_for('static', path='dist/' + vite_asset('map', 'js')) }}"></script>
+    <script type="module" src="{{ url_for('static', path='dist/js/savedRoutes.js') }}"></script>
+    <script type="module" src="{{ url_for('static', path='dist/js/importRoute.js') }}"></script>
+
     <script>lucide.createIcons();</script>
 
 </body>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,25 @@
+import { defineConfig } from "vite";
+import { resolve } from "path";
+
+export default defineConfig({
+  base: "/static/dist/",
+
+  build: {
+    outDir: "static/dist",
+    emptyOutDir: true,
+    manifest: true,
+
+    rollupOptions: {
+      input: {
+        map: resolve(__dirname, "static/js/map.js"),
+        savedRoutes: resolve(__dirname, "static/js/routes/savedRoutesDashboard.js"),
+        importRoute: resolve(__dirname, "static/js/importRoute.js"),
+      },
+      output: {
+        entryFileNames: "js/[name].js",
+        chunkFileNames: "js/[name]-[hash].js",
+        assetFileNames: "assets/[name]-[hash][extname]",
+      },
+    },
+  },
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
     emptyOutDir: true,
     manifest: true,
 
-    rollupOptions: {
+    rolldownOptions: {
       input: {
         map: resolve(__dirname, "static/js/map.js"),
         savedRoutes: resolve(__dirname, "static/js/routes/savedRoutesDashboard.js"),


### PR DESCRIPTION
# Pull Request: Migrate CDN dependencies to npm packages + misc fixes

## Summary
Converts Crestr's frontend dependencies (OpenLayers, Driver.js, Chart.js, Lucide) from CDN-hosted scripts to npm packages for better version control, offline builds, and bundling with Vite. Also includes a fix for the elevation profile chart breaking on theme change in manual routing mode, and a couple of small chores (removing an unused FastAPI route, updating a deprecated Vite config option).

## Related Issue
closes ABD-24

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor
- [x] Other (dependency migration + config cleanup)

## Description of Changes
- **OpenLayers**: converted from CDN `<script>` include to npm package import.
- **Driver.js**: converted from CDN to npm package.
- **Chart.js**: replaced CDN include with npm package; updated dark mode colours to match the new import setup.
- **Lucide**: converted CDN icons to the npm package.
- **Elevation profile chart fix**: fixed a bug where changing the theme while in manual routing mode broke the elevation profile chart rendering.
- **Removed unused `vite_asset` FastAPI route**: no longer needed now that CDN assets are bundled via npm/Vite instead of served through a custom backend route.
- **Vite config**: updated the deprecated `rollUpOptions` key to `rollDownOptions` (naming per current Vite/Rollup API).

Overall, this removes Crestr's reliance on external CDNs for core frontend libraries, making builds more reproducible and reducing runtime dependency on third-party CDN uptime.

## Screenshots / Visuals (if applicable)

### Elevation Profile Before 
<img width="1470" height="832" alt="image" src="https://github.com/user-attachments/assets/a1666dd6-1990-4e5f-87ae-3b086d171862" />


### Elevation Profile After
<img width="1470" height="833" alt="image" src="https://github.com/user-attachments/assets/76f0071e-1fb0-4f1a-9741-a8b598104761" />



## Testing
- Verified local dev build (`npm run dev`) and production build (`npm run build`) succeed with all four libraries loaded via npm instead of CDN.
- Manually tested manual routing mode: toggled dark/light theme and confirmed the elevation profile chart re-renders correctly without breaking.
- Confirmed removal of the `vite_asset` route doesn't break asset loading in production (Caddy/Docker Compose setup).
- Confirmed Vite build no longer emits a deprecation warning after the `rollUpOptions` → `rollDownOptions` rename.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have tested my changes
- [x] I have updated documentation if needed
- [x] I have referenced the related issue
- [x] This PR is scoped, focused, and ready for review

> **Note:**
> PRs for issues **not** tagged as contributor‑friendly may be closed without review.