### PR TITLE
PR feat: Replace the nav rail with one that is always present and expands automatically on hover

### DIFF
--- a/static/css/layout/nav-menu.css
+++ b/static/css/layout/nav-menu.css
@@ -1,137 +1,155 @@
-/* 
-  SLIDE-IN NAVIGATION MENU (sidenav)
+/* NAVIGATION RAIL (sidenav)
 
-  This is the main app's hamburger/side nav 
+  A persistent, compact navigation rail that is always visible (on desktop) and
+  expands on pointer hover / keyboard focus to reveal its labels.
 
   Distinct from the report-issue.css #navbar (a top navbar used on marketing/utility pages).
-
 */
 
+:root {
+  --nav-width-collapsed: 48px;
+  --nav-width-expanded: 200px;
+  --nav-border: 1px solid rgba(0, 0, 0, 0.08);
+  --nav-transition: width 0.22s ease;
+
+  --nav-link-transition: background-color 0.15s ease, color 0.15s ease;
+  --nav-link-height: 44px;
+  --nav-link-height-compact: 40px;
+  --nav-link-padding: 0 8px;
+  --nav-link-margin: 8px 8px;
+  --nav-link-gap: 12px;
+  --nav-link-radius: 8px;
+
+  --nav-font-size: 18px;
+  --nav-font-weight: 500;
+  --nav-icon-size: 22px;
+
+  --nav-link-colour: #818181;
+  --nav-link-hover-colour: #000000;
+  --nav-link-hover-bg: #d1d5db;
+}
+
+html.dark {
+  --nav-border: 1px solid rgba(255, 255, 255, 0.12);
+
+  --nav-link-colour: #9ca3af;
+  --nav-link-hover-colour: #f3f4f6;
+  --nav-link-hover-bg: rgba(255, 255, 255, 0.08);
+}
+
+/* The rail itself */
 .sidenav {
   height: 100%;
-  width: 0;
+  width: var(--nav-width-collapsed);
   position: fixed;
   z-index: 1000;
   top: 0;
   left: 0;
-  overflow-x: hidden;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
-  transition: width 0.3s ease-in-out;
-  background: var(--bg);
+  transition: var(--nav-transition);
+  backdrop-filter: blur(30px);
+  -webkit-backdrop-filter: blur(30px);
+  border-right: var(--nav-border);
+  background: var(--glass-bg);
   border-right: 1px solid var(--border);
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
 }
 
-/* inner wrapper holds all content at a fixed width */
+/* Ensures that the sidenav is expanded whenever the it is hovered over or one of the inner links are focused on */
+.sidenav:hover,
+.sidenav:focus-within {
+  width: var(--nav-width-expanded);
+}
+
+/* Inner Wrapper */
 .sidenav-inner {
-  width: 17rem; 
+  width: var(--nav-width-expanded);
   height: 100%;
-  padding-top: 60px;
+  display: flex;
+  flex-direction: column;
+  padding-top: 16px;
+}
+
+/* A container for the sidenav links */
+.sidenav-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: flex;
   flex-direction: column;
 }
 
-.sidenav a {
-  padding: 8px 8px 8px 32px;
-  text-decoration: none;
-  font-size: 1.6rem;
-  color: #818181;
-  margin-bottom: 1.5rem;
+/* row styling which is shared between links and buttons */
+.sidenav-link {
   display: flex;
-  flex-direction: row;
-  gap: 0.5rem;
-  transition: 0.3s;
-  width: max-content;
-  cursor: pointer;
-}
-
-.sidenav a:not(.closebtn) {
-  padding: 10px 32px 10px 32px;
-  border-radius: 28px;
-  text-align: center;
-  margin-left: 1rem;
-}
-
-.sidenav a:hover {
-  color: #000000;
-  background-color: #d1d5db;
-}
-
-.sidenav a i {
-  justify-content: center;
   align-items: center;
-  width: 1em;
-  height: 1em;
-}
-
-.sidenav .closebtn {
-  position: absolute;
-  top: 8px;
-  right: 16px;
-  font-size: 32px;
-  padding: 6px 10px;
-  width: auto;
-  margin: 0;
-  color: #818181;
+  gap: var(--nav-link-gap);
+  height: var(--nav-link-height);
+  padding: var(--nav-link-padding);
+  margin: var(--nav-link-margin);
+  border-radius: var(--nav-link-radius);
+  text-decoration: none;
+  color: var(--nav-link-colour);
+  font-size: var(--nav-font-size);
   line-height: 1;
-  transition: color 0.2s ease, transform 0.1s ease, background-color 0.2s ease;
+  white-space: nowrap;
   cursor: pointer;
-  border-radius: 6px;
+  transition: var(--nav-link-transition);
 }
 
-.sidenav .closebtn:hover {
-  color: #000000;
-  transform: scale(1.05);
+.sidenav-link:hover {
+  color: var(--nav-link-hover-colour);
+  background-color: var(--nav-link-hover-bg);
 }
 
-#sidenav-login-logout-button-container {
+.sidenav-link:focus-visible {
+  outline: 2px solid var(--blue, #3b82f6);
+  outline-offset: 2px;
+}
+
+/* Icon sizing + styling */
+.sidenav-link svg {
+  width: var(--nav-icon-size);
+  height: var(--nav-icon-size);
+  flex-shrink: 0;
+}
+
+/* link text (i.e 'saved routes') styling */
+.sidenav-link .nav-label {
+  font-size: var(--nav-font-size);
+  font-weight: var(--nav-font-weight);
+  color: inherit;
+}
+
+/* Auth button container (placed at the bottom of the sidenav) */
+.sidenav-auth {
   margin-top: auto;
-  padding-bottom: 1.5rem;
+  padding: 12px 0 16px;
   flex-shrink: 0;
   display: flex;
-  justify-content: center;
-  align-items: center;
   flex-direction: column;
 }
 
-.sidenav-login-logout-button {
-  font-size: 1.1rem;
+/* login / logout buttons */
+.sidenav-auth-button {
+  border: none;
+  background: transparent;
+  font-family: inherit;
 }
 
+/* donate button - currently disabled, only opens when there is a full release  */
 #donate-button {
   cursor: not-allowed;
 }
 
-/* Nav limits for smaller devices / short viewports */
+/* Nav limits for short viewports */
 @media screen and (max-height: 450px) {
-  .sidenav {
-    padding-top: 15px;
+  .sidenav-inner {
+    padding-top: 8px;
   }
-  .sidenav a {
-    font-size: 18px;
+  .sidenav-link {
+    height: var(--nav-link-height-compact);
   }
-}
-
-/* DARK MODE */
-
-html.dark .sidenav a {
-  color: #9ca3af;
-}
-
-html.dark .sidenav a:hover:not(.closebtn) {
-  color: #f3f4f6;
-  background-color: rgba(255, 255, 255, 0.08);
-}
-
-html.dark .closebtn {
-  color: #9ca3af;
-  padding: 6px 10px;
-  transition: color 0.2s ease, transform 0.1s ease, background-color 0.2s ease;
-}
-
-html.dark .closebtn:hover {
-  color: #f3f4f6;
-  background-color: rgba(255, 255, 255, 0.12);
-  transform: scale(1.05);
 }

--- a/static/css/layout/navbar.css
+++ b/static/css/layout/navbar.css
@@ -3,7 +3,7 @@
 
   Extracted from report-issue.css  
   
-  Distinct from layout/nav-menu.css (the slide-in hamburger sidenav used on the map page)
+  Distinct from layout/nav-menu.css (the expandable navigation rail used on the map page)
   
   This is the sticky top bar used on utility pages like 'Report an Issue'.
 */

--- a/static/css/pages/map.css
+++ b/static/css/pages/map.css
@@ -35,7 +35,7 @@
 #mode-toggle {
   position: absolute;
   top: 5px;
-  left: 10px;
+  left: 70px;
   z-index: 900;
   background: rgb(255 255 255 / 0.65);
   backdrop-filter: blur(10px);
@@ -83,7 +83,7 @@
 #start-end {
   position: absolute;
   top: 60px;
-  left: 10px;
+  left: 70px;
   z-index: 1000;
   background: rgb(255 255 255 / 0.65);
   backdrop-filter: blur(10px);
@@ -230,7 +230,7 @@
 #manual-mode-content {
   position: absolute;
   top: 60px;
-  left: 10px;
+  left: 70px;
   z-index: 1000;
   background: rgb(255 255 255 / 0.65);
   backdrop-filter: blur(10px);

--- a/static/css/pages/stats-panel.css
+++ b/static/css/pages/stats-panel.css
@@ -6,7 +6,7 @@
 #route-stats {
     position: absolute;
     bottom: 20px;
-    left: 20px;
+    left: 70px;
     z-index: 2;
     background: rgb(255 255 255 / 0.65);
     backdrop-filter: blur(10px);

--- a/static/css/vendor/tours.css
+++ b/static/css/vendor/tours.css
@@ -1,15 +1,7 @@
 /* CUSTOM THEME FOR DRIVER.JS TOURS */
 
 :root {
-  --tour-blue: #2563eb;
-  --tour-blue-hover: #1d4ed8;
-  --tour-blue-light: #eaf0ff;
-  --tour-text-dark: #16181d;
-  --tour-text-gray: #6b7280;
-  --tour-text-red: red;
-  --tour-border: #e5e7eb;
-  --tour-radius: 14px;
-  --tour-shadow: 0 10px 30px rgba(16, 24, 40, 0.14), 0 2px 6px rgba(16, 24, 40, 0.08);
+  --tour-ink: #FFFFFF;
 }
 
 /* this ensures that interaction is allowed for DriverJS popover controls */
@@ -21,7 +13,7 @@ body.tour-active .driver-popover * {
 /* Popover wrapper */
 .driver-popover.app-tour-theme {
   background: var(--bg);
-  color: var(--ink);
+  color: var(--tour-ink);
   border-radius: var(--radius-md);
   border: 1px solid var(--border);
   box-shadow: var(--shadow-surface);
@@ -48,7 +40,7 @@ body.tour-active .driver-popover * {
 .app-tour-theme .driver-popover-title {
   font-size: 17px;
   font-weight: 700;
-  color: var(--ink);
+  color: var(--tour-ink);
   margin-bottom: 6px;
 }
 
@@ -60,7 +52,7 @@ body.tour-active .driver-popover * {
 
 /* Close button */
 .app-tour-theme .driver-popover-close-btn {
-  color: var(--ink) !important;
+  color: var(--tour-ink) !important;
   font-size: 16px;
   top: 16px;
   right: 16px;
@@ -85,7 +77,7 @@ body.tour-active .driver-popover * {
 /* Buttons */
 .app-tour-theme .driver-popover-footer-btn {
   background: var(--blue);
-  color: var(--ink);
+  color: var(--tour-ink);
   border: none;
   border-radius: 10px;
   padding: 9px 18px;
@@ -104,7 +96,7 @@ body.tour-active .driver-popover * {
 /* Previous buttons */
 .app-tour-theme .driver-popover-prev-btn {
   background:var(--btn-bg);
-  color: var(--ink);
+  color: var(--tour-ink);
 }
 .app-tour-theme .driver-popover-prev-btn:hover {
   background: var(--btn-bg-hover);

--- a/static/js/routes/savedRoutesDashboard.js
+++ b/static/js/routes/savedRoutesDashboard.js
@@ -5,7 +5,7 @@
 
 import { deleteRoute, downloadRoute, loadRoute } from "./routeApi.js";
 
-import { closeNav, closeSavedRoutesDash,  } from "../ui.js"
+import { closeSavedRoutesDash } from "../ui.js"
 
 import { displayLoadedRouteOnMap } from "./loadRoute.js";
 
@@ -62,7 +62,6 @@ async function onLoadClick(event) {
 
   try {
     await closeSavedRoutesDash();
-    await closeNav();
     const data = await loadRoute(route.routeName);
     await displayLoadedRouteOnMap(data);
     await initChartToggleListener();

--- a/static/js/tours/tours.js
+++ b/static/js/tours/tours.js
@@ -96,14 +96,13 @@ export function createSavedRouteDashboardTour() {
 export function createAutomaticRoutingTour(onTourEnd) {
     return driver({
         popoverClass: 'app-tour-theme',
-        disableActiveInteraction: true,
 
         // injects active class to body upon starting the tour
         onInit: () => {
             document.body.classList.add("tour-active");
         },
         
-        // 2. removes active class from body when the tour ends 
+        // this removes active class from body when the tour ends 
         onDestroyStarted: () => {
             document.body.classList.remove("tour-active");
         },
@@ -123,10 +122,10 @@ export function createAutomaticRoutingTour(onTourEnd) {
             }
             },
             {
-            element: '#auto-open-nav-button',
+            element: '#the-sidenav',
             popover: {
-                title: 'The Menu',
-                description: 'Pressing this button will let you navigate between settings, importing routes and your saved routes dashboard.'
+                title: 'Navigation',
+                description: 'Use the navigation rail on the left to open settings, import routes and access your saved routes dashboard. It expands when you hover over it.'
             }
             },
             {

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -141,10 +141,6 @@ const setEndCoordButton = document.getElementById("set-end-coord-button");
 const startCoordEntry = document.getElementById("start-point-entry");
 const endCoordEntry = document.getElementById("end-point-entry");
 
-const autoOpenNavButton = document.getElementById("auto-open-nav-button");
-const manualOpenNavButton = document.getElementById("manual-open-nav-button");
-const closeNavButton = document.getElementById("close-nav-button");
-
 const autoHomeButton = document.getElementById("auto-home-button");
 const manualHomeButton = document.getElementById("manual-home-button");
 
@@ -161,7 +157,6 @@ const searchForAreaButton = document.getElementById("search-for-area-button");
 
 const mapElement = document.getElementById("map");
 
-const navBar = document.getElementById("the-sidenav");
 const reportIssueOpenButton = document.getElementById('report-issues-open-button')
 const loginNavBarButton = document.getElementById('sidenav-login-button');
 const logoutNavBarButton = document.getElementById('sidenav-logout-button');
@@ -362,7 +357,6 @@ function showReportIssueModal(show) {
   if (!reportIssueModal) return;
   if (show) {
     reportIssueModal.showModal();
-    closeNav();
   } else {
     reportIssueModal.close();
   }
@@ -668,17 +662,8 @@ export function mapClickHandler(event) {
 
 //#region OPEN/CLOSE PANEL FUNCTIONS
 
-function openNav() {
-  navBar.style.width = "17rem";
-}
-
-export function closeNav() {
-  navBar.style.width = "0";
-}
-
 // this is for the 'create route' button on the panel shown on the saved routes dashboard when the user has no saved routes
 function noRouteCreateFunction() {
-  closeNav()
   closeSavedRoutesDash()
 }
 
@@ -924,12 +909,11 @@ function clearImportRouteInput() {
 }
 
 /**
- * Function responsible for closing the import route panel and the navigation panel when the cancel button is clicked.
+ * Function responsible for clearing and closing the import route panel when the cancel button is clicked.
  */
 function cancelRouteImport() {
     clearImportRouteInput();
     closeImportRoute();
-    closeNav();
 };
 
 /**
@@ -1899,11 +1883,6 @@ export function initUi() {
   });
 
   // These event listeners are for navigation panels.
-  addClickListener(autoOpenNavButton, openNav, "click");
-  addClickListener(manualOpenNavButton, openNav, "click");
-
-  addClickListener(closeNavButton, closeNav, "click");
-
   addClickListener(openSavedRoutesDashButton, openSavedRoutesDash, "click");
   addClickListener(closeSavedRoutesDashButton, closeSavedRoutesDash, "click");
 

--- a/templates/map.html
+++ b/templates/map.html
@@ -80,7 +80,6 @@
         <!-- ##### MAIN ROUTING PANEL ##### -->
         <div id="start-end">
             <div class="coords-header">
-                <span id="auto-open-nav-button" style="font-size:20px; cursor:pointer;">&#9776;</span>
                 <span class="coords-title">Path Generation</span>
                 <button id="auto-home-button" class="home-button"><i data-lucide="rotate-ccw"></i></button>
             </div>
@@ -121,7 +120,6 @@
         <!-- ##### MANUAL ROUTING PANEL ##### -->
         <div id="manual-mode-content" style="display: none;">
             <div id="manual-routing-header" class="coords-header">
-                <span id="manual-open-nav-button" style="font-size:20px; cursor:pointer;">&#9776;</span>
                 <span class="coords-title">Manual Route Creation</span>
                 <button id="manual-home-button" class="home-button"><i data-lucide="rotate-ccw"></i></button>
             </div>
@@ -240,29 +238,99 @@
         <div id="map"></div>
     </div>
 
-    <!-- ##### SIDE NAV BAR ##### -->
-    <div id="the-sidenav" class="sidenav">
+    <!-- ##### SIDE NAV RAIL ##### -->
+    <div id="the-sidenav" class="sidenav" aria-label="Main navigation">
         <div class="sidenav-inner">
-            <div id="sidenav-upper-links">
-                <a id="close-nav-button" href="javascript:void(0)" class="closebtn">&times;</a>
-                <a id="saved-routes-dash-open-button"><i data-lucide="waypoints"></i>Saved Routes</a>
-                <a id="import-route-open-button"><i data-lucide="import"></i>Import Route</a>
-                <a id="settings-open-button"><i data-lucide="settings"></i>Settings</a>
-                <a id="report-issues-open-button"><i data-lucide="bug"></i>Report Issues</a>
-                <a class="tooltip-left" id="donate-button" data-tooltip="We're still in Beta, so donations are closed for now. Thank you so much for the support!" href="javascript:void(0)"><i data-lucide="heart"></i>Donate</a>
-            </div>
+            <ul class="sidenav-links">
+                <li>
+                    <a
+                        id="saved-routes-dash-open-button"
+                        class="sidenav-link"
+                        aria-label="Saved Routes"
+                    >
+                        <i data-lucide="waypoints"></i>
+                        <span class="nav-label">Saved Routes</span>
+                    </a>
+                </li>
+
+                <li>
+                    <a
+                        id="import-route-open-button"
+                        class="sidenav-link"
+                        aria-label="Import Route"
+                    >
+                        <i data-lucide="import"></i>
+                        <span class="nav-label">Import Route</span>
+                    </a>
+                </li>
+
+                <li>
+                    <a
+                        id="settings-open-button"
+                        class="sidenav-link"
+                        aria-label="Settings"
+                    >
+                        <i data-lucide="settings"></i>
+                        <span class="nav-label">Settings</span>
+                    </a>
+                </li>
+
+                <li>
+                    <a
+                        id="report-issues-open-button"
+                        class="sidenav-link"
+                        aria-label="Report Issues"
+                    >
+                        <i data-lucide="bug"></i>
+                        <span class="nav-label">Report Issues</span>
+                    </a>
+                </li>
+
+                <li>
+                    <a
+                        class="sidenav-link tooltip-left"
+                        id="donate-button"
+                        data-tooltip="We're still in Beta, so donations are closed for now. Thank you for the support!"
+                        href="javascript:void(0)"
+                    >
+                        <i data-lucide="heart"></i>
+                        <span class="nav-label">Donate</span>
+                    </a>
+                </li>
+            </ul>
+
             {% if user is none or not user.preferred_name %}
-                <div id="sidenav-login-logout-button-container">
-                    <button style="margin: .5rem;" id="sidenav-login-button" class="btn-pill sidenav-login-logout-button"><i data-lucide="log-in"></i>Log In</button>
+                <div
+                    id="sidenav-login-logout-button-container"
+                    class="sidenav-auth"
+                >
+                    <button
+                        type="button"
+                        id="sidenav-login-button"
+                        class="sidenav-link sidenav-auth-button"
+                        aria-label="Log In"
+                    >
+                        <i data-lucide="log-in"></i>
+                        <span class="nav-label">Log In</span>
+                    </button>
                 </div>
             {% else %}
-                <div id="sidenav-login-logout-button-container">
-                    <button style="margin: .5rem;" id="sidenav-logout-button" class="btn-pill sidenav-login-logout-button"><i data-lucide="log-out"></i>Log Out</button>
+                <div
+                    id="sidenav-login-logout-button-container"
+                    class="sidenav-auth"
+                >
+                    <button
+                        type="button"
+                        id="sidenav-logout-button"
+                        class="sidenav-link sidenav-auth-button"
+                        aria-label="Log Out"
+                    >
+                        <i data-lucide="log-out"></i>
+                        <span class="nav-label">Log Out</span>
+                    </button>
                 </div>
             {% endif %}
         </div>
-    </div>
-
     </div>
 
     <!-- ##### SAVED ROUTE DASHBOARD ##### -->


### PR DESCRIPTION
# Pull Request Template

## Summary

Replaces the existing nav rail with a persistent, always-visible rail that expands automatically on hover. Also fixes a bug in manual routing mode where switching the current theme broke the elevation profile chart.

## Related Issue

Closes ABD-25

## Type of Change

Select all that apply:

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (explain below)

## Description of Changes

- Replaced the previous collapsible/toggle nav rail with a nav rail that is always present on screen and expands automatically on hover, removing the need for an explicit open/close interaction.
- Updated related layout and spacing so the map and side panels correctly resize/reflow when the rail expands and collapses.
- Fixed a bug in manual routing mode where changing the current theme (light/dark) broke the elevation profile chart 

## Screenshots / Visuals (if applicable)

### Before

![image](https://github.com/user-attachments/assets/8c1192f9-7f0f-48e8-9541-bd8ac1ce9f89)

### After

![image](https://github.com/user-attachments/assets/3e5ca90e-dd91-4f53-8aa6-557573df4ca8)

## Testing

- Manually tested the nav rail across desktop breakpoints, confirming it stays visible at rest and expands smoothly on hover without layout shift.
- Manually tested theme toggling (light/dark) while in manual routing mode with an active route, confirming the elevation profile chart now re-renders correctly with the updated theme colours.
- Verified no regressions to existing map interactions (drag-end route regeneration, saved points panel, side panel) with the new nav rail in place.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have tested my changes
- [x] I have updated documentation if needed
- [x] I have referenced the related issue
- [x] This PR is scoped, focused, and ready for review

> **Note:**
> PRs for issues **not** tagged as contributor‑friendly may be closed without review.

