### PR TITLE
PR fix: Add Naismith's Rule for stats generated during manual routing

### DIFF
--- a/src/Routes/helpers.py
+++ b/src/Routes/helpers.py
@@ -93,22 +93,31 @@ def normalise_route(coordinates: list, avg_speed_kmh: float = 4.5) -> dict:
 
     converted_coords = []
 
-    if not coordinates or len(coordinates) < 2:
-        return({"success": False, "message": "Route is too small"})
+    if not coordinates:
+        return({"success": False, "message": "No coordinates passed in."})
+    
+    if len(coordinates) < 2:
+        return {
+            "distance_m": 0.0,
+            "distance_km": 0.0,
+            "elevation_gain_m": 0,
+            "eta_seconds": 0
+        }
 
     total_distance_m = 0.0
     total_elevation_gain_m = 0.0
     total_seconds = 0.0
 
-    has_elevation = len(coordinates[0]) == 3
-
     for i in range(len(coordinates) - 1):
+
+        has_elevation = len(coordinates[i]) == 3 and len(coordinates[i+1]) == 3
+
         lon1, lat1 = coordinates[i][0], coordinates[i][1]
         lon2, lat2 = coordinates[i + 1][0], coordinates[i + 1][1]
 
-        segement_distance = haversine(lon1, lat1, lon2, lat2)
+        segment_distance = haversine(lon1, lat1, lon2, lat2)
 
-        total_distance_m += segement_distance
+        total_distance_m += segment_distance
 
         # elevation gain (only if available)
         if has_elevation:
@@ -118,10 +127,10 @@ def normalise_route(coordinates: list, avg_speed_kmh: float = 4.5) -> dict:
             if e1 is not None and e2 is not None:
                 elevation_difference = e2 - e1
 
-                slope_ratio = elevation_difference / segement_distance if total_distance_m > 0 else 0.0 
+                slope_ratio = elevation_difference / segment_distance if segment_distance > 0 else 0.0 
 
                 segment_eta = naismith_helper(
-                    horizontal_distance_metres=segement_distance,
+                    horizontal_distance_metres=segment_distance,
                     elevation_difference_metres=elevation_difference,
                     slope_ratio=slope_ratio
                 )

--- a/src/Routes/routes_fastapi.py
+++ b/src/Routes/routes_fastapi.py
@@ -35,7 +35,8 @@ from src.Routes.routes_schemas import (
     SaveRouteModel,
     LoadRouteModel,
     DeleteRouteModel,
-    DownloadRouteModel
+    DownloadRouteModel,
+    NormaliseRouteModel
 )
 
 from src.Routes.helpers import (
@@ -52,6 +53,37 @@ router = APIRouter()
 
 # FASTAPI ROUTES 
 
+#region Normalised Stats
+@router.post(
+    '/routing/normalise-route-stats',
+    dependencies=[
+        Depends(
+            RateLimiter(
+                limiter=Limiter(Rate(60, Duration.MINUTE)),
+                callback=rate_limit_exceeded_callback
+            )
+        )
+    ]
+)
+def calculate_path(
+    data: NormaliseRouteModel
+):
+    try: 
+        routeStats = normalise_route(data.coordinates)
+
+        return routeStats
+    except HTTPException:
+        raise
+    except Exception as error:
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "success": False,
+                "message": "There was an error normalising route stats. "
+            }
+        )
+#endregion
+
 #region Calculating Path 
 
 @router.post(
@@ -59,7 +91,7 @@ router = APIRouter()
     dependencies=[
         Depends(
             RateLimiter(
-                limiter=Limiter(Rate(10, Duration.MINUTE)),
+                limiter=Limiter(Rate(60, Duration.MINUTE)),
                 callback=rate_limit_exceeded_callback
             )
         )

--- a/src/Routes/routes_schemas.py
+++ b/src/Routes/routes_schemas.py
@@ -17,3 +17,6 @@ class DeleteRouteModel(BaseModel):
 class DownloadRouteModel(BaseModel):
     route_name: str
     route_type: str
+
+class NormaliseRouteModel(BaseModel):
+    coordinates: list

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -896,7 +896,6 @@ async function handleRouteImport() {
     }
 
     clearImportRouteInput();
-    console.log(`Importing route from URL: ${url}`);
     return url;
   }
 }
@@ -1248,8 +1247,6 @@ async function handleAutoRouteGeneration(start=null, end=null) {
     setLastKnownDistanceKm(routeStats.total_distance);
     setLastAutoRouteStats(routeStats);
 
-    console.log(`AUTO ROUTE STATS : ${routeStats}`);
-
     displayAutoRouteStats(getLastAutoRouteStats());
     
     resetElevationChart();
@@ -1317,7 +1314,6 @@ async function displayPath(data) {
       await localforage.setItem("cachedAutoRouteStartPointCoords", startMercatorCoord);
       await localforage.setItem("cachedAutoRouteEndPointCoords", endMercatorCoord);
       await localforage.setItem("cachedAutoRouteStats", data.route_stats);
-      console.log(data.route_stats);
     }
   }
 
@@ -1335,8 +1331,8 @@ async function displayPath(data) {
   return data.route_stats;
   } 
   catch(error) {
-    console.log(error.message);
     showToast('Sorry, there was an unexpected error when calculating your route, please try again later.')
+    throw new Error(error.message)
   }
 };
 
@@ -1376,8 +1372,8 @@ async function handleLoadCachedRoute() {
     }
   }
   catch(error) {
-    console.log(error.message)
     showToast("There was an error loading you last route", "error", null);
+    throw new Error(error.message)
   }
   finally {
     localforage.clear();
@@ -1498,10 +1494,6 @@ async function displayAutoCachedRouteStats(routeStats) {
     if (statsDiv) {
       statsDiv.remove();
     };
-    
-    console.log(`LAST AUTO ROUTE STATS : ${JSON.stringify(getLastAutoRouteStats())}`)
-    console.log(`AUTO CACHED ROUTES : ${JSON.stringify(routeStats)}`)
-    console.log(`LAST AUTO ROUTE STATS : ${JSON.stringify(getLastAutoRouteStats())}`)
 
     statsDiv = document.createElement("div");
     statsDiv.id = "route-stats";
@@ -1516,7 +1508,6 @@ async function displayAutoCachedRouteStats(routeStats) {
 
 async function handleLoadManualCachedRoute() {
 
-  console.log('updating route state')
   const updateManualRouteState = (newUserClicks, newPathCoords, newSegmentCache) => {
     manualRouteState.userClicks = newUserClicks;
     manualRouteState.pathCoords = newPathCoords;
@@ -1670,8 +1661,6 @@ export async function updateManualRoute() {
 
     const routeStats = await routeStatsResponse.json();
 
-    console.log(JSON.stringify(routeStats));
-
     const distanceDisplay = formatDistance(routeStats.distance_km);
     const etaDisplay = formatETA(routeStats.eta_seconds);
     const isSnappedToEnd = checkIfCircularRoute();
@@ -1735,7 +1724,7 @@ export async function updateManualRoute() {
     createElevationProfile(pathCoords);
   }
   catch (error) {
-    console.log(error.message);
+    throw new Error(error.message);
   }
 };
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1650,68 +1650,93 @@ export async function updateManualRoute() {
 
   if (saveContainer) saveContainer.style.display = "flex";
 
-  const { userClicks, pathCoords } = manualRouteState;
-  const totalDistanceKm = calculateTotalDistance(pathCoords) / 1000;
-  const distanceDisplay = formatDistance(totalDistanceKm);
-  const etaDisplay = calculateEta(totalDistanceKm);
-  const isSnappedToEnd = checkIfCircularRoute();
-  const features = [];
-  const elevationGainDisplay = formatElevation(calculateElevationGain(pathCoords));
+  try {
 
-  if (!window.appConfig.loggedIn) {
-    await localforage.setItem('cachedUserClicks', userClicks);
-    await localforage.setItem('cachedPathCoords', pathCoords);
-    await localforage.setItem('cachedManualRouteStats', {"total_distance": totalDistanceKm, "elevation_gain": calculateElevationGain(pathCoords)});
-  }
-  setLastKnownDistanceKm(totalDistanceKm);
+    const { userClicks, pathCoords } = manualRouteState;
 
-  userClicks.forEach((point, index) => {
-    const feature = new Feature({
-      geometry: new Point(point),
-      type: "point",
+    const transformedPathCoords = pathCoords.map(coord => {
+      const [lon, lat] = toLonLat(coord);
+
+      return coord.length === 3 ? [lon, lat, coord[2]] : [lon, lat]
     });
-    feature.set("index", index);
-    features.push(feature);
-  });
 
-  if (pathCoords.length > 1) {
-    features.push(
-      new Feature({
-        geometry: new LineString(pathCoords),
-        type: "line",
+    const routeStatsResponse = await fetch("/routing/normalise-route-stats", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        coordinates: transformedPathCoords
       }),
-    );
-  }
+    });
 
-  manualRouteLayer = new VectorLayer({
-    source: new VectorSource({ features }),
-    style(feature) {
-      const featureType = feature.get("type");
-      if (featureType === "point") {
-        const index = feature.get("index");
-        const isStart = index === 0;
-        const isEnd = index === userClicks.length - 1;
+    const routeStats = await routeStatsResponse.json();
 
-        if (isSnappedToEnd) {
-          if (isStart) return getSavedPointStyle("Start/End", "#00A86B");
-          if (isEnd) return getSavedPointStyle("", "#00A86B");
-        }
-        if (isStart) return getSavedPointStyle("Start", "#00A86B");
-        if (isEnd) return getSavedPointStyle("End", "#D32F2F");
-        return createManualPointStyle("", "#000", 6.5);
-      }
-      return new Style({
-        stroke: new Stroke(getRouteStrokeStyle()),
+    console.log(JSON.stringify(routeStats));
+
+    const distanceDisplay = formatDistance(routeStats.distance_km);
+    const etaDisplay = formatETA(routeStats.eta_seconds);
+    const isSnappedToEnd = checkIfCircularRoute();
+    const features = [];
+    const elevationGainDisplay = formatElevation(routeStats.elevation_gain_m);
+
+
+    if (!window.appConfig.loggedIn) {
+      await localforage.setItem('cachedUserClicks', userClicks);
+      await localforage.setItem('cachedPathCoords', pathCoords);
+      await localforage.setItem('cachedManualRouteStats', {"total_distance": routeStats.distance_km, "elevation_gain": calculateElevationGain(pathCoords)});
+    }
+    setLastKnownDistanceKm(routeStats.distance_km);
+
+    userClicks.forEach((point, index) => {
+      const feature = new Feature({
+        geometry: new Point(point),
+        type: "point",
       });
-    },
-  });
+      feature.set("index", index);
+      features.push(feature);
+    });
 
-  map.addLayer(manualRouteLayer);
+    if (pathCoords.length > 1) {
+      features.push(
+        new Feature({
+          geometry: new LineString(pathCoords),
+          type: "line",
+        }),
+      );
+    }
 
-  const isOnePoint = pathCoords.length === 1;
+    manualRouteLayer = new VectorLayer({
+      source: new VectorSource({ features }),
+      style(feature) {
+        const featureType = feature.get("type");
+        if (featureType === "point") {
+          const index = feature.get("index");
+          const isStart = index === 0;
+          const isEnd = index === userClicks.length - 1;
 
-  updateManualRouteStats(isOnePoint, distanceDisplay, etaDisplay, elevationGainDisplay, pathCoords);
-  createElevationProfile(pathCoords);
+          if (isSnappedToEnd) {
+            if (isStart) return getSavedPointStyle("Start/End", "#00A86B");
+            if (isEnd) return getSavedPointStyle("", "#00A86B");
+          }
+          if (isStart) return getSavedPointStyle("Start", "#00A86B");
+          if (isEnd) return getSavedPointStyle("End", "#D32F2F");
+          return createManualPointStyle("", "#000", 6.5);
+        }
+        return new Style({
+          stroke: new Stroke(getRouteStrokeStyle()),
+        });
+      },
+    });
+
+    map.addLayer(manualRouteLayer);
+
+    const isOnePoint = pathCoords.length === 1;
+
+    updateManualRouteStats(isOnePoint, distanceDisplay, etaDisplay, elevationGainDisplay, pathCoords);
+    createElevationProfile(pathCoords);
+  }
+  catch (error) {
+    console.log(error.message);
+  }
 };
 
 function updateManualRouteStats(isOnePoint, distanceDisplay, etaDisplay, elevationGainDisplay, pathCoords) {

--- a/templates/map.html
+++ b/templates/map.html
@@ -747,6 +747,7 @@
             apiDeleteRouteUrl: "/routing/delete-route",
             apiDownloadRouteFileUrl: "/routing/download-route",
             apiImportRouteUrl: "/routing/import-route-file",
+            apiNormaliseRouteStatsUrl: "/routing/normalise-route-stats",
 
             // points + search API endpoints
             apiSearchAreaUrl: "/search/search-area",


### PR DESCRIPTION
# Pull Request Template

## Summary
This PR aims to improve consistency of route statistics created during routing, by introducing the use of Naismith's Rule to generate ETAs for manual routing. 

This introduces consistency as dynamic ETAs are calculated via Naismith's Rule during automatic routing + ETAs created during the saving of a route are also calculated via Naismith's Rule

## Related Issue

Closes ABD-32
## Type of Change
Select all that apply:
- [ ] Bug fix  
- [x] New feature  
- [ ] Documentation update  
- [ ] Refactor  
- [ ] Other (explain below)

## Description of Changes
- `Routes/helpers.py`: Tweaks and bug fixes of the Naismith's Rule function
-  `Routes/routes_fastapi.py`: Added new `/routing/normalise-route-stats` FastAPI route which takes in a coordinate as input and returns statistics about the inputted path, such as an ETA calculated via Naismith's Rule
- `Routes/route_schemas.py`: Added new `NormaliseRouteModel` Pydantic BaseModel class for the new `/routing/normalise-route-stats` FastAPI route
- `static/js/ui.js`: Removed unneccesary console.log() statements and replaced with `throw new Error()` where appropriate + added route stats call to `/routing/normalise-route-stats` FastAPI route to access the new Naismith's Rule ETA
- `templates/map.html`: Added new `/routing/normalise-route-stats` FastAPI route to `window.appConfig` mapped to the identifier `apiNormaliseRouteStatsUrl`

## Screenshots / Visuals (if applicable)
N/A

## Testing
- Completed both manual and automatic routing to ensure that no unneccessary console.log() statements in the console
- Compared manual routing ETAs to automatic routing ETAs to ensure that they were the same (as automatic routing is validated to use Naismith's Rule) + checked with other mapping applications to see if the times generated for the specific routes were reasonable and accurate 

## Checklist
- [x] My code follows the project’s style guidelines  
- [x] I have tested my changes  
- [x] I have updated documentation if needed  
- [x] I have referenced the related issue  
- [x] This PR is scoped, focused, and ready for review  

> **Note:**  
> PRs for issues **not** tagged as contributor‑friendly may be closed without review.
