### PR TITLE
Fix/cache routes upon unauthenticated save attempt

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,4 @@
-app.crestr.co.uk {
+{$SITE_DOMAIN} {
     reverse_proxy web-fastapi:5000
 }
 

--- a/caddy.env
+++ b/caddy.env
@@ -1,0 +1,1 @@
+SITE_DOMAIN = http://localhost

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,9 @@ services:
     ports:
       - "80:80"
       - "443:443"
+    env_file:
+      - path: caddy.env
+        required: true
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - caddy_data:/data

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "chart.js": "^4.5.1",
         "driver.js": "^1.8.0",
+        "localforage": "^1.10.0",
         "lucide": "^1.30.0",
         "ol": "^10.10.0"
       },
@@ -422,11 +423,26 @@
         "node": ">=10.19"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/lerc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
       "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
       "license": "Apache-2.0"
+    },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.33.0",
@@ -699,6 +715,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
       }
     },
     "node_modules/lucide": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "chart.js": "^4.5.1",
     "driver.js": "^1.8.0",
+    "localforage": "^1.10.0",
     "lucide": "^1.30.0",
     "ol": "^10.10.0"
   },
@@ -32,4 +33,3 @@
     "vite": "^8.2.1"
   }
 }
-

--- a/src/fastapi_app.py
+++ b/src/fastapi_app.py
@@ -50,8 +50,13 @@ app.mount(
 
 # Vite Helpers:
 # These helpers resolve a Vite source path (the keys used in vite.config.js build.input) to the actual
-# hashed output file, reading the manifest once at import time.
+# hashed output file. The manifest is read with an mtime-based cache so that a rebuilt manifest
+# (e.g. after `npm run build` on a bind-mounted static dir) is picked up without restarting the app.
 VITE_MANIFEST_PATH = STATIC_DIR / "dist" / ".vite" / "manifest.json"
+
+# (mtime_ns, size) fingerprint of the last-read manifest -> parsed manifest data.
+# Reloaded lazily whenever the file on disk changes.
+_vite_manifest_cache = {"fingerprint": None, "data": {}}
 
 
 def _load_vite_manifest() -> dict:
@@ -64,14 +69,30 @@ def _load_vite_manifest() -> dict:
     return {}
 
 
-VITE_MANIFEST = _load_vite_manifest()
+def _get_vite_manifest() -> dict:
+    """Return the current Vite manifest, re-reading it only when it has changed on disk."""
+    try:
+        manifest_stat = VITE_MANIFEST_PATH.stat()
+        fingerprint = (manifest_stat.st_mtime_ns, manifest_stat.st_size)
+    except FileNotFoundError:
+        _vite_manifest_cache["fingerprint"] = None
+        _vite_manifest_cache["data"] = {}
+        return {}
+    except OSError as error:
+        print(f"CRITICAL: Failed to stat Vite manifest: {error}")
+        return _vite_manifest_cache["data"]
+
+    if _vite_manifest_cache["fingerprint"] != fingerprint:
+        _vite_manifest_cache["fingerprint"] = fingerprint
+        _vite_manifest_cache["data"] = _load_vite_manifest()
+    return _vite_manifest_cache["data"]
 
 
 def vite_asset(src: str) -> str:
     """
     Resolve a Vite source path to its built, content-hashed output path relative to the /static mount
     """
-    entry = VITE_MANIFEST.get(src)
+    entry = _get_vite_manifest().get(src)
     if isinstance(entry, dict) and entry.get("file"):
         return f"dist/{entry['file']}"
     return f"dist/js/{src.rsplit('/', 1)[-1]}"
@@ -81,7 +102,7 @@ def vite_css(src: str) -> list:
     """
     Return the CSS assets declared for a Vite entry
     """
-    entry = VITE_MANIFEST.get(src)
+    entry = _get_vite_manifest().get(src)
     if isinstance(entry, dict) and entry.get("css"):
         return [f"dist/{css}" for css in entry["css"]]
     return []

--- a/static/css/base/tokens.css
+++ b/static/css/base/tokens.css
@@ -27,16 +27,21 @@
   /* Surfaces */
   --bg: #ffffff;
   --surface-bg: rgba(255, 255, 255, 0.92);
+  --surface-subtle: #f1f5f9;
   --field-bg: #ffffff;
-  --glass-bg: rgba(249, 250, 251, 0.4);   /* the frosted slide-panel background */
+  --glass-bg: rgba(249, 250, 251, 0.4);   /* the glassmorphism slide-panel background */
   --secondary-bg: #e2e8f0;
   --secondary-bg-hover: #cbd5e1;
+
+  --panel-glass-bg: rgb(255 255 255 / 0.65); /* the glassmorphism routing panel background */
+  --panel-glass-bg-hover: rgba(223, 221, 221, 0.65);
 
   /* Text */
   --ink: #1f2937;
   --secondary-ink: #ffffff;
   --ink-strong: #111827;
   --muted: #64748b;
+  --muted-strong: #475569;
   --muted-alt: #4b5563;
   --placeholder: #94a3b8;
 
@@ -51,11 +56,13 @@
   --btn-disabled-bg: #93b4f2;
   --btn-disabled-text: #ffffff;
 
-  /* Solid card surface (opaque alternative to the frosted --glass-bg) */
+  /* Solid card surface (opaque alternative to the glassmorphism bg) */
   --card-bg: #ffffff;
   --card-border: #b9b8b8;
 
   /* Layout and shapes */
+  --panel-radius: 7px;
+
   --radius-lg: 20px;
   --radius-md: 12px;
   --radius-sm: 8px;
@@ -63,6 +70,7 @@
 
   --shadow-surface: 0 10px 35px rgba(15, 23, 42, 0.06);
   --shadow-lift: 0 4px 12px rgba(37, 99, 235, 0.28);
+  --panel-shadow: 0 2px 6px rgba(0,0,0,0.1);
 
   --font-sans: -apple-system, BlinkMacSystemFont, "SF Pro Text",
     "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -89,16 +97,22 @@
 html.dark {
   --bg: #212224;
   --surface-bg: rgba(35, 36, 38, 0.8);
+  --surface-subtle: rgb(55 65 81 / 0.75);
   --field-bg: #1c1c1e;
   --secondary-field-bg: #2c3038;
   --glass-bg: rgba(17, 24, 39, 0.85);
+
   --secondary-bg: rgb(69, 68, 68);
   --secondary-bg-hover: rgb(87, 87, 87);
+
+  --panel-glass-bg: rgb(31 41 55 / 0.75);
+  --panel-glass-bg-hover: rgba(18, 25, 34, 0.75);
 
   --ink: #f8fafc;
   --secondary-ink: #ffffff;
   --ink-strong: #f3f4f6;
   --muted: #94a3b8;
+  --muted-strong: #9ca3af;
   --muted-alt: #9ca3af;
   --placeholder: #64748b;
 

--- a/static/css/components/donate-modal.css
+++ b/static/css/components/donate-modal.css
@@ -8,33 +8,6 @@
 
   Depends on: modal.css (base overlay/content/actions), tokens.css,
   buttons.css (.modal-btn-secondary).
-
-  Usage:
-    <dialog class="modal-overlay" id="donateModal">
-      <div class="modal-wrapper">
-        <div class="modal-content donate-modal-content">
-          <button class="donate-modal-close" data-donate-close aria-label="Close">×</button>
-          <div class="modal-header">
-            <h2>Support Crest</h2>
-          </div>
-          <div class="modal-body donate-modal-body">
-            <p>Crest is free and in active development. Donations go toward
-               hosting costs — no pressure, and Crest stays free either way.</p>
-          </div>
-          <div class="donate-options">
-            <a class="donate-option" href="https://liberapay.com/YOUR_HANDLE" target="_blank" rel="noopener noreferrer">
-              ...
-            </a>
-            <a class="donate-option" href="https://ko-fi.com/YOUR_HANDLE" target="_blank" rel="noopener noreferrer">
-              ...
-            </a>
-          </div>
-          <div class="modal-actions">
-            <button class="modal-btn modal-btn-secondary" data-donate-close>Maybe later</button>
-          </div>
-        </div>
-      </div>
-    </dialog>
 */
 
 .donate-modal-content {

--- a/static/css/components/load-last-route-modal.css
+++ b/static/css/components/load-last-route-modal.css
@@ -1,0 +1,47 @@
+/*
+  LOAD LAST ROUTE MODAL COMPONENT
+
+  Extends the base .modal-overlay / .modal-content pattern from modal.css
+  with a load-route-specific layout
+
+  Depends on: 
+    - modal.css 
+    - tokens.css
+    - buttons.css 
+*/
+
+.load-last-route-modal-route-container {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 16px;
+  background-color: var(--secondary-bg);
+  border-radius: 6px;
+  text-align: left;
+}
+
+.load-last-route-modal-route-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.load-last-route-modal-route-container p {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ink);
+  white-space: nowrap;
+}
+
+.load-last-route-modal-route-container span {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ink-strong);
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/static/css/layout/nav-menu.css
+++ b/static/css/layout/nav-menu.css
@@ -10,12 +10,13 @@
   --nav-width-collapsed: 48px;
   --nav-width-expanded: 200px;
   --nav-border: 1px solid rgba(0, 0, 0, 0.08);
+  --nav-border-radius: 30px;
   --nav-transition: width 0.22s ease;
 
   --nav-link-transition: background-color 0.15s ease, color 0.15s ease;
   --nav-link-height: 44px;
   --nav-link-height-compact: 40px;
-  --nav-link-padding: 0 8px;
+  --nav-link-padding: 0 5px;
   --nav-link-margin: 8px 8px;
   --nav-link-gap: 12px;
   --nav-link-radius: 8px;
@@ -54,6 +55,8 @@ html.dark {
   border-right: var(--nav-border);
   background: var(--glass-bg);
   border-right: 1px solid var(--border);
+  border-top-right-radius: var(--nav-border-radius);
+  border-bottom-right-radius: var(--nav-border-radius);
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
 }
 

--- a/static/css/pages/map.css
+++ b/static/css/pages/map.css
@@ -12,6 +12,38 @@
   reference it since both are always shown together on this page).
 */
 
+/* local tokens */
+:root {
+  --map-bg-fallback: #f8f9fa;
+  --mode-button-hover-text: #334155;
+  --action-shadow-sm: 0 1px 3px rgba(37, 99, 235, 0.2); 
+  --generate-button-hover-shadow: 0 3px 6px rgba(37, 99, 235, 0.3);
+  --generate-button-active-shadow: 0 1px 2px rgba(37, 99, 235, 0.2);
+  --coord-input-focus-border: #3b82f6;
+  --coord-input-focus-ring: 0 0 3px 1px rgba(59, 130, 246, 0.2), 0 0 8px 3px rgba(59, 130, 246, 0.1);
+  --coord-input-active-border: #5a76e7;
+  --home-button-bg: rgb(100 116 139 / 0.65);
+  --home-button-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  --home-button-hover-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  --point-name-color: #ef4444;
+}
+
+html.dark {
+  --coord-input-bg: #374151;
+  --coord-input-text: #f3f4f6;
+  --coord-input-border: #4b5563;
+  --coord-input-placeholder: #6b7280;
+  --coord-button-bg: #4b5563;
+  --coord-button-border: #6b7280;
+  --coord-button-hover-bg: #6b7280;
+  --coord-button-hover-border: #9ca3af;
+  --mode-button-bg: #374151;
+  --mode-button-text: #d1d5db;
+  --mode-button-border: #4b5563;
+  --mode-button-hover-bg: #4b5563;
+  --error-message-color: #f87171;
+}
+
 /* Map container */
 #map {
   position: absolute;
@@ -19,8 +51,9 @@
   left: 0;
   width: 100%;
   height: 100vh;
+  height: 100dvh;
   z-index: 1;
-  background: #f8f9fa;
+  background: var(--map-bg-fallback); /* fallback before OL tiles paint */
   overflow: hidden;
 }
 
@@ -31,34 +64,35 @@
 }
 
 /* MODE TOGGLING */
-
 #mode-toggle {
   position: absolute;
   top: 5px;
   left: 70px;
   z-index: 900;
-  background: rgb(255 255 255 / 0.65);
+  background: var(--panel-glass-bg);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  border: 1px solid #e2e8f0;
-  padding: 8px;
+  border-radius: var(--panel-radius);
+  box-shadow: var(--panel-shadow);
+  border: 1px solid var(--border-alt);
+  padding: 5px;
   font-family: var(--font-sans);
+  max-width: calc(100vw - 90px);
 }
 
 .mode-toggle-container {
   display: flex;
-  gap: 4px;
+  gap: 3px;
+  flex-wrap: wrap;
 }
 
 .mode-button {
-  padding: 8px 16px;
-  background: rgb(241 245 249 / 0.75);
-  color: #475569;
-  border: 1px solid #cbd5e1;
-  border-radius: 6px;
-  font-size: 13px;
+  padding: 5px 11px;
+  background: rgb(241 245 249 / 0.75); /* --surface-subtle base color at a one-off alpha */
+  color: var(--muted-strong);
+  border: 1px solid var(--border-alt);
+  border-radius: 5px;
+  font-size: 12px;
   font-weight: 500;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -66,40 +100,40 @@
 }
 
 .mode-button:hover {
-  background: #e2e8f0;
-  border-color: #94a3b8;
-  color: #334155;
+  background: var(--secondary-bg);
+  border-color: var(--placeholder);
+  color: var(--mode-button-hover-text);
 }
 
 .mode-button.active {
   background: var(--blue);
   color: white;
-  border-color: #1e40af;
-  box-shadow: 0 2px 4px rgba(37, 99, 235, 0.2);
+  border-color: var(--blue-dark-alt);
+  box-shadow: var(--action-shadow-sm);
 }
 
 /* AUTOMATIC ROUTE GENERATION */
-
 #start-end {
   position: absolute;
-  top: 60px;
+  top: 48px;
   left: 70px;
   z-index: 1000;
-  background: rgb(255 255 255 / 0.65);
+  background: var(--panel-glass-bg);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  border: 1px solid #e2e8f0;
-  min-width: 280px;
+  border-radius: var(--panel-radius);
+  box-shadow: var(--panel-shadow);
+  border: 1px solid var(--border-alt);
+  min-width: 240px;
+  max-width: calc(100vw - 90px);
   font-family: var(--font-sans);
 }
 
 .coords-header {
-  background: rgb(241 245 249 / 0.65);
-  padding: 12px 16px;
-  border-radius: 8px 8px 0 0;
-  border-bottom: 1px solid #e2e8f0;
+  background: var(--surface-subtle); /* --surface-subtle base color at a one-off alpha */
+  padding: 8px 12px;
+  border-radius: var(--panel-radius) var(--panel-radius) 0 0;
+  border-bottom: 1px solid var(--border-alt);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -107,17 +141,17 @@
 
 .coords-title {
   font-weight: 600;
-  font-size: 14px;
-  color: #1e293b;
+  font-size: 13px;
+  color: var(--ink);
   letter-spacing: -0.01em;
 }
 
 .coords-content {
-  padding: 12px 16px;
+  padding: 8px 12px;
 }
 
 .coord-row {
-  margin-bottom: 12px;
+  margin-bottom: 8px;
 }
 
 .coord-row:last-child {
@@ -126,57 +160,57 @@
 
 .coord-label {
   display: block;
-  font-size: 13px;
-  color: #475569;
+  font-size: 12px;
+  color: var(--muted-strong);
   font-weight: 500;
-  margin-bottom: 4px;
+  margin-bottom: 3px;
   pointer-events: none;
 }
 
 .coord-input-group {
   display: flex;
-  gap: 8px;
+  gap: 6px;
+  flex-wrap: wrap;
 }
 
 .coord-input {
   flex: 1;
-  padding: 8px 12px;
-  border: 1px solid #e1cbcb;
-  border-radius: 8px;
-  font-size: 13px;
+  min-width: 0;
+  padding: 6px 10px;
+  border-width: 1px;
+  border-style: solid;
+  border-color: var(--border-alt);
+  border-radius: 6px;
+  font-size: 12px;
   font-family: inherit;
   background: white;
-  color: #1e293b;
-  width: 180px;
+  color: var(--ink);
+  width: 150px;
+  max-width: 100%;
   transition: all 0.14s ease-in-out;
 }
 
-.coord-input:hover {
-  border-color: #94a3b8;
-}
-
 .coord-input:focus {
-  border-color: #3b82f6;
-  box-shadow: 0 0 4px 1px rgba(59, 130, 246, 0.2),
-    0 0 12px 4px rgba(59, 130, 246, 0.1);
+  border-color: var(--coord-input-focus-border);
+  box-shadow: var(--coord-input-focus-ring);
   outline: none;
 }
 
 .coord-input.input-error {
-  border-color: #fc4646;
+  border-color: var(--error-accent);
 }
 
 .coord-input.is-active {
-  border-color: #5a76e7;
+  border-color: var(--coord-input-active-border);
 }
 
 .coord-button {
-  padding: 8px 16px;
-  background: #f1f5f9;
-  color: #1e293b;
-  border: 1px solid #cbd5e1;
-  border-radius: 6px;
-  font-size: 12px;
+  padding: 6px 12px;
+  background: var(--surface-subtle);
+  color: var(--ink);
+  border: 1px solid var(--secondary-bg-hover);
+  border-radius: 5px;
+  font-size: 11px;
   font-weight: 500;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -184,14 +218,14 @@
 }
 
 .coord-button:hover {
-  background: #e2e8f0;
-  border-color: #94a3b8;
+  background: var(--secondary-bg);
+  border-color: var(--placeholder);
   transform: translateY(-1px);
 }
 
 .set-start-end-coord {
-  width: clamp(8rem, 8vw, 10rem);
-  font-size: clamp(0.8rem, 0.3vw, 2rem);
+  width: clamp(6.5rem, 7vw, 8.5rem);
+  font-size: clamp(0.75rem, 0.25vw, 1.1rem);
 }
 
 .set-start-end-coord:active {
@@ -200,70 +234,69 @@
 
 .generate-button {
   width: 100%;
-  padding: 12px;
+  padding: 8px;
   background: var(--blue);
   color: white;
   border: none;
-  border-radius: 6px;
-  font-size: 14px;
+  border-radius: 5px;
+  font-size: 13px;
   font-weight: 600;
   cursor: pointer;
-  margin-top: 12px;
+  margin-top: 8px;
   transition: all 0.2s ease;
-  box-shadow: 0 2px 4px rgba(37, 99, 235, 0.2);
+  box-shadow: var(--action-shadow-sm);
   white-space: nowrap;
 }
 
 .generate-button:hover {
-  background: #1e40af;
-  box-shadow: 0 4px 8px rgba(37, 99, 235, 0.3);
+  background: var(--blue-dark);
+  box-shadow: var(--generate-button-hover-shadow);
   transform: translateY(-1px);
 }
 
 .generate-button:active {
   transform: translateY(0);
-  box-shadow: 0 1px 2px rgba(37, 99, 235, 0.2);
+  box-shadow: var(--generate-button-active-shadow);
 }
 
 /* MANUAL ROUTE CREATION */
-
 #manual-mode-content {
   position: absolute;
-  top: 60px;
+  top: 48px;
   left: 70px;
   z-index: 1000;
-  background: rgb(255 255 255 / 0.65);
+  background: var(--panel-glass-bg);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  border: 1px solid #e2e8f0;
-  min-width: 280px;
+  border-radius: var(--panel-radius);
+  box-shadow: var(--panel-shadow);
+  border: 1px solid var(--border-alt);
+  min-width: 240px;
+  max-width: calc(100vw - 90px);
   font-family: var(--font-sans);
 }
 
 .manual-instruction {
-  font-size: 13px;
-  color: #475569;
-  margin-bottom: 12px;
-  padding: 8px;
-  background: #f1f5f9;
+  font-size: 12px;
+  color: var(--muted-strong);
+  margin-bottom: 8px;
+  padding: 6px 8px;
+  background: var(--surface-subtle);
   border-radius: 4px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--border-alt);
 }
 
 /* SAVE / LOAD ROUTE PANEL */
-
 #save-route-container {
   position: static;
 }
 
-/* wrapper for both the toggle button and the panel underneath it */
 #save-route-button-container {
   z-index: 1000;
   position: absolute;
   right: 9rem;
-  width: 15rem;
+  width: 13rem;
+  max-width: calc(100vw - 2rem);
   display: flex;
   flex-direction: column;
 }
@@ -273,16 +306,16 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  background: rgb(255 255 255 / 0.65);
+  background: var(--panel-glass-bg);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
-  border-radius: 0 0 8px 8px;
+  border-radius: 0 0 var(--panel-radius) var(--panel-radius);
   border: none;
-  color: #1f2937;
-  padding: 8px 14px;
-  font-size: 14px;
+  color: var(--ink);
+  padding: 6px 12px;
+  font-size: 13px;
   cursor: pointer;
-  gap: 6px;
+  gap: 5px;
   transition: all 0.15s ease-in-out;
 }
 
@@ -298,27 +331,27 @@
   border-radius: 0;
 }
 
-/* panel sits below the button, inside the same container */
 #save-route {
   overflow: hidden;
   height: 0;
   margin-right: 0.5rem;
-  background: rgb(255 255 255 / 0.65);
+  background: var(--panel-glass-bg);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
-  border-radius: 0 0 8px 8px;
+  border-radius: 0 0 var(--panel-radius) var(--panel-radius);
   border: none;
   border-top: none;
-  width: 15rem;
+  width: 13rem;
+  max-width: 100%;
   transition: all 0.15s ease-in-out;
 }
 
 #save-route-toggle-button:hover {
-  background: rgba(223, 221, 221, 0.65);
+  background: var(--panel-glass-bg-hover);
 }
 
 #save-route-toggle-button:hover + #save-route {
-  background: rgba(223, 221, 221, 0.65);
+  background: var(--panel-glass-bg-hover);
 }
 
 /* Generate Button positioning anchor */
@@ -328,30 +361,30 @@
 
 /* Home Button */
 .home-button {
-  background: rgb(100 116 139 / 0.65);
+  background: var(--home-button-bg);
   color: white;
-  border-radius: 6px;
-  width: 32px;
-  height: 32px;
-  font-size: 16px;
+  border-radius: 5px;
+  width: 28px;
+  height: 28px;
+  font-size: 14px;
   cursor: pointer;
   transition: all 0.2s ease;
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--home-button-shadow);
   border: none;
 }
 
 .home-button i {
-  width: 20px;
-  height: 20px;
+  width: 16px;
+  height: 16px;
 }
 
 .home-button:hover {
-  background: #475569;
+  background: var(--muted-alt);
   transform: translateY(-1px);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--home-button-hover-shadow);
 }
 
 .home-button:active {
@@ -363,115 +396,173 @@
   display: none;
 }
 
-/* DELETE POINT MODAL (page-specific content styling only;
-   overlay/card/button styling lives in components/modal.css) */
-
+/* DELETE POINT MODAL */
 #point-name-display {
   font-weight: 700;
-  color: #ef4444;
+  color: var(--point-name-color);
 }
 
-/* DARK MODE */
-/* Only the actual map tiles / #map are excluded from theming */
+/* RESPONSIVE STYLES */
 
-html.dark #start-end,
-html.dark #manual-mode-content,
-html.dark #route-stats,
-html.dark #mode-toggle,
-html.dark #remove-point {
-  background: rgb(31 41 55 / 0.75);
-  border-color: #4b5563;
-  color: #f3f4f6;
+@media (max-width: 1024px) {
+  #mode-toggle,
+  #start-end,
+  #manual-mode-content {
+    left: 14px;
+    max-width: calc(100vw - 28px);
+  }
+
+  #save-route-button-container {
+    right: 1rem;
+    width: 12rem;
+  }
+
+  #save-route {
+    width: 12rem;
+  }
 }
 
-html.dark #save-route,
-html.dark #save-route-toggle-button {
-  background: rgb(31 41 55 / 0.75);
-  color: #f3f4f6;
+@media (max-width: 768px) {
+  #mode-toggle {
+    top: 6px;
+    left: 10px;
+    padding: 4px;
+    max-width: calc(100vw - 20px);
+  }
+
+  .mode-button {
+    padding: 5px 9px;
+    font-size: 11px;
+  }
+
+  #start-end,
+  #manual-mode-content {
+    top: 42px;
+    left: 10px;
+    min-width: 0;
+    width: calc(100vw - 20px);
+    max-width: 300px;
+  }
+
+  .coords-header,
+  .coords-content {
+    padding: 7px 10px;
+  }
+
+  .coords-title {
+    font-size: 12px;
+  }
+
+  .coord-label {
+    font-size: 11px;
+  }
+
+  .coord-input {
+    width: auto;
+    min-width: 110px;
+    padding: 5px 8px;
+    font-size: 12px;
+  }
+
+  .coord-input-group {
+    flex-direction: column;
+    gap: 5px;
+  }
+
+  .coord-button {
+    width: 100%;
+    padding: 6px 10px;
+    font-size: 11px;
+    text-align: center;
+  }
+
+  .set-start-end-coord {
+    width: 100%;
+    font-size: 0.8rem;
+  }
+
+  .generate-button {
+    padding: 7px;
+    font-size: 12px;
+    margin-top: 6px;
+  }
+
+  .manual-instruction {
+    font-size: 11px;
+    padding: 5px 7px;
+    margin-bottom: 6px;
+  }
+
+  #save-route-button-container {
+    right: 10px;
+    width: min(12rem, calc(100vw - 20px));
+  }
+
+  #save-route {
+    width: 100%;
+    margin-right: 0;
+  }
+
+  #save-route-toggle-button {
+    padding: 5px 10px;
+    font-size: 12px;
+  }
 }
 
-html.dark #save-route-toggle-button:hover + #save-route,
-html.dark #save-route-toggle-button:hover {
-  background: rgba(18, 25, 34, 0.75);
-  color: #f3f4f6;
-}
-
-html.dark .coords-header,
-html.dark .stats-header {
-  background: rgb(55 65 81 / 0.75);
-  border-bottom-color: #4b5563;
-}
-
-html.dark .coords-title,
-html.dark .stats-title {
-  color: #f3f4f6;
-}
-
-html.dark .coord-label,
-html.dark .stat-label,
-html.dark .manual-instruction {
-  color: #9ca3af;
-}
-
-html.dark .manual-instruction {
-  background-color: #1e293b;
-  border-color: #1e293b;
-}
+/* DARK MODE
+   Backgrounds/text now inherit from --panel-glass-bg, --panel-glass-bg-hover,
+   --surface-subtle and --muted-strong (all redefined in html.dark in tokens.css),
+   so the panel containers no longer need page-local dark overrides here — only
+   the values with no token equivalent remain. */
 
 html.dark .coord-input {
-  background: #374151;
-  color: #f3f4f6;
-  border-color: #4b5563;
+  background: var(--coord-input-bg);
+  color: var(--coord-input-text);
+  border-color: var(--coord-input-border);
 }
 
 html.dark .coord-input:focus,
 html.dark .coord-input.is-active {
-  border-color: #3b82f6;
-  box-shadow: 0 0 4px 1px rgba(59, 130, 246, 0.2),
-    0 0 12px 4px rgba(59, 130, 246, 0.1);
+  border-color: var(--coord-input-focus-border);
+  box-shadow: var(--coord-input-focus-ring);
   outline: none;
 }
 
 html.dark .coord-input.input-error {
-  border-color: #fc4646;
+  border-color: var(--error-accent);
 }
 
 html.dark .coord-input::placeholder {
-  color: #6b7280;
+  color: var(--coord-input-placeholder);
 }
 
 html.dark .coord-button {
-  background: #4b5563;
-  color: #f3f4f6;
-  border-color: #6b7280;
+  background: var(--coord-button-bg);
+  color: var(--coord-input-text);
+  border-color: var(--coord-button-border);
 }
 
 html.dark .coord-button:hover {
-  background: #6b7280;
-  border-color: #9ca3af;
-}
-
-html.dark .generate-button {
-  background: var(--blue);
-  color: #ffffff;
+  background: var(--coord-button-hover-bg);
+  border-color: var(--coord-button-hover-border);
 }
 
 html.dark .mode-button {
-  background: #374151;
-  color: #d1d5db;
-  border-color: #4b5563;
+  background: var(--mode-button-bg);
+  color: var(--mode-button-text);
+  border-color: var(--mode-button-border);
 }
 
 html.dark .mode-button.active {
   background: var(--blue);
   color: #ffffff;
-  border-color: #3b82f6;
+  border-color: var(--coord-input-focus-border);
 }
 
 html.dark .mode-button:hover {
-  background: #4b5563;
+  background: var(--mode-button-hover-bg);
 }
 
 html.dark .error-message {
-  color: #f87171;
+  color: var(--error-message-color);
 }

--- a/static/css/pages/stats-panel.css
+++ b/static/css/pages/stats-panel.css
@@ -8,28 +8,28 @@
     bottom: 20px;
     left: 70px;
     z-index: 2;
-    background: rgb(255 255 255 / 0.65);
+    background: var(--panel-glass-bg);
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
     border-radius: 8px;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-    border: 1px solid #e2e8f0;
+    box-shadow: 0 2px 8px var(--panel-shadow);
+    border: 1px solid var(--border-alt);
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 
     min-width: 5rem;
 }
 
 .stats-header {
-    background: rgb(241 245 249 / 0.75);
+    background: var(--panel-glass-bg);
     padding: 12px 16px;
     border-radius: 8px 8px 0 0;
-    border-bottom: 1px solid #e2e8f0;
+    border-bottom: 1px solid var(--border-alt);
 }
 
 .stats-title {
     font-weight: 600;
     font-size: 14px;
-    color: #1e293b;
+    color: var(--ink-strong);
     letter-spacing: -0.01em;
 }
 
@@ -55,22 +55,14 @@
 
 .stat-label {
     font-size: 13px;
-    color: #64748b;
+    color: var(--muted);
     font-weight: 500;
 }
 
 .stat-value {
     font-size: 13px;
     font-weight: 600;
-    color: #1e293b;
-}
-
-.stat-value.gain {
-    color: #28a745;
-}
-
-.stat-value.loss {
-    color: #dc3545;
+    color: var(--ink);
 }
 
 .stats-button {
@@ -122,7 +114,7 @@
     width: 800px; /* this is to  expand size */
     max-width: 100%; /* this prevents it from spilling off the right screen boundary */
     padding: 0 1rem;
-    border-left: 1px solid #e2e8f0; 
+    border-left: 1px solid var(--border-alt); 
 }
 
 #stat-content-and-chart-container {
@@ -139,8 +131,8 @@
     justify-content: center;
     text-align: center;
     padding: 1.5rem;
-    background-color: #f8fafc; /* Subtle, clean off-white background */
-    border: 1px dashed #cbd5e1; /* Clean dashed boundary border */
+    background-color: var(--surface-subtle); /* Subtle, clean off-white background */
+    border: 1px dashed var(--secondary-border); /* Clean dashed boundary border */
     border-radius: 8px;
     width: 90%;
     max-width: 400px;
@@ -149,16 +141,8 @@
 /* Simple typography styling matching your application colors */
 .empty-chart-state p {
     margin: 0;
-    color: #1f2937; /* Clean dark text */
+    color: var(--ink); /* Clean dark text */
     font-size: 0.95rem;
     font-weight: 500;
     line-height: 1.4;
-}
-
-
-/* DARK MODE */ 
-
-html.dark #route-stats .stat-value,
-html.dark #route-stats .stat-label {
-    color: #f3f4f6;
 }

--- a/static/js/constants.js
+++ b/static/js/constants.js
@@ -1,0 +1,1 @@
+export const MAP_VIEW_PADDING = [300, 340, 300, 430]

--- a/static/js/routes/loadRoute.js
+++ b/static/js/routes/loadRoute.js
@@ -31,6 +31,7 @@ import { deleteRoute, loadRoute } from "./routeApi.js";
 
 import { initChartToggleListener } from "../elevationChart.js";
 import { getSavedPointStyle } from "../saved_points/style.js";
+import { MAP_VIEW_PADDING } from "../constants.js";
 
 
 let routeList = null;
@@ -111,7 +112,7 @@ export function displayLoadedRouteOnMap(data) {
         if (complete) {
           view.fit(vectorSource.getExtent(), {
             size: map.getSize(),
-            padding: [50, 100, 100, 430],
+            padding: MAP_VIEW_PADDING,
             duration: 1000
           })
         }
@@ -123,7 +124,7 @@ export function displayLoadedRouteOnMap(data) {
   else {
     map.getView().fit(vectorSource.getExtent(), {
       size: map.getSize(),
-      padding: [50, 100, 100, 430],
+      padding: MAP_VIEW_PADDING,
       duration: 1000,
     });
   }

--- a/static/js/routes/saveRoute.js
+++ b/static/js/routes/saveRoute.js
@@ -34,7 +34,10 @@ import {
   formatElevation,
   formatETA
 } from "../utils/format-utils.js"
+
 import { toLonLat } from "ol/proj.js";
+
+import localforage from "localforage";
 
 let saveRouteForm = null;
 const allRoutesContainer = document.getElementById("all-routes-container");
@@ -52,13 +55,8 @@ export function initSaveRoute() {
   }
 }
 
-function handleSaveRoute(e) {
+async function handleSaveRoute(e) {
   e.preventDefault();
-
-  if (!window.appConfig.loggedIn) {
-    showLoginModal(true, 'save routes');
-    return;
-  }
 
   let elevDisplayValue; 
   let routeName = "";
@@ -72,6 +70,13 @@ function handleSaveRoute(e) {
     routeName = routeNameEntry.value;
     eta = routeETADisplay?.textContent;
     elevationChange = routeElevationDisplay?.textContent
+
+    if (!window.appConfig.loggedIn) {
+      showLoginModal(true, 'save routes');
+      await localforage.setItem("unauthenticated-save-route-attempt", true);
+      await localforage.setItem("cachedRouteName", routeName);
+      return;
+    }
 
 
     const mode = getCurrentMode();

--- a/static/js/routing/routing.js
+++ b/static/js/routing/routing.js
@@ -18,6 +18,7 @@ import { logError } from "../utils/logError-utils.js";
 
 import { fromLonLat, toLonLat } from "ol/proj.js";
 import { getDistance } from "ol/sphere.js";
+import localforage from "localforage";
 
 /**
  * Function used to calculate and return a path (and associated information) between two given points in projection EPSG: 4326 (Lon, Lat)
@@ -199,6 +200,8 @@ export async function addManualPoint(x, y) {
     logError("Calculating Path", error.message, null, "NO_PATH_FOUND");
     throw error;
   }
+
+  await localforage.setItem('cachedSegmentCache', segmentCache)
 
   // this appends the segment to pathCoords (skips first point to prevent duplication)
   manualRouteState.pathCoords.push(... segment.slice(1))

--- a/static/js/saved_points/savedPoints.js
+++ b/static/js/saved_points/savedPoints.js
@@ -1,6 +1,6 @@
 import { getSavedPointStyle } from "./style.js";
 import { getMap } from "../map.js";
-import { showLoginModal, showDeletePointModal } from "../ui.js";
+import { showLoginModal, showModal} from "../ui.js";
 import { showToast } from "../utils/ui-utils.js";
 import { logError } from "../utils/logError-utils.js";
 import { fromLonLat, toLonLat } from "ol/proj.js";
@@ -10,6 +10,7 @@ import VectorLayer from "ol/layer/Vector.js";
 import VectorSource from "ol/source/Vector.js";
 
 let savedPointsLayer = null;
+const deletePointModal = document.getElementById('delete-point-confirmation-dialog');
 
 export function getSavedPointsLayer() {
     return savedPointsLayer
@@ -161,23 +162,23 @@ export async function deleteSavedPoint(selectedPoint) {
     const data = await response.json();
 
     if (response.status === 401) {
-      showDeletePointModal(false);
+      showModal(false, deletePointModal);
       showLoginModal(true);
       return;
     }
     else if (!response.ok) {
-      showDeletePointModal(false);
+      showModal(false, deletePointModal);
       throw new Error(data.message || "There was an unexpected error whilst deleting your point, try again later.")
     }
 
     if (data.success) {
-      showDeletePointModal(false);
+      showModal(false, deletePointModal);
       selectedPoint = null;
       loadAndDisplaySavedPoints();
       return;
     }
     else {
-      showDeletePointModal(false);
+      showModal(false, deletePointModal);
       throw new Error(data.message || "There was an unexpected error whilst deleting your point, try again later.")
     }
   }

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -270,6 +270,38 @@ export function getClickMode() {
   return clickMode;
 }
 
+/**
+ * Checks if user is on mobile device and advices to use Crestr on desktop / laptop instead 
+ * 
+ * @param {void}
+ * @returns {void}
+ */
+function checkIfMobile() {
+  const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) || window.innerWidth < 1024;   
+  if (isMobile) {
+      document.body.innerHTML = `
+          <div style="height: 100vh; display: flex; align-items: center; justify-content: center; text-align: center; padding: 20px; font-family: system-ui;">
+              <div>
+                  <h1 style="font-size: 2.5rem; margin-bottom: 1rem;">Crestr Hiking App</h1>
+                  <p style="font-size: 1.3rem; margin-bottom: 2rem;">
+                      This website is designed for desktop only.
+                  </p>
+                  <p style="max-width: 500px; margin: 0 auto 2rem;">
+                      For the best experience on your phone, we’re building a dedicated mobile app.<br><br>
+                      In the meantime, please visit us on a laptop or desktop computer.
+                  </p>
+                  <button onclick="window.location.reload()" 
+                          style="padding: 14px 32px; font-size: 1.1rem; background: #2563eb; color: white; border: none; border-radius: 8px; cursor: pointer;">
+                      Refresh Anyway
+                  </button>
+              </div>
+          </div>
+      `;
+  }
+}
+//#endregion
+//#region DONATE MODAL
+
 //#region GENERAL MODAL
 
 /**

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -9,6 +9,9 @@ import Feature from "ol/Feature.js";
 import GeoJSON from "ol/format/GeoJSON.js"
 import { Translate } from "ol/interaction.js"
 
+// LocalForage
+import localforage from "localforage";
+
 // Local File Imports
 
 import {
@@ -43,7 +46,6 @@ import { calculatePath, addManualPoint } from "./routing/index.js";
 import {
   getMap,
   onMapClick,
-  onMapRenderComplete,
   getRouteLayer,
   getPathColour,
   setRouteLayer,
@@ -202,6 +204,13 @@ const donateModalContent = document.getElementById('donate-modal-content');
 const donateModalCloseButton = document.getElementById('donate-modal-close-button');
 const donateModalMaybeLaterButton = document.getElementById('donate-modal-maybe-later-button')
 
+// load last route modal
+const loadLastRouteModal = document.getElementById('load-last-route-dialog');
+const loadLastRouteModalContent = loadLastRouteModal.querySelector('.modal-content');
+const loadLastRouteModalRouteName = document.getElementById('load-last-route-dialog-route-name');
+const loadLastRouteModalLoadButton = document.getElementById('load-last-route-dialog-load-button');
+const loadLastRouteModalDismissButton = document.getElementById('load-last-route-dialog-dismiss-button');
+
 // saved route dash panel
 const openSavedRoutesDashButton = document.getElementById('saved-routes-dash-open-button');
 const closeSavedRoutesDashButton = document.getElementById('saved-routes-dash-go-back-button');
@@ -285,31 +294,35 @@ function checkIfMobile() {
 
 //#endregion
 
-//#region DONATE MODAL
+//#region GENERAL MODAL
 
 /**
- * Toggles the donate modal display and sets the action context
- * @param {boolean} show true if you want to show the modal, false if you want to hide the modal
- * @param {string} [actionName='perform this action'] the specific action that is being performed when showing the modal e.g save routes 
+ * Function used to catch clicks outside of a modal in order to close the modal upon these clicks. 
+ * 
+ * @param {Event} e 
+ * @param {HTMLDivElement} modalContent 
+ * @param {HTMLDialogElement} modal 
  * @returns {void}
  */
-export function showDonateModal(show) {
-  if (show) {
-    donateModal.showModal();
-  } 
-  else {
-    donateModal.close();
-  }
+function closeModalUponOutsideClick(e, modalContent, modal) {
+  if (modalContent && !modalContent.contains(e.target)) {
+      modal.close()
+    }
 };
 
 /**
- * Function used to catch clicks outside of the donate modal in order to close the modal upon these clicks 
- * @returns {void}
+ * Toggles the provided modal
+ * @param {boolean} show true if you want to show the modal, false if you want to hide the modal
+ * @param {HTMLDialogElement} modal The modal you want to open/close
+ * @returns {void} 
  */
-function dismissDonateModal(e) {
-  if (donateModalContent && !donateModalContent.contains(e.target)) {
-      showDonateModal(false);
-    }
+export function showModal(show, modal) {
+  if (show) {
+    modal.showModal();
+  } 
+  else {
+    modal.close();
+  }
 };
 
 //#endregion
@@ -346,40 +359,14 @@ function loginModalLogin() {
   return;
 };
 
-/**
- * Function used to catch clicks outside of the login modal in order to close the modal upon these clicks 
- * @returns {void}
- */
-function dismissLoginModal(e) {
-  if (loginModalContent && !loginModalContent.contains(e.target)) {
-      showLoginModal(false);
-    }
-};
-
 //#endregion
 
-//#region DELETE POINT MODAL
+//#region LOAD LAST ROUTE MODAL
 
-/**
- * Displays the Delete Point Modal if True is passed into the function and hides it if False is passed into the function
- * 
- * @param {boolean} show 
- * @returns {void}
- */
-export function showDeletePointModal(show) {
-  if (!deletePointModal) return;
-  show ? deletePointModal.showModal() : deletePointModal.close();
+function dismissLastLoadedRoute() {
+  showModal(false, loadLastRouteModal);
+  localforage.setItem('unauthenticated-save-route-attempt', false);
 }
-
-/**
- * Function used to catch clicks outside of the login modal in order to close the modal upon these clicks 
- * @returns {void}
- */
-function dismissDeletePointModal(e) {
-  if (deletePointModalContent && !deletePointModalContent.contains(e.target)) {
-      showDeletePointModal(false);
-    }
-};
 
 //#endregion
 
@@ -398,16 +385,6 @@ function showReportIssueModal(show) {
     reportIssueModal.close();
   }
 }
-
-/**
- * Closes the report issue modal if it registers a click outside of the modal
- * @returns {void}
- */
-function dismissReportIssueModal(e) {
-  if (reportIssueModalContent && !reportIssueModalContent.contains(e.target)) {
-      showReportIssueModal(false);
-    }
-};
 
 /**
  * This function validates the input fields for the report issue form.
@@ -680,7 +657,7 @@ export function mapClickHandler(event) {
     const pointName = selectedPoint.get("name");
     selectedPoint.setStyle(getSelectedPointStyle(pointName));
     deletePointModalNameDisplay.textContent = pointName;
-    showDeletePointModal(true);
+    showModal(true, deletePointModal);
   } 
   else if (!featureClicked) {
     const coordinate = event.coordinate;
@@ -988,9 +965,11 @@ function handleToggles(event) {
   event.currentTarget.classList.add("active");
 };
 
-function switchToAutoMode() {
+async function switchToAutoMode() {
   const map = getMap();
   if (!map) return;
+
+  await localforage.setItem("lastRoutingMode", "auto");
 
   setCurrentMode("auto");
   updateCursor();
@@ -1006,9 +985,11 @@ function switchToAutoMode() {
   clearAutoRoute();
 };
 
-function switchToManualMode() {
+async function switchToManualMode() {
   const map = getMap();
   if (!map) return;
+
+  await localforage.setItem("lastRoutingMode", "manual");
   
   setCurrentMode("manual");
   updateCursor();
@@ -1205,11 +1186,6 @@ function searchArea() {
 };
 //#endregion
 
-async function mapRenderComplete() {
-
-  loadAndDisplaySavedPoints();  
-};
-
 //#region AUTOMATIC ROUTING
 
 async function handleAutoRouteGeneration(start=null, end=null) {
@@ -1224,9 +1200,8 @@ async function handleAutoRouteGeneration(start=null, end=null) {
   try {
     const response = await calculatePath(startPoint, endPoint); // response.coordinates may return coordinates whereby each element has 3 values (x, y and elevation)
 
-    const routeStats = displayPath(response);
+    const routeStats = await displayPath(response);
 
-    routeStats.eta_seconds = formatETA(routeStats.eta_seconds)
     setLastKnownDistanceKm(routeStats.total_distance);
     setLastAutoRouteStats(routeStats);
     displayAutoRouteStats(getLastAutoRouteStats());
@@ -1246,7 +1221,7 @@ async function handleAutoRouteGeneration(start=null, end=null) {
   }
 };
 
-function displayPath(data) {
+async function displayPath(data) {
 
   try { 
   const map = getMap();
@@ -1270,7 +1245,7 @@ function displayPath(data) {
     featureProjection: "EPSG:3857",
   });
 
-  routeLayerSource.addFeature(pathFeature);
+  await routeLayerSource.addFeature(pathFeature);
 
   const coordinates = data.coordinates;
 
@@ -1290,6 +1265,14 @@ function displayPath(data) {
     interactivePointLayerSource.addFeature(startPointFeature)
     interactivePointLayerSource.addFeature(endPointFeature)
 
+    // only caches routes if user is not logged in
+    if (!window.appConfig.loggedIn) {
+      await localforage.setItem("cachedAutoRouteCoordinates", data.pathGeoJSON);
+      await localforage.setItem("cachedAutoRouteStartPointCoords", startMercatorCoord);
+      await localforage.setItem("cachedAutoRouteEndPointCoords", endMercatorCoord);
+      await localforage.setItem("cachedAutoRouteStats", data.route_stats);
+      console.log(data.route_stats);
+    }
   }
 
   setCurrentPathData(data.coordinates); // data.coordinates are [lon, lat, elev] (EPSG:4326)
@@ -1311,7 +1294,7 @@ function displayPath(data) {
   }
 };
 
-function displayAutoRouteStats(routeStats) {
+async function displayAutoRouteStats(routeStats) {
 
   let statsDiv = document.getElementById("route-stats");
 
@@ -1323,8 +1306,154 @@ function displayAutoRouteStats(routeStats) {
   statsDiv.id = "route-stats";
   document.body.appendChild(statsDiv);
 
-  statsDiv.innerHTML = createStatsPanel(formatDistance(parseFloat(routeStats.total_distance)), routeStats.eta_seconds, formatElevation(routeStats.elevation_gain))
+  statsDiv.innerHTML = createStatsPanel(formatDistance(parseFloat(routeStats.total_distance)), formatETA(routeStats.eta_seconds), formatElevation(routeStats.elevation_gain))
 };
+
+//#endregion
+
+//#region CACHED ROUTES
+
+async function handleLoadCachedAutoRoute() {
+  try {
+    await displayCachedRoute();
+
+    const [cachedCoords, cachedRouteStats] = await Promise.all([
+      await localforage.getItem("cachedAutoRouteCoordinates"),
+      await localforage.getItem('cachedAutoRouteStats')
+    ])
+
+    setLastKnownDistanceKm(cachedRouteStats.total_distance);
+
+    await displayCachedRouteStats(cachedRouteStats);
+
+    resetElevationChart();
+    initChartToggleListener();
+    createElevationProfile(cachedCoords.geometry.coordinates);
+
+    setCurrentPathData(cachedCoords.geometry.coordinates);
+
+    if (saveContainer) saveContainer.style.display = "flex";
+  }
+  catch(error) {
+    console.log(error.message)
+    showToast("There was an error loading you last route", "error", null);
+  }
+}
+    
+
+/**
+ * Loads the last cached route, automatically determines if route is manual / auto generated and retrieves the appropriate cached data 
+ * makes use of localforage as opposed to localstorage due to high volume data 
+ * @param {void} 
+ * @returns {void}
+ */
+async function displayCachedRoute() {
+
+  const currentMode = await localforage.getItem("lastRoutingMode"); // needed to differentiate between cached auto routes / cached manual routes
+  const map = getMap(); 
+
+  if (loadLastRouteModal) showModal(false, loadLastRouteModal);
+  // if (await localforage.getItem('unauthenticated-save-route-attempt')) localforage.setItem('unauthenticated-save-route-attempt', false);
+
+  try {  
+    if (currentMode === "auto") {
+
+      const routeLayer = getRouteLayer();
+
+      const routeLayerSource = routeLayer.getSource();
+      const interactivePointLayerSource = interactivePointLayer.getSource();
+
+      // clears all current features if present (unlikely given this occurs upon app load)
+      routeLayerSource.clear();
+      interactivePointLayerSource.getFeatures()
+      .filter(feature => feature.get('type') === 'start' || feature.get('type') === 'end')
+      .forEach(feature => interactivePointLayerSource.removeFeature(feature))
+
+      // clears the hovered point feature to prevent the preserving of stale OL point features
+      setHoverPointFeature(null);
+
+      // retrieves cached data in parallel 
+      const [cachedCoords, cachedStartCoords, cachedEndCoords] = await Promise.all([
+        localforage.getItem("cachedAutoRouteCoordinates"),
+        localforage.getItem("cachedAutoRouteStartPointCoords"),
+        localforage.getItem("cachedAutoRouteEndPointCoords")
+      ]);
+
+      // recreates the path, start point and end point features 
+      const pathFeature = new GeoJSON().readFeature(cachedCoords, {
+        dataProjection: "EPSG:4326",
+        featureProjection: "EPSG:3857",
+      });
+
+      const startPointFeature = createPoint(
+        cachedStartCoords,
+        getSavedPointStyle("Start", "#00A86B"),
+        "start",
+        "Start"
+      )
+
+      const endPointFeature = createPoint(
+        cachedEndCoords,
+        getSavedPointStyle("End", "#D32F2F"),
+        "end", 
+        "End"
+      )
+
+      // adds the features to the sources of the vector layers on the map --> displays the features on the map 
+      routeLayerSource.addFeature(pathFeature);
+      interactivePointLayerSource.addFeature(startPointFeature)
+      interactivePointLayerSource.addFeature(endPointFeature)
+
+      setTimeout(() => {
+        map.getView().fit(routeLayerSource.getExtent(), {
+          padding: [300, 300, 300, 430],
+          duration: 1200,
+        });
+        map.render();
+      }, 100);
+    }
+  }
+  catch (error) {
+    throw new Error(error.message);
+  }
+}
+
+async function displayCachedRouteStats(routeStats) {
+  try {
+    const parsedStats = typeof routeStats === "string" ? JSON.parse(routeStats) : routeStats;
+
+    console.log(routeStats);
+
+    let statsDiv = document.getElementById("route-stats");
+
+    if (statsDiv) {
+      statsDiv.remove();
+    };
+
+    statsDiv = document.createElement("div");
+    statsDiv.id = "route-stats";
+    document.body.appendChild(statsDiv);
+
+    statsDiv.innerHTML = createStatsPanel(formatDistance(parseFloat(parsedStats.total_distance)), formatETA(parsedStats.eta_seconds), formatElevation(parsedStats.elevation_gain));
+  }
+  catch (error) {
+    throw new Error(error.message)
+  }
+}
+
+async function handleInitialLoadCachedRoute() { 
+  const hasPreviousSaveAttempt = await localforage.getItem('unauthenticated-save-route-attempt')
+
+  if (hasPreviousSaveAttempt && window.appConfig.loggedIn) {
+    loadLastRouteModalRouteName.textContent = await localforage.getItem('cachedRouteName')
+    showModal(true, loadLastRouteModal);
+  }
+  else {
+    return;
+  }
+}
+
+window.displayCachedRoute = displayCachedRoute
 
 //#endregion
 
@@ -1878,7 +2007,7 @@ function initPointDeleteHandlers() {
 
   // for hiding if clicking anywhere outside the modal
   deletePointModal.addEventListener("click", (e) => {
-    dismissDeletePointModal(e);
+    closeModalUponOutsideClick(e, deletePointModalContent, deletePointModal)
   });
 
   // for deselecting the currently-selected point when the modal is closed 
@@ -1886,7 +2015,7 @@ function initPointDeleteHandlers() {
 
   // for when the user clicks the 'exit' button on the modal
   deletePointModalExitButton?.addEventListener("click", () => {
-    showDeletePointModal(false)
+    showModal(false, deletePointModal)
   });
 
   // for when the user clicks 'delete point' on the modal
@@ -1901,6 +2030,8 @@ export function initUi() {
     initCursorManager(map, getCurrentMode, getClickMode);
   }
 
+  localforage.setItem("lastRoutingMode", "auto");
+
   applyTheme(getTheme());
 
   initSaveRoute();
@@ -1912,9 +2043,13 @@ export function initUi() {
   // initial tour (automatic routing and saving the first route)
   handleInitialTour();
 
+  // shows modal to load previous route if prompted to login after attempted save route
+  handleInitialLoadCachedRoute()
+
   // These event listeners are for settings and preferences.
   setOnDistanceUnitChange(() => handleDistanceUnitToggle());
   window.addEventListener("load", checkIfMobile);
+  window.addEventListener('DOMContentLoaded', loadAndDisplaySavedPoints);
   window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
     applyTheme(getTheme());
   });
@@ -1971,22 +2106,25 @@ export function initUi() {
   addClickListener(document, handleKeyboardShortcuts, "keydown");
 
   // These event listeners are for the login modal
-  addClickListener(loginModalExitButton, () => showLoginModal(false), 'click');
+  addClickListener(loginModalExitButton, () => showModal(false, loginModal), 'click');
   addClickListener(loginModalLoginButton, loginModalLogin, 'click');
-  addClickListener(loginModal, dismissLoginModal, 'click');
+  addClickListener(loginModal, (e) => closeModalUponOutsideClick(e, loginModalContent, loginModal), 'click');
 
   // These event listeners are for the report issue modal
   addClickListener(reportIssueModalExit, () => showReportIssueModal(false), "click");
   addClickListener(reportIssueModalSubmit, () => handleReportIssueSubmission(reportIssueTitleInput.value.trim(), reportIssueTextAreaInput.value.trim()), "click");
 
   // These event listeners are for the donate modal
-  addClickListener(donateModalCloseButton, () => showDonateModal(false), "click");
-  addClickListener(donateModalMaybeLaterButton, () => showDonateModal(false), "click");
-  addClickListener(donateButton, () => showDonateModal(true), "click");
-  addClickListener(donateModal, dismissDonateModal, "click");
+  addClickListener(donateModalCloseButton, () => showModal(false, donateModal), "click");
+  addClickListener(donateModalMaybeLaterButton, () => showModal(false, donateModal), "click");
+  addClickListener(donateButton, () => showModal(true, donateModal), "click");
+  addClickListener(donateModal, (e) => closeModalUponOutsideClick(e, donateModal, donateModalContent), "click");
+
+  // These event listeners are for the load last route modal
+  addClickListener(loadLastRouteModalDismissButton, dismissLastLoadedRoute, "click");
+  addClickListener(loadLastRouteModalLoadButton, handleLoadCachedAutoRoute, "click");
 
   onMapClick(mapClickHandler);
-  onMapRenderComplete(mapRenderComplete);
 
   // These event listeners are for returning the map to the Lake District + clearing inputs
   autoHomeButton?.addEventListener("click", homeButtonFunction);

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1317,12 +1317,16 @@ async function handleLoadCachedAutoRoute() {
   try {
     await displayCachedRoute();
 
-    const [cachedCoords, cachedRouteStats] = await Promise.all([
+    const [cachedCoords, cachedRouteStats, startWebMercator, endWebMercator] = await Promise.all([
       await localforage.getItem("cachedAutoRouteCoordinates"),
-      await localforage.getItem('cachedAutoRouteStats')
+      await localforage.getItem('cachedAutoRouteStats'),
+      await localforage.getItem('cachedAutoRouteStartPointCoords'),
+      await localforage.getItem('cachedAutoRouteEndPointCoords')
     ])
 
     setLastKnownDistanceKm(cachedRouteStats.total_distance);
+    startCoordEntry.value = formatLatLon(toLonLat(startWebMercator))
+    endCoordEntry.value = formatLatLon(toLonLat(endWebMercator))
 
     await displayCachedRouteStats(cachedRouteStats);
 
@@ -1401,8 +1405,9 @@ async function displayCachedRoute() {
 
       // adds the features to the sources of the vector layers on the map --> displays the features on the map 
       routeLayerSource.addFeature(pathFeature);
-      interactivePointLayerSource.addFeature(startPointFeature)
-      interactivePointLayerSource.addFeature(endPointFeature)
+      addStartEndPoint(startPointFeature, interactivePointLayer, "start");
+      addStartEndPoint(endPointFeature, interactivePointLayer, "end");
+      setUpPointInteraction([interactivePointLayer]);
 
       setTimeout(() => {
         map.getView().fit(routeLayerSource.getExtent(), {

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -9,6 +9,9 @@ import Feature from "ol/Feature.js";
 import GeoJSON from "ol/format/GeoJSON.js"
 import { Translate } from "ol/interaction.js"
 
+// constants
+import { MAP_VIEW_PADDING } from "./constants.js";
+
 // LocalForage
 import localforage from "localforage";
 
@@ -207,9 +210,12 @@ const donateModalMaybeLaterButton = document.getElementById('donate-modal-maybe-
 // load last route modal
 const loadLastRouteModal = document.getElementById('load-last-route-dialog');
 const loadLastRouteModalContent = loadLastRouteModal.querySelector('.modal-content');
-const loadLastRouteModalRouteName = document.getElementById('load-last-route-dialog-route-name');
 const loadLastRouteModalLoadButton = document.getElementById('load-last-route-dialog-load-button');
 const loadLastRouteModalDismissButton = document.getElementById('load-last-route-dialog-dismiss-button');
+const loadLastRouteModalRouteName = document.getElementById('load-last-route-modal-route-name');
+const loadLastRouteModalRouteDistance = document.getElementById('load-last-route-modal-route-distance');
+const loadLastRouteModalRouteElevationGain = document.getElementById('load-last-route-modal-route-elevation-gain');
+
 
 // saved route dash panel
 const openSavedRoutesDashButton = document.getElementById('saved-routes-dash-open-button');
@@ -263,36 +269,6 @@ let interactivePointLayer = null; // stores the vector layer which holds the poi
 export function getClickMode() {
   return clickMode;
 }
-
-//#region MOBILE CHECK
-
-// check if user is on mobile and take subsequent action to inform them of decision to make Crest desktop only on web
-function checkIfMobile() {
-  const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent) || window.innerWidth < 1024;   
-
-  if (isMobile) {
-      document.body.innerHTML = `
-          <div style="height: 100vh; display: flex; align-items: center; justify-content: center; text-align: center; padding: 20px; font-family: system-ui;">
-              <div>
-                  <h1 style="font-size: 2.5rem; margin-bottom: 1rem;">Crest Hiking App</h1>
-                  <p style="font-size: 1.3rem; margin-bottom: 2rem;">
-                      This website is designed for desktop only.
-                  </p>
-                  <p style="max-width: 500px; margin: 0 auto 2rem;">
-                      For the best experience on your phone, we’re building a dedicated mobile app.<br><br>
-                      In the meantime, please visit us on a laptop or desktop computer.
-                  </p>
-                  <button onclick="window.location.reload()" 
-                          style="padding: 14px 32px; font-size: 1.1rem; background: #2563eb; color: white; border: none; border-radius: 8px; cursor: pointer;">
-                      Refresh Anyway
-                  </button>
-              </div>
-          </div>
-      `;
-  }
-}
-
-//#endregion
 
 //#region GENERAL MODAL
 
@@ -363,9 +339,37 @@ function loginModalLogin() {
 
 //#region LOAD LAST ROUTE MODAL
 
-function dismissLastLoadedRoute() {
+function discardLastLoadedRoute() {
   showModal(false, loadLastRouteModal);
-  localforage.setItem('unauthenticated-save-route-attempt', false);
+  localforage.clear();
+}
+
+function populateLastLoadedRouteModal(routeStats, routeName) {
+  loadLastRouteModalRouteName.textContent = routeName || 'Untitled route';
+  loadLastRouteModalRouteDistance.textContent = formatDistance(routeStats.total_distance)
+  loadLastRouteModalRouteElevationGain.textContent = `${routeStats.elevation_gain} m`
+}
+
+
+async function handleInitialLoadCachedRoute() { 
+  const hasPreviousSaveAttempt = await localforage.getItem('unauthenticated-save-route-attempt')
+  const routeName = await localforage.getItem('cachedRouteName'); 
+  const lastRoutingMode = await localforage.getItem('lastRoutingMode');
+
+  if (!hasPreviousSaveAttempt || !window.appConfig.loggedIn) return;
+
+  if (lastRoutingMode === "auto") {
+    const routeStats = await localforage.getItem('cachedAutoRouteStats');
+
+    populateLastLoadedRouteModal(routeStats, routeName);
+    showModal(true, loadLastRouteModal);
+  }
+  else {
+    const routeStats = await localforage.getItem('cachedManualRouteStats');
+
+    populateLastLoadedRouteModal(routeStats, routeName);
+    showModal(true, loadLastRouteModal);
+  }
 }
 
 //#endregion
@@ -1192,6 +1196,8 @@ async function handleAutoRouteGeneration(start=null, end=null) {
   const startPoint = start || startCoordEntry?.value || "";
   const endPoint = end || endCoordEntry?.value || "";
 
+  if (await localforage.getItem('lastRoutingMode') !== "auto") localforage.setItem('lastRoutingMode', "auto");
+
   if (validateInputCoords(startPoint, endPoint) !== true) return;
 
   generatePathButton.disabled = true;
@@ -1204,6 +1210,9 @@ async function handleAutoRouteGeneration(start=null, end=null) {
 
     setLastKnownDistanceKm(routeStats.total_distance);
     setLastAutoRouteStats(routeStats);
+
+    console.log(`AUTO ROUTE STATS : ${routeStats}`);
+
     displayAutoRouteStats(getLastAutoRouteStats());
     
     resetElevationChart();
@@ -1313,152 +1322,253 @@ async function displayAutoRouteStats(routeStats) {
 
 //#region CACHED ROUTES
 
-async function handleLoadCachedAutoRoute() {
+async function handleLoadCachedRoute() {
+  const routeType = await localforage.getItem("lastRoutingMode"); // needed to differentiate between cached auto routes / cached manual routes
+  if (loadLastRouteModal) showModal(false, loadLastRouteModal); // hides modal 
+
   try {
-    await displayCachedRoute();
-
-    const [cachedCoords, cachedRouteStats, startWebMercator, endWebMercator] = await Promise.all([
-      await localforage.getItem("cachedAutoRouteCoordinates"),
-      await localforage.getItem('cachedAutoRouteStats'),
-      await localforage.getItem('cachedAutoRouteStartPointCoords'),
-      await localforage.getItem('cachedAutoRouteEndPointCoords')
-    ])
-
-    setLastKnownDistanceKm(cachedRouteStats.total_distance);
-    startCoordEntry.value = formatLatLon(toLonLat(startWebMercator))
-    endCoordEntry.value = formatLatLon(toLonLat(endWebMercator))
-
-    await displayCachedRouteStats(cachedRouteStats);
-
-    resetElevationChart();
-    initChartToggleListener();
-    createElevationProfile(cachedCoords.geometry.coordinates);
-
-    setCurrentPathData(cachedCoords.geometry.coordinates);
-
-    if (saveContainer) saveContainer.style.display = "flex";
+    if (routeType === "auto") {
+      handleLoadAutoCachedRoute();
+    }
+    else if (routeType === "manual") {
+      switchToManualMode();
+      handleLoadManualCachedRoute();
+    }
+    else {
+      throw new Error("Invalid route type given")
+    }
   }
   catch(error) {
     console.log(error.message)
     showToast("There was an error loading you last route", "error", null);
   }
+  finally {
+    localforage.clear();
+  }
+}
+
+async function handleLoadAutoCachedRoute() {
+  try {
+      await displayAutoCachedRoute();
+
+      const [cachedCoords, cachedRouteStats, startWebMercator, endWebMercator] = await Promise.all([
+        await localforage.getItem("cachedAutoRouteCoordinates"),
+        await localforage.getItem('cachedAutoRouteStats'),
+        await localforage.getItem('cachedAutoRouteStartPointCoords'),
+        await localforage.getItem('cachedAutoRouteEndPointCoords')
+      ])
+
+      const parsedStats = typeof cachedRouteStats === "string" ? JSON.parse(cachedRouteStats) : cachedRouteStats;
+      setLastAutoRouteStats(parsedStats)
+
+      setLastKnownDistanceKm(cachedRouteStats.total_distance);
+      startCoordEntry.value = formatLatLon(toLonLat(startWebMercator))
+      endCoordEntry.value = formatLatLon(toLonLat(endWebMercator))
+
+      await displayAutoCachedRouteStats(parsedStats);
+
+      resetElevationChart();
+      initChartToggleListener();
+      createElevationProfile(cachedCoords.geometry.coordinates);
+
+      setCurrentPathData(cachedCoords.geometry.coordinates);
+
+      if (saveContainer) saveContainer.style.display = "flex";
+  }
+  catch(error) {
+    throw new Error(error.message);
+  }
 }
     
-
 /**
  * Loads the last cached route, automatically determines if route is manual / auto generated and retrieves the appropriate cached data 
  * makes use of localforage as opposed to localstorage due to high volume data 
- * @param {void} 
+ * @param {void}
  * @returns {void}
  */
-async function displayCachedRoute() {
-
-  const currentMode = await localforage.getItem("lastRoutingMode"); // needed to differentiate between cached auto routes / cached manual routes
+async function displayAutoCachedRoute() {
   const map = getMap(); 
 
-  if (loadLastRouteModal) showModal(false, loadLastRouteModal);
   // if (await localforage.getItem('unauthenticated-save-route-attempt')) localforage.setItem('unauthenticated-save-route-attempt', false);
 
   try {  
-    if (currentMode === "auto") {
 
-      const routeLayer = getRouteLayer();
+    const routeLayer = getRouteLayer();
 
-      const routeLayerSource = routeLayer.getSource();
-      const interactivePointLayerSource = interactivePointLayer.getSource();
+    const routeLayerSource = routeLayer.getSource();
+    const interactivePointLayerSource = interactivePointLayer.getSource();
 
-      // clears all current features if present (unlikely given this occurs upon app load)
-      routeLayerSource.clear();
-      interactivePointLayerSource.getFeatures()
-      .filter(feature => feature.get('type') === 'start' || feature.get('type') === 'end')
-      .forEach(feature => interactivePointLayerSource.removeFeature(feature))
+    // clears all current features if present (unlikely given this occurs upon app load)
+    routeLayerSource.clear();
+    interactivePointLayerSource.getFeatures()
+    .filter(feature => feature.get('type') === 'start' || feature.get('type') === 'end')
+    .forEach(feature => interactivePointLayerSource.removeFeature(feature))
 
-      // clears the hovered point feature to prevent the preserving of stale OL point features
-      setHoverPointFeature(null);
+    // clears the hovered point feature to prevent the preserving of stale OL point features
+    setHoverPointFeature(null);
 
-      // retrieves cached data in parallel 
-      const [cachedCoords, cachedStartCoords, cachedEndCoords] = await Promise.all([
-        localforage.getItem("cachedAutoRouteCoordinates"),
-        localforage.getItem("cachedAutoRouteStartPointCoords"),
-        localforage.getItem("cachedAutoRouteEndPointCoords")
-      ]);
+    // retrieves cached data in parallel 
+    const [cachedCoords, cachedStartCoords, cachedEndCoords] = await Promise.all([
+      localforage.getItem("cachedAutoRouteCoordinates"),
+      localforage.getItem("cachedAutoRouteStartPointCoords"),
+      localforage.getItem("cachedAutoRouteEndPointCoords")
+    ]);
 
-      // recreates the path, start point and end point features 
-      const pathFeature = new GeoJSON().readFeature(cachedCoords, {
-        dataProjection: "EPSG:4326",
-        featureProjection: "EPSG:3857",
+    // recreates the path, start point and end point features 
+    const pathFeature = new GeoJSON().readFeature(cachedCoords, {
+      dataProjection: "EPSG:4326",
+      featureProjection: "EPSG:3857",
+    });
+
+    const startPointFeature = createPoint(
+      cachedStartCoords,
+      getSavedPointStyle("Start", "#00A86B"),
+      "start",
+      "Start"
+    )
+
+    const endPointFeature = createPoint(
+      cachedEndCoords,
+      getSavedPointStyle("End", "#D32F2F"),
+      "end", 
+      "End"
+    )
+
+    // adds the features to the sources of the vector layers on the map --> displays the features on the map 
+    routeLayerSource.addFeature(pathFeature);
+    addStartEndPoint(startPointFeature, interactivePointLayer, "start");
+    addStartEndPoint(endPointFeature, interactivePointLayer, "end");
+    setUpPointInteraction([interactivePointLayer]);
+
+    setTimeout(() => {
+      map.getView().fit(routeLayerSource.getExtent(), {
+        padding: MAP_VIEW_PADDING,
+        duration: 1200,
       });
-
-      const startPointFeature = createPoint(
-        cachedStartCoords,
-        getSavedPointStyle("Start", "#00A86B"),
-        "start",
-        "Start"
-      )
-
-      const endPointFeature = createPoint(
-        cachedEndCoords,
-        getSavedPointStyle("End", "#D32F2F"),
-        "end", 
-        "End"
-      )
-
-      // adds the features to the sources of the vector layers on the map --> displays the features on the map 
-      routeLayerSource.addFeature(pathFeature);
-      addStartEndPoint(startPointFeature, interactivePointLayer, "start");
-      addStartEndPoint(endPointFeature, interactivePointLayer, "end");
-      setUpPointInteraction([interactivePointLayer]);
-
-      setTimeout(() => {
-        map.getView().fit(routeLayerSource.getExtent(), {
-          padding: [300, 300, 300, 430],
-          duration: 1200,
-        });
-        map.render();
-      }, 100);
-    }
+      map.render();
+    }, 100);
   }
   catch (error) {
     throw new Error(error.message);
   }
 }
 
-async function displayCachedRouteStats(routeStats) {
+async function displayAutoCachedRouteStats(routeStats) {
   try {
-    const parsedStats = typeof routeStats === "string" ? JSON.parse(routeStats) : routeStats;
-
-    console.log(routeStats);
 
     let statsDiv = document.getElementById("route-stats");
 
     if (statsDiv) {
       statsDiv.remove();
     };
+    
+    console.log(`LAST AUTO ROUTE STATS : ${JSON.stringify(getLastAutoRouteStats())}`)
+    console.log(`AUTO CACHED ROUTES : ${JSON.stringify(routeStats)}`)
+    console.log(`LAST AUTO ROUTE STATS : ${JSON.stringify(getLastAutoRouteStats())}`)
 
     statsDiv = document.createElement("div");
     statsDiv.id = "route-stats";
     document.body.appendChild(statsDiv);
 
-    statsDiv.innerHTML = createStatsPanel(formatDistance(parseFloat(parsedStats.total_distance)), formatETA(parsedStats.eta_seconds), formatElevation(parsedStats.elevation_gain));
+    statsDiv.innerHTML = createStatsPanel(formatDistance(parseFloat(routeStats.total_distance)), formatETA(routeStats.eta_seconds), formatElevation(routeStats.elevation_gain));
   }
   catch (error) {
     throw new Error(error.message)
   }
 }
 
-async function handleInitialLoadCachedRoute() { 
-  const hasPreviousSaveAttempt = await localforage.getItem('unauthenticated-save-route-attempt')
+async function handleLoadManualCachedRoute() {
 
-  if (hasPreviousSaveAttempt && window.appConfig.loggedIn) {
-    loadLastRouteModalRouteName.textContent = await localforage.getItem('cachedRouteName')
-    showModal(true, loadLastRouteModal);
+  console.log('updating route state')
+  const updateManualRouteState = (newUserClicks, newPathCoords, newSegmentCache) => {
+    manualRouteState.userClicks = newUserClicks;
+    manualRouteState.pathCoords = newPathCoords;
+    manualRouteState.segmentCache = newSegmentCache;
   }
-  else {
-    return;
+
+  const newUserClicks = await localforage.getItem('cachedUserClicks');
+  const newPathCoords = await localforage.getItem('cachedPathCoords');
+  const newSegmentCache = await localforage.getItem('cachedSegmentCache');
+
+  await updateManualRouteState(newUserClicks, newPathCoords, newSegmentCache)
+
+  const map = getMap();
+  if (!map) return;
+
+  if (manualRouteLayer) map.removeLayer(manualRouteLayer);
+  if (!removeExistingStats()) return;
+
+  if (saveContainer) saveContainer.style.display = "flex";
+
+  const { userClicks, pathCoords } = manualRouteState;
+  const totalDistanceKm = calculateTotalDistance(pathCoords) / 1000;
+  const distanceDisplay = formatDistance(totalDistanceKm);
+  const etaDisplay = calculateEta(totalDistanceKm);
+  const isSnappedToEnd = checkIfCircularRoute();
+  const features = [];
+  const elevationGainDisplay = formatElevation(calculateElevationGain(pathCoords));
+
+  localforage.setItem('cachedUserClicks', userClicks)
+  localforage.setItem('cachedPathCoords', pathCoords)
+  
+  setLastKnownDistanceKm(totalDistanceKm);
+
+  userClicks.forEach((point, index) => {
+    const feature = new Feature({
+      geometry: new Point(point),
+      type: "point",
+    });
+    feature.set("index", index);
+    features.push(feature);
+  });
+
+  if (pathCoords.length > 1) {
+    features.push(
+      new Feature({
+        geometry: new LineString(pathCoords),
+        type: "line",
+      }),
+    );
   }
+
+  manualRouteLayer = new VectorLayer({
+    source: new VectorSource({ features }),
+    style(feature) {
+      const featureType = feature.get("type");
+      if (featureType === "point") {
+        const index = feature.get("index");
+        const isStart = index === 0;
+        const isEnd = index === userClicks.length - 1;
+
+        if (isSnappedToEnd) {
+          if (isStart) return getSavedPointStyle("Start/End", "#00A86B");
+          if (isEnd) return getSavedPointStyle("", "#00A86B");
+        }
+        if (isStart) return getSavedPointStyle("Start", "#00A86B");
+        if (isEnd) return getSavedPointStyle("End", "#D32F2F");
+        return createManualPointStyle("", "#000", 6.5);
+      }
+      return new Style({
+        stroke: new Stroke(getRouteStrokeStyle()),
+      });
+    },
+  });
+
+  map.addLayer(manualRouteLayer);
+
+  const isOnePoint = pathCoords.length === 1;
+
+  updateManualRouteStats(isOnePoint, distanceDisplay, etaDisplay, elevationGainDisplay, pathCoords);
+  createElevationProfile(pathCoords);
+
+  setTimeout(() => {
+    map.getView().fit(manualRouteLayer.getSource().getExtent(), {
+      padding: MAP_VIEW_PADDING,
+      duration: 1200,
+    });
+    map.render();
+  }, 100);
 }
-
-window.displayCachedRoute = displayCachedRoute
 
 //#endregion
 
@@ -1494,7 +1604,7 @@ function removeExistingStats() {
   return true;
 };
 
-export function updateManualRoute() {
+export async function updateManualRoute() {
   const map = getMap();
   if (!map) return;
 
@@ -1510,7 +1620,12 @@ export function updateManualRoute() {
   const isSnappedToEnd = checkIfCircularRoute();
   const features = [];
   const elevationGainDisplay = formatElevation(calculateElevationGain(pathCoords));
-  
+
+  if (!window.appConfig.loggedIn) {
+    await localforage.setItem('cachedUserClicks', userClicks);
+    await localforage.setItem('cachedPathCoords', pathCoords);
+    await localforage.setItem('cachedManualRouteStats', {"total_distance": totalDistanceKm, "elevation_gain": calculateElevationGain(pathCoords)});
+  }
   setLastKnownDistanceKm(totalDistanceKm);
 
   userClicks.forEach((point, index) => {
@@ -2035,8 +2150,6 @@ export function initUi() {
     initCursorManager(map, getCurrentMode, getClickMode);
   }
 
-  localforage.setItem("lastRoutingMode", "auto");
-
   applyTheme(getTheme());
 
   initSaveRoute();
@@ -2053,8 +2166,11 @@ export function initUi() {
 
   // These event listeners are for settings and preferences.
   setOnDistanceUnitChange(() => handleDistanceUnitToggle());
-  window.addEventListener("load", checkIfMobile);
+
+  // This ensures that points are loaded near instantly 
   window.addEventListener('DOMContentLoaded', loadAndDisplaySavedPoints);
+
+  // This ensures that the theme of the app changes if system settings switch to dark mode after sunset 
   window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
     applyTheme(getTheme());
   });
@@ -2123,11 +2239,12 @@ export function initUi() {
   addClickListener(donateModalCloseButton, () => showModal(false, donateModal), "click");
   addClickListener(donateModalMaybeLaterButton, () => showModal(false, donateModal), "click");
   addClickListener(donateButton, () => showModal(true, donateModal), "click");
-  addClickListener(donateModal, (e) => closeModalUponOutsideClick(e, donateModal, donateModalContent), "click");
+  addClickListener(donateModal, (e) => closeModalUponOutsideClick(e, donateModalContent, donateModal), "click");
 
   // These event listeners are for the load last route modal
-  addClickListener(loadLastRouteModalDismissButton, dismissLastLoadedRoute, "click");
-  addClickListener(loadLastRouteModalLoadButton, handleLoadCachedAutoRoute, "click");
+  addClickListener(loadLastRouteModalDismissButton, discardLastLoadedRoute, "click");
+  addClickListener(loadLastRouteModalLoadButton, handleLoadCachedRoute, "click");
+  addClickListener(loadLastRouteModal, (e) => closeModalUponOutsideClick(e, loadLastRouteModalContent, loadLastRouteModal), "click");
 
   onMapClick(mapClickHandler);
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -2199,6 +2199,9 @@ export function initUi() {
   // These event listeners are for settings and preferences.
   setOnDistanceUnitChange(() => handleDistanceUnitToggle());
 
+  // This ensures mobile users are warned about the poor design of the mobile web UI
+  window.addEventListener("load", checkIfMobile);
+
   // This ensures that points are loaded near instantly 
   window.addEventListener('DOMContentLoaded', loadAndDisplaySavedPoints);
 

--- a/templates/map.html
+++ b/templates/map.html
@@ -289,14 +289,30 @@
         <dialog id="load-last-route-dialog" class="modal-overlay">
             <div class="modal-wrapper">
                 <div class="modal-content">
+
                     <div class="modal-header">
-                        <h2>Load <span id="load-last-route-dialog-route-name">Last Route</span></h2>
+                        <h2>Load your last route?</h2>
                     </div>
+
                     <div class="modal-body">
-                        <p>Do you want to load the last route you were working on ?</p>
+                        <div class="load-last-route-modal-route-container">
+                            <div class="load-last-route-modal-route-row">
+                                <p>Name</p>
+                                <span id="load-last-route-modal-route-name" class="modal-route-name"></span>
+                            </div>
+                            <div class="load-last-route-modal-route-row">
+                                <p>Distance</p>
+                                <span id="load-last-route-modal-route-distance" class="modal-route-distance"></span>
+                            </div>
+                            <div class="load-last-route-modal-route-row">
+                                <p>Elevation Gain</p>
+                                <span id="load-last-route-modal-route-elevation-gain"></span>
+                            </div>
+                        </div>
                     </div>
+
                     <div class="modal-actions">
-                        <button type="button" id="load-last-route-dialog-dismiss-button" class="modal-btn modal-btn-secondary">Dismiss</button>
+                        <button type="button" id="load-last-route-dialog-dismiss-button" class="modal-btn modal-btn-danger">Discard</button>
                         <button id="load-last-route-dialog-load-button" class="modal-btn modal-btn-normal">Load</button>
                     </div>
                 </div>

--- a/templates/map.html
+++ b/templates/map.html
@@ -285,6 +285,26 @@
             </div>
         </dialog>
 
+        <!-- ##### LOAD LAST ROUTE MODAL ##### -->
+        <dialog id="load-last-route-dialog" class="modal-overlay">
+            <div class="modal-wrapper">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h2>Load <span id="load-last-route-dialog-route-name">Last Route</span></h2>
+                    </div>
+                    <div class="modal-body">
+                        <p>Do you want to load the last route you were working on ?</p>
+                    </div>
+                    <div class="modal-actions">
+                        <button type="button" id="load-last-route-dialog-dismiss-button" class="modal-btn modal-btn-secondary">Dismiss</button>
+                        <button id="load-last-route-dialog-load-button" class="modal-btn modal-btn-normal">Load</button>
+                    </div>
+                </div>
+            </div>
+        </dialog>
+
+
+
 
         <div id="map"></div>
     </div>


### PR DESCRIPTION
# Pull Request Template

## Summary
Improve developer experience by eliminating hashed filenames (no more `docker-compose restart` needed for frontend changes), add route caching + loading for both auto-generated and manual routes (including after unauthenticated save attempts), and apply assorted UI polish, map fitting fixes, and config cleanup.

## Related Issue
Closes ABD-22

## Type of Change
Select all that apply:
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor
- [x] Other (explain below)

## Description of Changes
### DX / Build improvements
- Stopped hashing filenames so frontend changes are immediately visible without restarting Docker Compose.
- Created `caddy.env` and wired it into the docker-compose path attribute.

### Route caching
- Added caching + saving of auto-generated routes after an unauthenticated save attempt.
- Added caching + loading of routes for manual routing
- Replaced hardcoded padding in `view.fit()` calls when the map is moved to a loaded/cached route.

### UI / CSS polish
- Reduced the size of the main routing panel.
- Tokenified `map.css` and `stats-panel.css`.
- Updated nav-rail border styling.
- Removed an unnecessarily long comment in `donate-modal.css`.

## Screenshots / Visuals (if applicable)
N/A

## Testing
- Verified frontend hot-reload works without `docker-compose restart` after the hashing change.
- Tested auto-generated route caching after an unauthenticated save attempt.
- Tested manual route creation → cache → load flow, including coordinate restoration and map fitting.
- Confirmed start/end coords are correctly populated on load.
- Spot-checked UI changes (panel size, nav-rail border, tokenized styles).

## Checklist
- [x] My code follows the project’s style guidelines
- [x] I have tested my changes
- [x] I have updated documentation if needed
- [x] I have referenced the related issue
- [x] This PR is scoped, focused, and ready for review