### PR TITLE
PR feat : Add navigation shortcuts + shortcuts modal 

### DIFF
--- a/static/css/base/tokens.css
+++ b/static/css/base/tokens.css
@@ -140,8 +140,8 @@ html.dark {
 
   --btn-bg: #374151;
   --btn-bg-hover: #4b5563;
-  --secondary-btn-bg: #9e9b9b;
-  --secondary-btn-bg-hover: #727070;
+  --secondary-btn-bg: #7c7a7a;
+  --secondary-btn-bg-hover: #6a6868;
   --btn-disabled-bg: #1e293b;
   --btn-disabled-text: #64748b;
 

--- a/static/css/components/donate-modal.css
+++ b/static/css/components/donate-modal.css
@@ -16,6 +16,12 @@
   text-align: left;
 }
 
+.donate-modal-content svg {
+  width: 20px;
+  height: 20px;
+  color: var(--ink);
+}
+
 .donate-modal-content .modal-header h2 {
   text-align: center;
 }
@@ -110,11 +116,6 @@
   justify-content: center;
   background: var(--blue-soft);
   color: var(--blue);
-}
-
-.donate-option-icon svg {
-  width: 20px;
-  height: 20px;
 }
 
 .donate-option-text {

--- a/static/css/components/modal.css
+++ b/static/css/components/modal.css
@@ -87,6 +87,7 @@
    such as exiting */
 .modal-btn-secondary {
   background-color: var(--secondary-btn-bg);
+  
   color: #FFFFFF;
 }
 

--- a/static/css/components/shortcuts-modal.css
+++ b/static/css/components/shortcuts-modal.css
@@ -1,0 +1,96 @@
+/*
+  KEYBOARD SHORTCUTS MODAL COMPONENT
+
+  Extends the base .modal-overlay / .modal-content pattern from modal.css with a list of keyboard shortcuts
+
+  Depends on:
+    - modal.css (base overlay/content/actions)
+    - tokens.css
+    - buttons.css (.modal-btn-secondary)
+*/
+
+/* defines the general structure of the modal + the container */
+.shortcuts-modal-content {
+  display: flex;
+  flex-direction: column;
+  max-width: 480px;
+  max-height: 60vh;
+  margin: 5vh auto;
+}
+
+.shortcuts-modal-body {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  text-align: left;
+  padding-top: var(--space-xs);
+  padding-right: var(--space-2xs);
+}
+
+.shortcuts-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.shortcuts-group + .shortcuts-group {
+  margin-top: var(--space-md);
+}
+
+.shortcuts-group-title {
+  margin: 0 0 var(--space-2xs);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.shortcut-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+
+.shortcut-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.shortcut-key {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2xs);
+  flex-shrink: 0;
+}
+
+.shortcut-key kbd {
+  display: inline-block;
+  min-width: 1.75rem;
+  padding: 2px 8px;
+  font-family: var(--font-sans);
+  font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1.4;
+  text-align: center;
+  color: var(--ink-strong);
+  background: var(--surface-subtle);
+  border: 1px solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: var(--radius-sm);
+}
+
+.shortcut-key-plus {
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 0.85rem;
+}

--- a/static/css/layout/nav-menu.css
+++ b/static/css/layout/nav-menu.css
@@ -127,7 +127,7 @@ html.dark {
 }
 
 /* Auth button container (placed at the bottom of the sidenav) */
-.sidenav-auth {
+.sidenav-lower {
   margin-top: auto;
   padding: 12px 0 16px;
   flex-shrink: 0;
@@ -136,7 +136,7 @@ html.dark {
 }
 
 /* login / logout buttons */
-.sidenav-auth-button {
+.lower-sidenav-button {
   border: none;
   background: transparent;
   font-family: inherit;

--- a/static/css/pages/map.css
+++ b/static/css/pages/map.css
@@ -369,7 +369,7 @@ html.dark {
 
 /* Home Button */
 .home-button {
-  background: var(--home-button-bg);
+  background: var(--secondary-btn-bg);
   color: white;
   border-radius: 5px;
   width: 28px;
@@ -390,7 +390,7 @@ html.dark {
 }
 
 .home-button:hover {
-  background: var(--muted-alt);
+  background: var(--secondary-btn-bg-hover);
   transform: translateY(-1px);
   box-shadow: var(--home-button-hover-shadow);
 }

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -34,7 +34,8 @@ import {
   LogIn,
   LogOut,
   Coffee,
-  MoveRight
+  MoveRight,
+  Keyboard
 } from 'lucide';
 
 export let map = null;
@@ -54,7 +55,8 @@ createIcons({
     LogIn,
     LogOut,
     Coffee,
-    MoveRight
+    MoveRight,
+    Keyboard
   }
 });
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -162,9 +162,6 @@ const searchForAreaButton = document.getElementById("search-for-area-button");
 
 const mapElement = document.getElementById("map");
 
-const reportIssueOpenButton = document.getElementById('report-issues-open-button')
-const loginNavBarButton = document.getElementById('sidenav-login-button');
-const logoutNavBarButton = document.getElementById('sidenav-logout-button');
 
 // automatic mode + manual mode contents i.e mode-specific panels
 const autoModeContent = document.getElementById("auto-mode-content");
@@ -176,6 +173,13 @@ const routeNameEntry = document.getElementById("route-name");
 const saveContainer = document.getElementById('save-route-container');
 const saveRouteToggleButton = document.getElementById("save-route-toggle-button");
 const saveRouteContainer = document.getElementById('save-route-container');
+
+// Navigation Rail Buttons 
+const donateModalOpenButton = document.getElementById('donate-button');
+const reportIssueOpenButton = document.getElementById('report-issues-open-button')
+const shortcutsModalOpenButton = document.getElementById('sidenav-shortcuts-button');
+const loginNavBarButton = document.getElementById('sidenav-login-button');
+const logoutNavBarButton = document.getElementById('sidenav-logout-button');
 
 // delete point modal
 const deletePointModal = document.getElementById("delete-point-confirmation-dialog");
@@ -200,8 +204,6 @@ const reportIssueTitleInput = document.getElementById("report-issue-title");
 const reportIssueTextAreaInput = document.getElementById("report-issue-description");
 
 // donate modal
-const donateButton = document.getElementById('donate-button');
-
 const donateModal = document.getElementById('donate-modal');
 const donateModalContent = document.getElementById('donate-modal-content');
 const donateModalCloseButton = document.getElementById('donate-modal-close-button');
@@ -216,6 +218,10 @@ const loadLastRouteModalRouteName = document.getElementById('load-last-route-mod
 const loadLastRouteModalRouteDistance = document.getElementById('load-last-route-modal-route-distance');
 const loadLastRouteModalRouteElevationGain = document.getElementById('load-last-route-modal-route-elevation-gain');
 
+// Keyboard Shortcuts Modal
+const shortcutsModal = document.getElementById('shortcuts-dialog');
+const shortcutsModalContent = shortcutsModal.querySelector('.modal-content');
+const shortcutsModalCloseButton = document.getElementById('shortcuts-dialog-close-button');
 
 // saved route dash panel
 const openSavedRoutesDashButton = document.getElementById('saved-routes-dash-open-button');
@@ -252,7 +258,7 @@ let savingRoutesTourDriver;
 
 // grouped elements
 const panels = [savedRoutesDashContent, importRoutePanel, settingPanel];
-const modals = [donateModal, reportIssueModal]
+const modals = [donateModal, reportIssueModal, shortcutsModal]
 
 const allowedFileTypes = ['.gpx', '.kml', '.geojson', '.fit'];
 
@@ -1034,6 +1040,8 @@ async function switchToAutoMode() {
   const map = getMap();
   if (!map) return;
 
+  if (getCurrentMode() === 'auto') return;
+
   await localforage.setItem("lastRoutingMode", "auto");
 
   setCurrentMode("auto");
@@ -1053,6 +1061,8 @@ async function switchToAutoMode() {
 async function switchToManualMode() {
   const map = getMap();
   if (!map) return;
+
+  if (getCurrentMode() === 'manual');
 
   await localforage.setItem("lastRoutingMode", "manual");
   
@@ -2134,6 +2144,7 @@ function handleDistanceUnitToggle() {
  * @returns {void}
  */
 function handleKeyboardShortcuts(e) {
+  e.preventDefault();
 
   // this returns if the user is typing 
   if (document.activeElement.tagName === "INPUT" || 
@@ -2165,20 +2176,23 @@ function handleKeyboardShortcuts(e) {
  * @returns 
  */
 function appShortcuts(e, key) {
+
+  const isModifier = e.metaKey || e.ctrlKey;
+
   // this switches to auto mode if ctrl/cmd + a is pressed
-  if (key === 'a') {
+  if (isModifier && e.shiftKey && key === 'a') {
     e.preventDefault();
     switchToAutoMode();
     return;
   };
 
-  if (key === 'k') {
+  if (isModifier && e.shiftKey && key === 'k') {
     e.preventDefault();
     searchEntry.focus();
   }
     
   // this switches to manual mode if ctrl/cmd + m is pressed
-  if ((e.metaKey && key === 'm' && e.shiftKey) || (e.ctrlKey && key === 'm')) {
+  if (isModifier && e.shiftKey && key === 'm') {
     e.preventDefault();
     switchToManualMode();
     return;
@@ -2266,8 +2280,17 @@ function navigationShortcuts(e, key) {
       e,
       donateModal
     )
+    return;
   }
 
+  // shortcuts modal
+  if (key === '6') {
+    handleModalShortcut(
+      e,
+      shortcutsModal
+    )
+    return;
+  };
 }
 
 /**
@@ -2447,25 +2470,30 @@ export function initUi() {
   // These event listeners are for keyboard shortcuts.
   addClickListener(document, handleKeyboardShortcuts, "keydown");
 
-  // These event listeners are for the login modal
+  // Login Modal
   addClickListener(loginModalExitButton, () => showModal(false, loginModal), 'click');
   addClickListener(loginModalLoginButton, loginModalLogin, 'click');
   addClickListener(loginModal, (e) => closeModalUponOutsideClick(e, loginModalContent, loginModal), 'click');
 
-  // These event listeners are for the report issue modal
+  // Report Issue Modal
   addClickListener(reportIssueModalExit, () => showReportIssueModal(false), "click");
   addClickListener(reportIssueModalSubmit, () => handleReportIssueSubmission(reportIssueTitleInput.value.trim(), reportIssueTextAreaInput.value.trim()), "click");
 
-  // These event listeners are for the donate modal
+  // Donate Modal
   addClickListener(donateModalCloseButton, () => showModal(false, donateModal), "click");
   addClickListener(donateModalMaybeLaterButton, () => showModal(false, donateModal), "click");
-  addClickListener(donateButton, () => showModal(true, donateModal), "click");
+  addClickListener(donateModalOpenButton, () => showModal(true, donateModal), "click");
   addClickListener(donateModal, (e) => closeModalUponOutsideClick(e, donateModalContent, donateModal), "click");
 
-  // These event listeners are for the load last route modal
+  // Load Last Route Modal
   addClickListener(loadLastRouteModalDismissButton, discardLastLoadedRoute, "click");
   addClickListener(loadLastRouteModalLoadButton, handleLoadCachedRoute, "click");
   addClickListener(loadLastRouteModal, (e) => closeModalUponOutsideClick(e, loadLastRouteModalContent, loadLastRouteModal), "click");
+
+  // Keyboard Shortcuts Modal
+  addClickListener(shortcutsModalOpenButton, () => showModal(true, shortcutsModal), "click");
+  addClickListener(shortcutsModalCloseButton, () => showModal(false, shortcutsModal), "click");
+  addClickListener(shortcutsModal, (e) => closeModalUponOutsideClick(e, shortcutsModalContent, shortcutsModal), "click");
 
   onMapClick(mapClickHandler);
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -250,7 +250,10 @@ let automaticRoutingTourDriver;
 let savingRoutesTourDriver;
 
 
-// this is an array of allowed file types for route import
+// grouped elements
+const panels = [savedRoutesDashContent, importRoutePanel, settingPanel];
+const modals = [donateModal, reportIssueModal]
+
 const allowedFileTypes = ['.gpx', '.kml', '.geojson', '.fit'];
 
 let clickMode = null;
@@ -303,12 +306,10 @@ function checkIfMobile() {
 }
 //#endregion
 
-//#region DONATE MODAL
-
 //#region GENERAL MODAL
 
 /**
- * Function used to catch clicks outside of a modal in order to close the modal upon these clicks. 
+ * Catches clicks outside of a modal in order to close the modal upon these clicks. 
  * 
  * @param {Event} e 
  * @param {HTMLDivElement} modalContent 
@@ -335,6 +336,17 @@ export function showModal(show, modal) {
     modal.close();
   }
 };
+
+/**
+ * Closes all modals within the application
+ * 
+ * @returns {void}
+ */
+function closeModals() {
+  modals.forEach(modal => {
+    modal.close();
+  })
+}
 
 //#endregion
 
@@ -719,6 +731,19 @@ export function mapClickHandler(event) {
 function noRouteCreateFunction() {
   closeSavedRoutesDash()
 }
+
+/**
+ * Closes all panels accessible from the navigation raile
+ * @returns {void}
+ */
+function closePanels() {
+  const panels = [savedRoutesDashContent, importRoutePanel, settingPanel];
+
+  panels.forEach(panel => {
+    if (panel.style.width)
+    panel.style.width = "0";
+  });
+};
 
 function openSavedRoutesDash() {
 
@@ -2102,6 +2127,12 @@ function handleDistanceUnitToggle() {
 
 //#region KEYBOARD SHORTCUTS
 
+/**
+ * Orchestrates keyboard shortcuts process and order of events  
+ * 
+ * @param {Event} e 
+ * @returns {void}
+ */
 function handleKeyboardShortcuts(e) {
 
   // this returns if the user is typing 
@@ -2114,53 +2145,184 @@ function handleKeyboardShortcuts(e) {
   const key = e.key.toLowerCase();
   const mode = getCurrentMode();
 
-  // if ctrl / cmd key is pressed
+  // cmd / ctrl signals a routing action rather than navigation
   if (e.ctrlKey || e.metaKey) {
-    
-    // this switches to auto mode if ctrl/cmd + a is pressed
-    if (key === 'a') {
-      e.preventDefault();
-      switchToAutoMode();
-      return;
-    };
-
-    if (key === 'k') {
-      e.preventDefault();
-      searchEntry.focus();
-    }
-     
-    // this switches to manual mode if ctrl/cmd + m is pressed
-    if ((e.metaKey && key === 'm' && e.shiftKey) || (e.ctrlKey && key === 'm')) {
-      e.preventDefault();
-      switchToManualMode();
-      return;
-    };
-
+    appShortcuts(e, key)
     if (mode === "manual") {
-
-      // this un-does the last point if ctrl/cmd + z is clicked
-      if (key === "z") {
-        e.preventDefault();
-        undoManualRoutePoint();
-        return;
-      };
-       
-      
-      // this re-does the last undone point if ctrl/cmd + y is clicked
-      if (key === "y") {
-        e.preventDefault();
-        redoManualRoutePoint();
-        return;
-      };
-       
+      manualRouteShortcuts(e, key) 
     };
-
-  };
-
+  }
+  else {
+    navigationShortcuts(e, key)
+  }
 };
 
-//#endregion
+/**
+ * Handles general shortcuts
+ * 
+ * @param {Event} e 
+ * @param {String} key 
+ * @returns 
+ */
+function appShortcuts(e, key) {
+  // this switches to auto mode if ctrl/cmd + a is pressed
+  if (key === 'a') {
+    e.preventDefault();
+    switchToAutoMode();
+    return;
+  };
 
+  if (key === 'k') {
+    e.preventDefault();
+    searchEntry.focus();
+  }
+    
+  // this switches to manual mode if ctrl/cmd + m is pressed
+  if ((e.metaKey && key === 'm' && e.shiftKey) || (e.ctrlKey && key === 'm')) {
+    e.preventDefault();
+    switchToManualMode();
+    return;
+  };
+}
+
+/**
+ * Handles shortcuts for manual routing 
+ * 
+ * @param {Event} e 
+ * @param {String} key 
+ * @returns {void}
+ */
+function manualRouteShortcuts(e, key) {
+  // this un-does the last point if ctrl/cmd + z is clicked
+  if (key === "z") {
+    e.preventDefault();
+    undoManualRoutePoint();
+    return;
+  };
+    
+  
+  // this re-does the last undone point if ctrl/cmd + y is clicked
+  if (key === "y") {
+    e.preventDefault();
+    redoManualRoutePoint();
+    return;
+  };
+}
+
+/**
+ * Handles shortcuts for opening/closing panels and modals 
+ * 
+ * @param {Event} e 
+ * @param {String} key 
+ * @returns {void}
+ */
+function navigationShortcuts(e, key) {
+
+  // saved routes dash
+  if (key === '1') {
+    handlePanelShortcut(
+      e, 
+      savedRoutesDashContent, 
+      () => openSavedRoutesDash(),
+      () => closeSavedRoutesDash()
+    );
+    return;
+  }
+
+  // import route panel
+  if (key === '2') {
+    handlePanelShortcut(
+      e, 
+      importRoutePanel, 
+      () => openImportRoute(),
+      () => closeImportRoute()
+    );
+    return;
+  }
+  
+  // settings panel
+  if (key === '3') {
+    handlePanelShortcut(
+      e,
+      settingPanel,
+      () => openSettings(),
+      () => closeSettings()
+    );
+    return;
+  }
+
+  // report issue modal
+  if (key === '4') {
+    handleModalShortcut(
+      e,
+      reportIssueModal
+    );
+    return;
+  }
+
+  // donate modal
+  if (key === '5') {
+    handleModalShortcut(
+      e,
+      donateModal
+    )
+  }
+
+}
+
+/**
+ * @param {Event} e
+ * @param {HTMLDivElement} panel 
+ * @param {Function} open 
+ * @param {Function} close 
+ * @returns {void}
+ */
+function handlePanelShortcut(e, panel, open, close) {
+  e.preventDefault();
+
+  closeModals();
+
+  /**
+  * Helper to tell if any other panels are open
+  * 
+  * @param {HTMLDivElement} currentPanel 
+  * @returns {Boolean} 
+  */
+  const isOtherPanelOpen = (currentPanel) => {
+    return panels.some(panel => panel.style.width === "100vw" && panel !== currentPanel);
+  };
+
+
+  if (panel.style.width === "100vw") {
+    close();
+  } else {
+    closePanels();
+    open();
+  }
+}
+
+/**
+ * Helper to open/close modals
+ * 
+ * @param {Event} e 
+ * @param {HTMLDialogElement} modal 
+ * @returns {void}
+ */
+function handleModalShortcut(e, modal) {
+  e.preventDefault();
+
+  closePanels();
+
+  if (modal.open) {
+    modal.close();
+    return;
+  }
+  else {
+    closeModals();
+    modal.show();
+  }
+}
+//#endregion
 
 //#region EVENT LISTENERS / INIT
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -123,7 +123,7 @@ import {
   createSettingsTour
 } from "./tours/tours.js";
 
-import { logout } from "./auth/auth.js";
+import { login, logout } from "./auth/auth.js";
 import { logError } from "./utils/logError-utils.js";
 import { Vector } from "ol/source.js";
 import Style from "ol/style/Style.js";
@@ -258,7 +258,7 @@ let savingRoutesTourDriver;
 
 // grouped elements
 const panels = [savedRoutesDashContent, importRoutePanel, settingPanel];
-const modals = [donateModal, reportIssueModal, shortcutsModal]
+const modals = [donateModal, reportIssueModal, shortcutsModal, loginModal]
 
 const allowedFileTypes = ['.gpx', '.kml', '.geojson', '.fit'];
 
@@ -2144,7 +2144,6 @@ function handleDistanceUnitToggle() {
  * @returns {void}
  */
 function handleKeyboardShortcuts(e) {
-  e.preventDefault();
 
   // this returns if the user is typing 
   if (document.activeElement.tagName === "INPUT" || 
@@ -2231,6 +2230,7 @@ function manualRouteShortcuts(e, key) {
  * @returns {void}
  */
 function navigationShortcuts(e, key) {
+  e.preventDefault();
 
   // saved routes dash
   if (key === '1') {
@@ -2303,6 +2303,11 @@ function navigationShortcuts(e, key) {
 function handlePanelShortcut(e, panel, open, close) {
   e.preventDefault();
 
+  if (loginModal.open) {
+    loginModal.close();
+    return;
+  };
+
   closeModals();
 
   /**
@@ -2338,7 +2343,6 @@ function handleModalShortcut(e, modal) {
 
   if (modal.open) {
     modal.close();
-    return;
   }
   else {
     closeModals();

--- a/static/js/utils/ui-utils.js
+++ b/static/js/utils/ui-utils.js
@@ -20,6 +20,8 @@
  * Parses a coordinate string in the form "X, Y" (or "X,Y").
  * Returns [x, y] as numbers or null if the format is invalid.
  * Never throws.
+ * @param {String} value
+ * @returns {Array}
  */
 export function parseCoordString(value) {
   if (typeof value !== "string") return null;
@@ -281,6 +283,9 @@ export function createNoRouteCard() {
 /**
  * This returns a stats panel showing key details of the currently-displayed route 
  * 
+ * @param {String} distanceDisplay
+ * @param {String} etaDisplay
+ * @param {String} elevationGain
  * @returns {string} HTML string for the stats panel showing key route details 
  */
 export function createStatsPanel(distanceDisplay, etaDisplay, elevationGain) {

--- a/templates/map.html
+++ b/templates/map.html
@@ -38,6 +38,7 @@
     <link rel="stylesheet" href="{{ url_for('static', path='css/components/buttons.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='css/components/donate-modal.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='css/components/load-last-route-modal.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', path='css/components/shortcuts-modal.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', path='css/components/form-fields.css') }}">
 
     <!-- Layout CSS Files -->
@@ -322,7 +323,76 @@
             </div>
         </dialog>
 
+        <!-- ##### DELETE POINT MODAL ##### -->
+        <dialog id="shortcuts-dialog" class="modal-overlay">
+            <div class="modal-wrapper">
+                <div class="modal-content shortcuts-modal-content">
+                    <div class="modal-header">
+                        <h2>Keyboard Shortcuts</h2>
+                    </div>
+                    <div class="modal-body shortcuts-modal-body">
+                        <div class="shortcuts-group">
+                            <h3 class="shortcuts-group-title">Routing</h3>
+                            <div class="shortcut-item">
+                                <span class="shortcut-name">Switch to Auto Mode</span>
+                                <span class="shortcut-key"><kbd>Ctrl/⌘</kbd><span class="shortcut-key-plus">+</span><kbd>Shift</kbd><span class="shortcut-key-plus">+</span><kbd>A</kbd></span>
+                            </div>
+                            <div class="shortcut-item">
+                                <span class="shortcut-name">Switch to Manual Mode</span>
+                                <span class="shortcut-key"><kbd>Ctrl/⌘</kbd><span class="shortcut-key-plus">+</span><kbd>Shift</kbd><span class="shortcut-key-plus">+</span><kbd>M</kbd></span>
+                            </div>
+                            <div class="shortcut-item">
+                                <span class="shortcut-name">Focus Map Search</span>
+                                <span class="shortcut-key"><kbd>Ctrl/⌘</kbd><span class="shortcut-key-plus">+</span><kbd>Shift</kbd><span class="shortcut-key-plus">+</span><kbd>K</kbd></span>
+                            </div>
+                        </div>
 
+                        <div class="shortcuts-group">
+                            <h3 class="shortcuts-group-title">Manual Routing</h3>
+                            <div class="shortcut-item">
+                                <span class="shortcut-name">Undo Last Point</span>
+                                <span class="shortcut-key"><kbd>Ctrl/⌘</kbd><span class="shortcut-key-plus">+</span><kbd>Z</kbd></span>
+                            </div>
+                            <div class="shortcut-item">
+                                <span class="shortcut-name">Redo Last Point</span>
+                                <span class="shortcut-key"><kbd>Ctrl/⌘</kbd><span class="shortcut-key-plus">+</span><kbd>Y</kbd></span>
+                            </div>
+                        </div>
+
+                        <div class="shortcuts-group">
+                            <h3 class="shortcuts-group-title">Navigation</h3>
+                            <div class="shortcut-item">
+                                <span class="shortcut-name">Saved Routes</span>
+                                <span class="shortcut-key"><kbd>1</kbd></span>
+                            </div>
+                            <div class="shortcut-item">
+                                <span class="shortcut-name">Import Route</span>
+                                <span class="shortcut-key"><kbd>2</kbd></span>
+                            </div>
+                            <div class="shortcut-item">
+                                <span class="shortcut-name">Settings</span>
+                                <span class="shortcut-key"><kbd>3</kbd></span>
+                            </div>
+                            <div class="shortcut-item">
+                                <span class="shortcut-name">Report Issue</span>
+                                <span class="shortcut-key"><kbd>4</kbd></span>
+                            </div>
+                            <div class="shortcut-item">
+                                <span class="shortcut-name">Donate</span>
+                                <span class="shortcut-key"><kbd>5</kbd></span>
+                            </div>
+                            <div class="shortcut-item">
+                                <span class="shortcut-name">Keyboard Shortcuts</span>
+                                <span class="shortcut-key"><kbd>6</kbd></span>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="modal-actions">
+                        <button type="button" id="shortcuts-dialog-close-button" class="modal-btn modal-btn-secondary">Close</button>
+                    </div>
+                </div>
+            </div>
+        </dialog>
 
 
         <div id="map"></div>
@@ -332,6 +402,7 @@
     <div id="the-sidenav" class="sidenav" aria-label="Main navigation">
         <div class="sidenav-inner">
             <ul class="sidenav-links">
+
                 <li>
                     <a
                         id="saved-routes-dash-open-button"
@@ -364,61 +435,66 @@
                         <span class="nav-label">Settings</span>
                     </a>
                 </li>
-
-                <li>
-                    <a
-                        id="report-issues-open-button"
-                        class="sidenav-link"
-                        aria-label="Report Issues"
-                    >
-                        <i data-lucide="bug"></i>
-                        <span class="nav-label">Report Issues</span>
-                    </a>
-                </li>
-
-                <li>
-                    <a
-                        class="sidenav-link"
-                        id="donate-button"
-                        href="javascript:void(0)"
-                    >
-                        <i data-lucide="heart"></i>
-                        <span class="nav-label">Donate</span>
-                    </a>
-                </li>
             </ul>
 
-            {% if user is none or not user.preferred_name %}
-                <div
-                    id="sidenav-login-logout-button-container"
-                    class="sidenav-auth"
+            <div class="sidenav-lower">
+                <ul class="sidenav-links">
+                    <li>
+                        <a
+                            id="report-issues-open-button"
+                            class="sidenav-link"
+                            aria-label="Report Issues"
+                        >
+                            <i data-lucide="bug"></i>
+                            <span class="nav-label">Report Issues</span>
+                        </a>
+                    </li>
+
+                    <li>
+                        <a
+                            class="sidenav-link"
+                            id="donate-button"
+                            href="javascript:void(0)"
+                        >
+                            <i data-lucide="heart"></i>
+                            <span class="nav-label">Donate</span>
+                        </a>
+                    </li>
+                </ul>
+
+                <button
+                    type="button"
+                    id="sidenav-shortcuts-button"
+                    class="sidenav-link lower-sidenav-button"
+                    aria-label="keyboard shortcuts"
                 >
+                    <i data-lucide="keyboard"></i>
+                    <span class="nav-label">Shortcuts</span>
+                </button>
+
+                {% if user is none or not user.preferred_name %} 
                     <button
                         type="button"
                         id="sidenav-login-button"
-                        class="sidenav-link sidenav-auth-button"
+                        class="sidenav-link lower-sidenav-button"
                         aria-label="Log In"
                     >
                         <i data-lucide="log-in"></i>
                         <span class="nav-label">Log In</span>
                     </button>
-                </div>
-            {% else %}
-                <div
-                    id="sidenav-login-logout-button-container"
-                    class="sidenav-auth"
-                >
+                {% else %}
                     <button
                         type="button"
                         id="sidenav-logout-button"
-                        class="sidenav-link sidenav-auth-button"
+                        class="sidenav-link lower-sidenav-button"
                         aria-label="Log Out"
                     >
                         <i data-lucide="log-out"></i>
                         <span class="nav-label">Log Out</span>
                     </button>
-                </div>
-            {% endif %}
+                {% endif %}
+
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
Pull Request Template

## Summary
This PR aims to add more keyboard shortcuts for faster use of Crestr as well as introduce a new modal, the shortcuts modal, to better inform users of the available shortcuts in Crestr

## Related Issue
Closes ABD-33

## Type of Change
Select all that apply:
- [ ] Bug fix  
- [x] New feature  
- [ ] Documentation update  
- [ ] Refactor  
- [ ] Other (explain below)

## Description of Changes
- `tokens.css`: Altered the `--secondary-btn-bg` and `secondary-btn-bg-hover` tokens slightly 
- `donate-modal.css`: Made SVGs use the `--ink` token so that they aligned with the theme of the app
- `shortcuts-modal.css`: Added an extension of the base `modal.css` file which holds styles specifically for the new keyboard shortcuts modal 
- `ui.js`: Added new keyboard shortcuts + improved maintainability of these shortcuts by making new individual and scoped functions, such as `navigationShortcuts` and `manualRoutingShortcuts` 
- `map.html`: Moved utilities pages and modals to the lower half of the navigation rail with login/logout + added new keyboard shortcut modal 


## Screenshots / Visuals (if applicable)
####
### The Shortcuts Modal
<img width="1470" height="828" alt="image" src="https://github.com/user-attachments/assets/4707dfcd-6e01-4a50-8339-f595347ba133" />

## Testing
- Closed and opened each modal whilst both logged in and logged out to that they worked as intended 

## Checklist
- [x] My code follows the project’s style guidelines  
- [x] I have tested my changes  
- [x] I have updated documentation if needed  
- [x] I have referenced the related issue  
- [x] This PR is scoped, focused, and ready for review  

> **Note:**  
> PRs for issues **not** tagged as contributor‑friendly may be closed without review.
