### PR TITLE
feat: Add donate modal with Liberapay and Ko-fi + remove old no-donation state

### DIFF
--- a/static/css/components/donate-modal.css
+++ b/static/css/components/donate-modal.css
@@ -1,0 +1,177 @@
+/*
+  DONATE MODAL COMPONENT
+
+  Extends the base .modal-overlay / .modal-content pattern from modal.css
+  with a donation-specific layout: a couple of lines of context, then a
+  list of donation options as clickable cards (external links, open in
+  a new tab).
+
+  Depends on: modal.css (base overlay/content/actions), tokens.css,
+  buttons.css (.modal-btn-secondary).
+
+  Usage:
+    <dialog class="modal-overlay" id="donateModal">
+      <div class="modal-wrapper">
+        <div class="modal-content donate-modal-content">
+          <button class="donate-modal-close" data-donate-close aria-label="Close">×</button>
+          <div class="modal-header">
+            <h2>Support Crest</h2>
+          </div>
+          <div class="modal-body donate-modal-body">
+            <p>Crest is free and in active development. Donations go toward
+               hosting costs — no pressure, and Crest stays free either way.</p>
+          </div>
+          <div class="donate-options">
+            <a class="donate-option" href="https://liberapay.com/YOUR_HANDLE" target="_blank" rel="noopener noreferrer">
+              ...
+            </a>
+            <a class="donate-option" href="https://ko-fi.com/YOUR_HANDLE" target="_blank" rel="noopener noreferrer">
+              ...
+            </a>
+          </div>
+          <div class="modal-actions">
+            <button class="modal-btn modal-btn-secondary" data-donate-close>Maybe later</button>
+          </div>
+        </div>
+      </div>
+    </dialog>
+*/
+
+.donate-modal-content {
+  position: relative;
+  max-width: 420px;
+  text-align: left;
+}
+
+.donate-modal-content .modal-header h2 {
+  text-align: center;
+}
+
+.donate-modal-body {
+  text-align: center;
+  padding-top: 0;
+}
+
+.donate-modal-body p {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+.donate-modal-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-size: 1.25rem;
+  line-height: 1;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.donate-modal-close:hover {
+  background: var(--secondary-bg);
+  color: var(--ink);
+}
+
+.donate-modal-close:focus-visible {
+  outline: 3px solid var(--blue-ring);
+  outline-offset: 2px;
+}
+
+/* This styles the options list */
+
+.donate-options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 4px 0 20px 0;
+}
+
+.donate-option {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 14px;
+  border-radius: var(--radius-md);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.15s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.15s cubic-bezier(0.4, 0, 0.2, 1),
+    border-color 0.15s;
+}
+
+.donate-option:hover {
+  transform: translateY(-1.5px);
+  box-shadow: var(--shadow-surface);
+  border-color: var(--blue);
+}
+
+.donate-option:focus-visible {
+  outline: 3px solid var(--blue-ring);
+  outline-offset: 2px;
+}
+
+.donate-option:active {
+  transform: translateY(0);
+}
+
+.donate-option-icon {
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--blue-soft);
+  color: var(--blue);
+}
+
+.donate-option-icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+.donate-option-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.donate-option-name {
+  display: block;
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: var(--ink-strong);
+}
+
+.donate-option-desc {
+  display: block;
+  margin-top: 2px;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.donate-option-arrow {
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  color: var(--muted);
+  transition: transform 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.donate-option:hover .donate-option-arrow {
+  transform: translateX(2px);
+  color: var(--blue);
+}

--- a/static/css/layout/nav-menu.css
+++ b/static/css/layout/nav-menu.css
@@ -139,11 +139,6 @@ html.dark {
   font-family: inherit;
 }
 
-/* donate button - currently disabled, only opens when there is a full release  */
-#donate-button {
-  cursor: not-allowed;
-}
-
 /* Nav limits for short viewports */
 @media screen and (max-height: 450px) {
   .sidenav-inner {

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -32,7 +32,9 @@ import {
   Bug,
   Heart,
   LogIn,
-  LogOut
+  LogOut,
+  Coffee,
+  MoveRight
 } from 'lucide';
 
 export let map = null;
@@ -50,7 +52,9 @@ createIcons({
     Bug,
     Heart,
     LogIn,
-    LogOut
+    LogOut,
+    Coffee,
+    MoveRight
   }
 });
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -194,6 +194,14 @@ const reportIssueResultLabel = document.getElementById('report-issue-result-labe
 const reportIssueTitleInput = document.getElementById("report-issue-title");
 const reportIssueTextAreaInput = document.getElementById("report-issue-description");
 
+// donate modal
+const donateButton = document.getElementById('donate-button');
+
+const donateModal = document.getElementById('donate-modal');
+const donateModalContent = document.getElementById('donate-modal-content');
+const donateModalCloseButton = document.getElementById('donate-modal-close-button');
+const donateModalMaybeLaterButton = document.getElementById('donate-modal-maybe-later-button')
+
 // saved route dash panel
 const openSavedRoutesDashButton = document.getElementById('saved-routes-dash-open-button');
 const closeSavedRoutesDashButton = document.getElementById('saved-routes-dash-go-back-button');
@@ -274,6 +282,35 @@ function checkIfMobile() {
       `;
   }
 }
+
+//#endregion
+
+//#region DONATE MODAL
+
+/**
+ * Toggles the login modal display and sets the action context
+ * @param {boolean} show true if you want to show the modal, false if you want to hide the modal
+ * @param {string} [actionName='perform this action'] the specific action that is being performed when showing the modal e.g save routes 
+ * @returns {void}
+ */
+export function showDonateModal(show) {
+  if (show) {
+    donateModal.showModal();
+  } 
+  else {
+    donateModal.close();
+  }
+};
+
+/**
+ * Function used to catch clicks outside of the donate modal in order to close the modal upon these clicks 
+ * @returns {void}
+ */
+function dismissDonateModal(e) {
+  if (donateModalContent && !donateModalContent.contains(e.target)) {
+      showDonateModal(false);
+    }
+};
 
 //#endregion
 
@@ -1938,9 +1975,15 @@ export function initUi() {
   addClickListener(loginModalLoginButton, loginModalLogin, 'click');
   addClickListener(loginModal, dismissLoginModal, 'click');
 
-  // These event listeners are for the login modal
-  addClickListener(reportIssueModalExit, () => showReportIssueModal(false), "click")
+  // These event listeners are for the report issue modal
+  addClickListener(reportIssueModalExit, () => showReportIssueModal(false), "click");
   addClickListener(reportIssueModalSubmit, () => handleReportIssueSubmission(reportIssueTitleInput.value.trim(), reportIssueTextAreaInput.value.trim()), "click");
+
+  // These event listeners are for the donate modal
+  addClickListener(donateModalCloseButton, () => showDonateModal(false), "click");
+  addClickListener(donateModalMaybeLaterButton, () => showDonateModal(false), "click");
+  addClickListener(donateButton, () => showDonateModal(true), "click");
+  addClickListener(donateModal, dismissDonateModal, "click");
 
   onMapClick(mapClickHandler);
   onMapRenderComplete(mapRenderComplete);

--- a/templates/map.html
+++ b/templates/map.html
@@ -29,6 +29,7 @@
     <link rel="stylesheet" href="{{ url_for('static', path='css/components/tooltip.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='css/components/modal.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='css/components/buttons.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', path='css/components/donate-modal.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='css/components/form-fields.css') }}">
 
     <!-- Layout CSS Files -->
@@ -170,6 +171,51 @@
             <button id="remove-point-button">remove</button>
         </div>
 
+        <!-- ##### DONATE MODAL ##### -->
+        <dialog class="modal-overlay" id="donate-modal">
+            <div class="modal-wrapper" id="donate-modal-wrapper">
+                <div class="modal-content donate-modal-content" id="donate-modal-content">
+                    <button class="donate-modal-close" id="donate-modal-close-button" data-donate-close aria-label="Close">&times;</button>
+                
+                    <div class="modal-header">
+                        <h2>Support Crestr</h2>
+                    </div>
+                
+                    <div class="modal-body donate-modal-body">
+                        <p>Crestr is free and in active development. Donations go toward hosting costs, no pressure, and Crestr stays free either way.</p>
+                    </div>
+                
+                    <div class="donate-options">
+                        <a class="donate-option" href="https://liberapay.com/abd_ulll16/donate" target="_blank" rel="noopener noreferrer">
+                        <span class="donate-option-icon">
+                            <i data-lucide="heart"></i>
+                        </span>
+                        <span class="donate-option-text">
+                            <span class="donate-option-name">Liberapay</span>
+                            <span class="donate-option-desc">Recurring, weekly or monthly</span>
+                        </span>
+                        <i data-lucide="move-right"></i>
+                        </a>
+                
+                        <a class="donate-option" href="https://ko-fi.com/abdulsultan" target="_blank" rel="noopener noreferrer">
+                        <span class="donate-option-icon">
+                            <i data-lucide="coffee"></i>
+                        </span>
+                        <span class="donate-option-text">
+                            <span class="donate-option-name">Ko-fi</span>
+                            <span class="donate-option-desc">One-off, buy Crestr a coffee</span>
+                        </span>
+                        <i data-lucide="move-right"></i>
+                        </a>
+                    </div>
+            
+                    <div class="modal-actions">
+                        <button id="donate-modal-maybe-later-button" class="modal-btn modal-btn-secondary" data-donate-close type="button">Maybe later</button>
+                    </div>
+                </div>
+            </div>
+        </dialog>
+
         <!-- ##### REPORT ISSUE MODAL ##### -->
         <dialog id="report-issue-dialog" class="modal-overlay">
             <div class="modal-wrapper">
@@ -288,9 +334,8 @@
 
                 <li>
                     <a
-                        class="sidenav-link tooltip-left"
+                        class="sidenav-link"
                         id="donate-button"
-                        data-tooltip="We're still in Beta, so donations are closed for now. Thank you for the support!"
                         href="javascript:void(0)"
                     >
                         <i data-lucide="heart"></i>


### PR DESCRIPTION
# Pull Request Template
## Summary
Adds a donate modal (Liberapay + Ko-fi) and removes the "donations closed" tooltip on the donate link.

## Related Issue
Closes ABD-26

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (explain below)

## Description of Changes
Replaces the disabled `.inactive` donate link (with its "still in Beta, donations closed" tooltip) with a modal listing Liberapay and Ko-fi as donation options. Follows the existing `.modal-overlay` / `.modal-content` pattern used by current modals, so no new base component was introduced, just a `donate-modal.css` extension and matching wire-up JS (open/close, backdrop click).

## Screenshots / Visuals (if applicable)

### Modal

<img width="1470" height="828" alt="image" src="https://github.com/user-attachments/assets/59a7fe56-bcc3-409b-ae3d-b357dc0588f5" />

## Testing
Manually tested open/close via the donate link, the × button, "Maybe later", backdrop click, and Escape. Checked both light and dark mode. Verified both donation links open in a new tab.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have tested my changes
- [x] I have updated documentation if needed
- [x] I have referenced the related issue
- [x] This PR is scoped, focused, and ready for review

> **Note:**
> PRs for issues **not** tagged as contributor‑friendly may be closed without review.