### PR TITLE
PR fix: Tweaks and Fixes of bugs introduced in v0.2.11

### DIFF
--- a/graph_generation/elevation_upgrade.py
+++ b/graph_generation/elevation_upgrade.py
@@ -6,6 +6,7 @@ import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
 from src.Pathfinding.Nodefinder import NodeFinder as n
+from src.Routes.helpers import naismith_helper
 import rasterio as r
 import pickle as p
 import math
@@ -80,42 +81,6 @@ for i, elev in enumerate(elev_samples):
 print(f"Elevation added to all vertices\nTest: {graph.vs[100]['elev']}")
 
 #region HELPER FUNCTIONS
-def naismith_helper(horizontal_distance_metres: float, elevation_difference_metres: float, slope_ratio: float) -> dict:
-    """
-    PURPOSE : this is a function used to calculate the weight of an edge using Naismith's rule
-
-    PARAMS : takes euclidean distance, elevation difference and slope ratio as parameters
-        - euclidean distance + elevation difference --> used in naismith formula
-        - slope ratio --> used to determine which avg speed (in mph) to use
-
-    RETURN VALUE : dictionary of ascent and descent value (assinged to edges depending on if the edge is going up or down)
-    """
-
-    # group of logic conditions to set walking speed based on elevation gain (in the form of the slope ratio)
-    # absoloute val used as it doesn't matter if the value is negative or positive --> reduces number of conditions and likelihood of errors
-    abs_slope = abs(slope_ratio) 
-
-    if abs_slope < 0.09: # flat / gentle grade (Under 5°)
-        avg_walking_speed_metres = 1.4  
-    elif abs_slope < 0.21: # moderate grade (5° - 12°)
-        avg_walking_speed_metres = 1.1  
-    elif abs_slope < 0.46: # steep mountain grade (12° - 25°)
-        avg_walking_speed_metres = 0.8  
-    else: # extreme / scramble grade (+ 25°)
-        avg_walking_speed_metres = 0.5  
-
-    # distance calculations
-    ascent_metres = max(0, elevation_difference_metres) # max is used to ensure there is only a positive value, rather than a negative value for the ASCENT
-    descent_metres = abs(min(0, elevation_difference_metres)) # min is used to ensure there is only a negative, or zero, value for the DESCENT
-
-    # ETA calculations
-    flat_time = horizontal_distance_metres / avg_walking_speed_metres # this is the time taken to walk the distance if it was a straight line
-    climb_time = (ascent_metres / 10) * 60 # this is the time taken to walk UP the slope caused by the difference in elevation
-    descent_time = (descent_metres / 7.5) * 60 # this is the time taken to walk DOWN the slope caused by the difference in elevation
-    return { # dict is used to reference the helper function more effectively
-        "ascent" : flat_time + climb_time,
-        "descent" : flat_time + descent_time
-    }
 
 # this is a function used to calculate the addition to edge costs based on their surface, sac_scale and visibility tag values
 def get_terrain_factor(sac_scale: str, trail_visibility: str, surface: str) -> float:

--- a/src/Pathfinding/Nodefinder.py
+++ b/src/Pathfinding/Nodefinder.py
@@ -145,20 +145,6 @@ class NodeFinder:
                 
         return total_distance_metres
 
-    def calculate_eta(self, path, graph):
-        # 'path' now contains coordinate tuples, this is mapped back to vertex IDs to extract edge cost values.
-        total_seconds = 0
-        for start_coord, end_coord in zip(path, path[1:]):
-            u = self.node_to_id[start_coord]
-            v = self.node_to_id[end_coord]
-            
-            # This retrieves the edge index connecting vertex u to v
-            edge_id = graph.get_eid(u, v, directed=True, error=False)
-            if edge_id != -1:
-                total_seconds += graph.es[edge_id]['cost']
-                
-        return total_seconds
-
     def calculate_map_center_and_zoom(self, web_mercator_coordinates):
         if len(web_mercator_coordinates) > 1:
             x_coords = [coord[0] for coord in web_mercator_coordinates]

--- a/src/Routes/helpers.py
+++ b/src/Routes/helpers.py
@@ -23,6 +23,44 @@ def isRoughlyInCumbria(x: float, y: float) -> bool:
 
     return x >= MIN_X and x <= MAX_X and y >= MIN_Y and y <= MAX_Y 
 
+def naismith_helper(horizontal_distance_metres: float, elevation_difference_metres: float, slope_ratio: float) -> dict:
+    """
+    PURPOSE : this is a function used to calculate the weight of an edge using Naismith's rule
+
+    PARAMS : takes euclidean distance, elevation difference and slope ratio as parameters
+        - euclidean distance + elevation difference --> used in naismith formula
+        - slope ratio --> used to determine which avg speed (in mph) to use
+
+    RETURN VALUE : dictionary of ascent and descent value (assinged to edges depending on if the edge is going up or down)
+    """
+
+    # group of logic conditions to set walking speed based on elevation gain (in the form of the slope ratio)
+    # absoloute val used as it doesn't matter if the value is negative or positive --> reduces number of conditions and likelihood of errors
+    abs_slope = abs(slope_ratio) 
+
+    if abs_slope < 0.09: # flat / gentle grade (Under 5°)
+        avg_walking_speed_metres = 1.4  
+    elif abs_slope < 0.21: # moderate grade (5° - 12°)
+        avg_walking_speed_metres = 1.1  
+    elif abs_slope < 0.46: # steep mountain grade (12° - 25°)
+        avg_walking_speed_metres = 0.8  
+    else: # extreme / scramble grade (+ 25°)
+        avg_walking_speed_metres = 0.5  
+
+    # distance calculations
+    ascent_metres = max(0, elevation_difference_metres) # max is used to ensure there is only a positive value, rather than a negative value for the ASCENT
+    descent_metres = abs(min(0, elevation_difference_metres)) # min is used to ensure there is only a negative, or zero, value for the DESCENT
+
+    # ETA calculations
+    flat_time = horizontal_distance_metres / avg_walking_speed_metres # this is the time taken to walk the distance if it was a straight line
+    climb_time = (ascent_metres / 10) * 60 # this is the time taken to walk UP the slope caused by the difference in elevation
+    descent_time = (descent_metres / 7.5) * 60 # this is the time taken to walk DOWN the slope caused by the difference in elevation
+    return { # dict is used to reference the helper function more effectively
+        "ascent" : flat_time + climb_time,
+        "descent" : flat_time + descent_time
+    }
+
+
 def haversine(x1: float, y1: float, x2: float, y2: float) -> float:
 
     # NOTE : coords need to be in lon/lat 
@@ -60,6 +98,7 @@ def normalise_route(coordinates: list, avg_speed_kmh: float = 4.5) -> dict:
 
     total_distance_m = 0.0
     total_elevation_gain_m = 0.0
+    total_seconds = 0.0
 
     has_elevation = len(coordinates[0]) == 3
 
@@ -67,11 +106,9 @@ def normalise_route(coordinates: list, avg_speed_kmh: float = 4.5) -> dict:
         lon1, lat1 = coordinates[i][0], coordinates[i][1]
         lon2, lat2 = coordinates[i + 1][0], coordinates[i + 1][1]
 
-        # distance calculation
-        if converted_coords and converted_coords != []:
-            total_distance_m += haversine(converted_coords[i][0], converted_coords[i][1], converted_coords[i + 1][0], converted_coords[i + 1][1])
-        else:
-            total_distance_m += haversine(lon1, lat1, lon2, lat2)
+        segement_distance = haversine(lon1, lat1, lon2, lat2)
+
+        total_distance_m += segement_distance
 
         # elevation gain (only if available)
         if has_elevation:
@@ -79,18 +116,35 @@ def normalise_route(coordinates: list, avg_speed_kmh: float = 4.5) -> dict:
             e2 = coordinates[i + 1][2]
 
             if e1 is not None and e2 is not None:
-                if e2 > e1:
-                    total_elevation_gain_m += (e2 - e1)
+                elevation_difference = e2 - e1
+
+                slope_ratio = elevation_difference / segement_distance if total_distance_m > 0 else 0.0 
+
+                segment_eta = naismith_helper(
+                    horizontal_distance_metres=segement_distance,
+                    elevation_difference_metres=elevation_difference,
+                    slope_ratio=slope_ratio
+                )
+
+                if elevation_difference > 0:
+                    total_seconds += segment_eta['ascent']
+                    total_elevation_gain_m += elevation_difference
+                else:
+                    total_seconds += segment_eta['descent']
+                    
 
     distance_km = total_distance_m / 1000.0
-    eta_hours = distance_km / avg_speed_kmh
-    eta_seconds = round(eta_hours * 60 * 60, 2)
+    if not has_elevation:
+        eta_hours = distance_km / avg_speed_kmh
+        final_seconds = round(eta_hours * 3600, 2)
+    else:
+        final_seconds = round(total_seconds, 2)
 
     return {
         "distance_m": total_distance_m,
         "distance_km": distance_km,
         "elevation_gain_m": total_elevation_gain_m,
-        "eta_seconds": eta_seconds
+        "eta_seconds": final_seconds
     }
 
 # helper function which returns true if the first coordinate has 3 values (i.e x, y and z)

--- a/src/Routes/helpers.py
+++ b/src/Routes/helpers.py
@@ -64,22 +64,23 @@ def normalise_route(coordinates: list, avg_speed_kmh: float = 4.5) -> dict:
     has_elevation = len(coordinates[0]) == 3
 
     for i in range(len(coordinates) - 1):
-        x1, y1 = coordinates[i][0], coordinates[i][1]
-        x2, y2 = coordinates[i + 1][0], coordinates[i + 1][1]
+        lon1, lat1 = coordinates[i][0], coordinates[i][1]
+        lon2, lat2 = coordinates[i + 1][0], coordinates[i + 1][1]
 
         # distance calculation
         if converted_coords and converted_coords != []:
             total_distance_m += haversine(converted_coords[i][0], converted_coords[i][1], converted_coords[i + 1][0], converted_coords[i + 1][1])
         else:
-            total_distance_m += haversine(x1, y1, x2, y2)
+            total_distance_m += haversine(lon1, lat1, lon2, lat2)
 
         # elevation gain (only if available)
         if has_elevation:
             e1 = coordinates[i][2]
             e2 = coordinates[i + 1][2]
 
-            if e2 > e1:
-                total_elevation_gain_m += (e2 - e1)
+            if e1 is not None and e2 is not None:
+                if e2 > e1:
+                    total_elevation_gain_m += (e2 - e1)
 
     distance_km = total_distance_m / 1000.0
     eta_hours = distance_km / avg_speed_kmh

--- a/src/Routes/routes_fastapi.py
+++ b/src/Routes/routes_fastapi.py
@@ -243,7 +243,7 @@ def calculate_path(
         
         # Calculates ETA 
         # NOTE : this is in SECONDS
-        eta_seconds = service.calculate_eta(path, graph)
+        eta_seconds = normalise_route(wgs84_coordinates)['eta_seconds']
 
         path_geojson = {
             "type": "Feature",

--- a/src/fastapi_app.py
+++ b/src/fastapi_app.py
@@ -145,7 +145,11 @@ def format_distance(
 def format_elevation(elevation_gain):
     if not isinstance(elevation_gain, int) or isinstance(elevation_gain, float):
         elevation_gain = int(float(elevation_gain))
-    return f"+{elevation_gain} m" if elevation_gain >= 0 else f"{elevation_gain} m"
+    
+    if elevation_gain == 0:
+        return "No Data"
+    else: 
+        return f"+{elevation_gain} m" if elevation_gain > 0 else f"{elevation_gain} m"
 
 def format_eta(seconds):
     hours = seconds // 3600

--- a/static/css/base/tokens.css
+++ b/static/css/base/tokens.css
@@ -52,8 +52,8 @@
 
   --btn-bg: #3c3c3c;
   --btn-bg-hover: #454545;
-  --secondary-btn-bg: #9d9797;
-  --secondary-btn-bg-hover: #888484;
+  --secondary-btn-bg: #b4b0b0;
+  --secondary-btn-bg-hover: #7e7b7b;
   --btn-disabled-bg: #93b4f2;
   --btn-disabled-text: #ffffff;
 
@@ -81,7 +81,8 @@
   --space-3xl: 4rem;
 
   --shadow-surface: 0 10px 35px rgba(15, 23, 42, 0.06);
-  --shadow-lift: 0 4px 12px rgba(37, 99, 235, 0.28);
+  --shadow-lift-blue: 0 4px 12px rgba(37, 99, 235, 0.28);
+  --shadow-lift-normal: 0 4px 12px rgba(86, 86, 87, 0.28);
   --panel-shadow: 0 2px 6px rgba(0,0,0,0.1);
 
   --font-sans: -apple-system, BlinkMacSystemFont, "SF Pro Text",
@@ -133,13 +134,14 @@ html.dark {
   --secondary-border: #FFFFFF;
 
   --blue: #3b82f6;
-  --blue-dark: #60a5fa;
+  --blue-dark: #226bc3;
   --blue-soft: rgba(59, 130, 246, 0.15);
   --blue-ring: rgba(59, 130, 246, 0.4);
 
   --btn-bg: #374151;
   --btn-bg-hover: #4b5563;
-  --secondary-btn-bg: #FFFFFF;
+  --secondary-btn-bg: #9e9b9b;
+  --secondary-btn-bg-hover: #727070;
   --btn-disabled-bg: #1e293b;
   --btn-disabled-text: #64748b;
 

--- a/static/css/components/buttons.css
+++ b/static/css/components/buttons.css
@@ -46,7 +46,7 @@
 .btn-primary:hover:not(:disabled) {
   background: var(--blue-dark);
   transform: translateY(-1px);
-  box-shadow: var(--shadow-lift);
+  box-shadow: var(--shadow-lift-blue);
 }
 
 .btn-primary:active:not(:disabled) {
@@ -72,6 +72,7 @@
 .btn-secondary:hover {
   background-color: var(--secondary-btn-bg-hover);
   transform: translateY(-1px);
+  box-shadow: var(--shadow-lift-normal);
 }
 
 .btn-secondary:active {

--- a/static/css/components/loading-spinner.css
+++ b/static/css/components/loading-spinner.css
@@ -5,6 +5,10 @@
   Spinner markup/animation from https://cssloaders.github.io
 */
 
+.loading-button {
+  position: relative;
+}
+
 .loader {
   position: absolute;
   display: none;
@@ -14,33 +18,30 @@
   border-bottom-color: transparent;
   border-radius: 50%;
   box-sizing: border-box;
+  top: 50%;
+  left: 50%;
   animation: rotation 1s linear infinite;
-  top: 23%;
-  left: 48%;
-  transform: translate(-50%, -50%);
 }
 
 @keyframes rotation {
   0% {
-    transform: rotate(0deg);
+    transform: translate(-50%, -50%) rotate(0deg);
   }
   100% {
-    transform: rotate(360deg);
+    transform: translate(-50%, -50%) rotate(360deg);
   }
 }
 
 .loading-button.loading .loading-button-text {
   visibility: hidden;
 }
-
 .loading-button.loading .loader {
-  display: inline-block;
+  display: block;          /* or inline-block */
 }
 
 .route-btn.loading .route-btn-text {
   visibility: hidden;
 }
-
 .route-btn.loading .loader {
-  display: inline-block;
+  display: block;
 }

--- a/static/css/components/modal.css
+++ b/static/css/components/modal.css
@@ -86,12 +86,12 @@
    meant for regular low-risk actions
    such as exiting */
 .modal-btn-secondary {
-  background-color: var(--secondary-bg);
-  color: var(--ink);
+  background-color: var(--secondary-btn-bg);
+  color: #FFFFFF;
 }
 
 .modal-btn-secondary:hover {
-  background-color: var(--secondary-bg-hover);
+  background-color: var(--secondary-btn-bg-hover);
   transform: translateY(-1.5px);
 }
 

--- a/static/css/pages/map.css
+++ b/static/css/pages/map.css
@@ -240,6 +240,7 @@ html.dark {
 }
 
 .generate-button {
+  position: relative;
   width: 100%;
   padding: 8px;
   background: var(--blue);

--- a/static/js/importRoute.js
+++ b/static/js/importRoute.js
@@ -46,6 +46,7 @@ export async function processImportedRouteFile(file) {
 export function displayImportedRouteCard(data) {
 
     const routeInfo = data.route_info;
+    console.log(routeInfo)
     const today = new Date();
 
     const routeName = routeInfo.route_name
@@ -59,7 +60,7 @@ export function displayImportedRouteCard(data) {
     const distanceKm = routeInfo.distance_km;
     const formattedDistanceKm = formatDistance(distanceKm);
     const formattedETA = formatETA(routeInfo.eta_seconds);
-    const formattedElevation = formatElevation(routeInfo.elevation_gain_metres)
+    const formattedElevation = routeInfo.elevation_gain_metres === 0 ? "No Data" : formatElevation(routeInfo.elevation_gain_metres)
 
     
 

--- a/static/js/routes/saveRoute.js
+++ b/static/js/routes/saveRoute.js
@@ -152,8 +152,10 @@ async function handleSaveRoute(e) {
           "month": "2-digit",
           "year": "numeric"
         }).format(today);
+
+        console.log(routeInfo)
         
-        elevDisplayValue = formatElevation(routeInfo.elevation_gain_metres);
+        elevDisplayValue = routeInfo.elevation_gain_metres === 0 ? "No Data" : formatElevation(routeInfo.elevation_gain_metres);
 
         eta = formatETA(routeInfo.eta_seconds);
         

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -270,6 +270,8 @@ export function getClickMode() {
   return clickMode;
 }
 
+//#region MOBILE CHECK
+
 /**
  * Checks if user is on mobile device and advices to use Crestr on desktop / laptop instead 
  * 
@@ -300,6 +302,7 @@ function checkIfMobile() {
   }
 }
 //#endregion
+
 //#region DONATE MODAL
 
 //#region GENERAL MODAL
@@ -1393,7 +1396,7 @@ async function handleLoadAutoCachedRoute() {
       const parsedStats = typeof cachedRouteStats === "string" ? JSON.parse(cachedRouteStats) : cachedRouteStats;
       setLastAutoRouteStats(parsedStats)
 
-      setLastKnownDistanceKm(cachedRouteStats.total_distance);
+      setLastKnownDistanceKm(parsedStats.total_distance);
       startCoordEntry.value = formatLatLon(toLonLat(startWebMercator))
       endCoordEntry.value = formatLatLon(toLonLat(endWebMercator))
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -366,7 +366,7 @@ export function showLoginModal(show, actionName = 'perform this action') {
  */
 function loginModalLogin() {
   showLoginModal(false);
-  window.location.href = 'https://app.crestr.co.uk/login-page';
+  window.location.href = '/login-page';
   return;
 };
 
@@ -2224,7 +2224,7 @@ export function initUi() {
   addClickListener(importRouteCloseButton, closeImportRoute, "click");
   addClickListener(importRouteCancelButton, cancelRouteImport, "click");
 
-  addClickListener(loginNavBarButton, () => window.location.href = "https://app.crestr.co.uk/login-page", 'click')
+  addClickListener(loginNavBarButton, () => window.location.href = "/login-page", 'click')
   addClickListener(logoutNavBarButton, logout, 'click')
 
   addClickListener(reportIssueOpenButton, () => showReportIssueModal(true), "click");

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -907,6 +907,8 @@ async function handleRouteImport() {
  */
 function validateFileInput(file) {
 
+  const fileName = file?.name;
+
     // this checks if a file is selected
     if (!file) {
         showToast("Please select a file to import.");
@@ -914,7 +916,7 @@ function validateFileInput(file) {
     }
 
     // this checks if the file is of the correct type
-    if (!allowedFileTypes.some(type => file.name.endsWith(type))) {
+    if (!allowedFileTypes.some(type => fileName.endsWith(type))) {
         showToast("Please select a valid file to import.");
         return false;
     }
@@ -2231,7 +2233,12 @@ export function initUi() {
 
 
   // These event listeners are for route import.
-  addClickListener(importRouteFileInput, validateFileInput, "change");
+  importRouteFileInput.addEventListener("change", (e) => {
+    const file = event.target.files[0];
+    validateFileInput(file);
+  });
+
+
   addClickListener(importRouteSubmitButton, handleRouteImport, "click");
   routeInputTypes.forEach(radio => {
     radio.addEventListener('change', handleRouteImportType);

--- a/static/js/utils/ui-utils.js
+++ b/static/js/utils/ui-utils.js
@@ -284,32 +284,35 @@ export function createNoRouteCard() {
  * @returns {string} HTML string for the stats panel showing key route details 
  */
 export function createStatsPanel(distanceDisplay, etaDisplay, elevationGain) {
-  return `
-      <div class="stats-header">
-          <span class="stats-title">Route Information</span>
-          <button id="toggle-elevation-chart" class="stats-button">Elevation Profile</button>
-      </div>
-      <div id="stat-content-and-chart-container">
-          <div class="stats-content">
-              <div class="stat-row">
-                  <span class="stat-label">Distance:</span>
-                  <span class="stat-value" id="route-distance-display">${distanceDisplay}</span>
-              </div>
-              <div class="stat-row">
-                  <span class="stat-label">ETA:</span>
-                  <span class="stat-value" id="route-eta-display">${etaDisplay}</span>
-              </div>
-              <div class="stat-row">
-                  <span class="stat-label">Elevation Gain:</span>
-                  <span class="stat-value" id="route-elevation-gain-display">${elevationGain}</span>
-              </div>
-          </div>
 
-          <div class="chart-wrapper"> 
-              <div id="elevation-chart-container">
-                  <canvas id="elevation-chart"></canvas>
-              </div>
-          </div>
-      </div>
-  `
+    const elevationGainDisplay = elevationGain == "+0 m" ? "No Data" : elevationGain
+
+    return `
+        <div class="stats-header">
+            <span class="stats-title">Route Information</span>
+            <button id="toggle-elevation-chart" class="stats-button">Elevation Profile</button>
+        </div>
+        <div id="stat-content-and-chart-container">
+            <div class="stats-content">
+                <div class="stat-row">
+                    <span class="stat-label">Distance:</span>
+                    <span class="stat-value" id="route-distance-display">${distanceDisplay}</span>
+                </div>
+                <div class="stat-row">
+                    <span class="stat-label">ETA:</span>
+                    <span class="stat-value" id="route-eta-display">${etaDisplay}</span>
+                </div>
+                <div class="stat-row">
+                    <span class="stat-label">Elevation Gain:</span>
+                    <span class="stat-value" id="route-elevation-gain-display">${elevationGainDisplay}</span>
+                </div>
+            </div>
+
+            <div class="chart-wrapper"> 
+                <div id="elevation-chart-container">
+                    <canvas id="elevation-chart"></canvas>
+                </div>
+            </div>
+        </div>
+    `
 }

--- a/templates/map.html
+++ b/templates/map.html
@@ -37,6 +37,7 @@
     <link rel="stylesheet" href="{{ url_for('static', path='css/components/modal.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='css/components/buttons.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='css/components/donate-modal.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', path='css/components/load-last-route-modal.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='css/components/form-fields.css') }}">
 
     <!-- Layout CSS Files -->


### PR DESCRIPTION
# Pull Request Template

## Summary
This PR resolves several bugs in cached/imported route handling and route ETA display, and makes a number of UI/styling and infrastructure adjustments. 

The majority of the bug fixes address regressions introduced in **v0.2.11**, the release that added caching and loading of cached routes. Key fixes include correcting cached route rendering, fixing missing CSS for the "load last route" modal, fixing the generate path button's loading animation centring, and handling route imports with missing elevation data. 

It also adds a "No Data" fallback for missing elevation figures and integrates the Naismith helper into route calculation and saving for more accurate ETAs.

## Related Issue

closes ABD-31
closes ABD-30
closes ABD-29

## Type of Change
Select all that apply:
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (explain below)

**Other:** Includes chore-level changes (relative URL redirects, secondary button colour updates).

## Description of Changes
- **fix (v0.2.11 regression):** Resolved an error when displaying cached routes caused by not referencing parsed stats objects.
- **fix (v0.2.11 regression):** Resolved an error caused by a missing `<link>` tag needed to load the "load last route" modal CSS file.
- **chore:** Changed URL redirects to be relative instead of absolute.
- **chore:** Updated secondary button colours (e.g. clear path and dismiss modal buttons) for visual consistency.
- **fix (v0.2.11 regression):** Resolved an error causing the generate path button's loading animation to not centre correctly.
- **fix:** Resolved an error when handling route imports that have no elevation data.
- **feat:** Display "No Data" instead of "+0 m" when elevation data is missing (implemented, then refined in a follow-up commit).
- **feat:** Integrated the Naismith helper into route calculation and route saving to improve ETA accuracy.

Most of the fixes above stem from the caching/cached-route-loading functionality introduced in v0.2.11 — this PR cleans up the regressions that shipped with that release.

## Screenshots / Visuals (if applicable)
N/A

## Testing
- Manually verified cached routes render correctly without stats-object errors.
- Confirmed the "load last route" modal now loads its styling correctly.
- Checked that URL redirects resolve correctly as relative paths across environments.
- Verified secondary button colours render consistently across relevant modals.
- Confirmed the generate path button's loading animation is centred correctly.
- Tested importing routes with no elevation data to confirm no errors occur and "No Data" displays as expected instead of "+0 m".
- Verified ETA calculations use the Naismith helper consistently during both route calculation and route saving.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have tested my changes
- [x] I have updated documentation if needed
- [x] I have referenced the related issue
- [x] This PR is scoped, focused, and ready for review

> **Note:**
> PRs for issues **not** tagged as contributor‑friendly may be closed without review.