### PR TITLE
chore: Add automatic routing in Caddyfile between dev and prod environments via SITE_DOMAIN env variable

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,4 @@
-app.crestr.co.uk {
+{$SITE_DOMAIN} {
     reverse_proxy web-fastapi:5000
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,11 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    env_file:
+      - path: example.env
+        required: true
+      - path: .env
+        required: false
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - caddy_data:/data

--- a/example.env
+++ b/example.env
@@ -1,5 +1,6 @@
  # Application
-ENVIRONMENT=production
+ENVIRONMENT=Dev
+SITE_DOMAIN=http://localhost
 
 # APIs
 LOCATIONIQ_API_KEY=your_locationiq_api_key


### PR DESCRIPTION
Pull Request Template

## Summary
This PR aims to improve DX by adding automatic routing to the `Caddyfile` + `caddy` service in Docker, by making use of a new `SITE_DOMAIN` environment variable used in both the `.env` and `.example.env` files. 

## Related Issue
Closes ABD-28

## Type of Change
Select all that apply:
- [x] Bug fix  
- [ ] New feature  
- [ ] Documentation update  
- [ ] Refactor  
- [ ] Other (explain below)

## Description of Changes
- `.env` + `.example.env` : Added a new `SITE_DOMAIN` variable which holds the site address that users (using `app.crestr.co.uk`) and developers / contributors (using `http://localhost`) type in
- `docker-compose.yml` : Added a new `env_path` attribute in the caddy service 
- `Caddyfile` : Removed the hardcoded `app.crestr.co.uk` site address and replaced it with the new environment variable 

## Screenshots / Visuals (if applicable)
Not Applicable 

## Testing
- Ran the application via `docker compose up -d` to ensure that the application loaded correctly with no syntax errors
- Ran the application with both the `app.crestr.co.uk` and http://localhost` `SITE_DOMAIN` variables to ensure that Caddy successfully routed both production and development domains 

## Checklist
- [x] My code follows the project’s style guidelines  
- [x] I have tested my changes  
- [x] I have updated documentation if needed  
- [x] I have referenced the related issue  
- [x] This PR is scoped, focused, and ready for review  

> **Note:**  
> PRs for issues **not** tagged as contributor‑friendly may be closed without review.
