### PR TITLE
PR chore: Improve Error Handling 

### DIFF
--- a/src/Routes/routes_fastapi.py
+++ b/src/Routes/routes_fastapi.py
@@ -307,7 +307,8 @@ def calculate_path(
                 "success": False,
                 "map_centre": DEFAULT_CENTRE,
                 "available_routes": [],
-                "message": "Sorry, there was an unexpected error whilst creating your route. "
+                "message": "Routing : HTTP 500 Error",
+                "user_message": "Sorry, there was an unexpected error whilst creating your route, please try again later."
             }
         )
 

--- a/src/Routes/routes_fastapi.py
+++ b/src/Routes/routes_fastapi.py
@@ -59,7 +59,7 @@ router = APIRouter()
     dependencies=[
         Depends(
             RateLimiter(
-                limiter=Limiter(Rate(10, Duration.MINUTE)),
+                limiter=Limiter(Rate(60, Duration.MINUTE)),
                 callback=rate_limit_exceeded_callback
             )
         )
@@ -97,7 +97,8 @@ def calculate_path(
                 status_code=400,
                 detail={
                     "success": False,
-                    "message": "Please enter coordinates within Cumbria. "
+                    "message": "Coordinates outside of Cumbria entered",
+                    "user_message": "Please enter coordinates within Cumbria. "
                 }
             )
 
@@ -149,7 +150,8 @@ def calculate_path(
                 "success": False,
                 "map_centre": DEFAULT_CENTRE,
                 "available_routes": available_routes, 
-                "message": str(e)
+                "message": str(e),
+                "user_message": "Invalid coordinates, please try again."
             }
         ) from e
 
@@ -179,7 +181,8 @@ def calculate_path(
                         "success": False,
                         "map_centre": DEFAULT_CENTRE,
                         "available_routes": available_routes,
-                        "message": "No path could be created"
+                        "message": "No path could be created",
+                        "user_message": "Sorry, path could not be generated, please try again later."
                     }
                 ) 
 
@@ -336,7 +339,8 @@ def save_route(
                 status_code=401,
                 detail={
                     "success": False,
-                    "message": "Please log in to save routes. "
+                    "message": "Unauthenticated attempt to save a route.",
+                    "user_message": "Please log in to save routes. "
                 }
             )
 
@@ -349,7 +353,8 @@ def save_route(
                 status_code=422,
                 detail={
                     "success": False,
-                    "message": "Route name required"
+                    "message": "A route name is required. ",
+                    "user_message": "A route name is required, please try again."
                 }
             )
         
@@ -360,7 +365,8 @@ def save_route(
                 status_code=422,
                 detail={
                     "success": False,
-                    "message": "Invalid route data"
+                    "message": "Invalid route data",
+                    "user_message": "File error. Please try uploading a different file."
                 }
             )
         
@@ -402,10 +408,14 @@ def save_route(
 
         log_action('Saving Route', False, short_traceback, None, 'SAVE_ROUTE')
 
-        return {
-            "success" : False,
-            "message" : "A route with this name already exists. Please pick a new name."
-        }
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "success": False,
+                "message": "ERROR : route name cannot be the same as other routes.",
+                "user_message": "A route with this name already exists. Please pick a new name."
+            }
+        )
 
     except HTTPException:
         raise
@@ -451,7 +461,8 @@ def load_route(
             status_code=401,
             detail={
                 "success": False,
-                "message": "Please Login to load routes"
+                "message": "Unauthenticated attempt to load a route.",
+                "user_message": "Please Login to load routes."
             }
         )
 
@@ -463,7 +474,8 @@ def load_route(
             status_code=422,
             detail={
                 "success": False,
-                "message": "Route name is required. "
+                "message": "Route name is required.",
+                "user_message": "A route name is required, please try again."
             }
         )
     
@@ -479,7 +491,8 @@ def load_route(
             status_code=404,
             detail={
                 "success": False,
-                "message": "The route could not be found in the server. "
+                "message": "The route could not be found in the server. ",
+                "user_message": "Sorry, the route could not be found in the server."
             }
         )
     
@@ -515,7 +528,8 @@ def load_route(
                 status_code=422,
                 detail={
                     "success": False,
-                    "message": "There are no valid coordinates within the route file. "
+                    "message": "There are no valid coordinates within the route file. ",
+                    "user_message": "Sorry, the coordinates in the file are not valid. "
                 }
             )
         
@@ -601,7 +615,8 @@ def delete_route(
             status_code=401,
             detail={
                 "success": False,
-                "message": "Unauthenticated attmept to delete route"
+                "message": "Unauthenticated attmept to delete route",
+                "user_message": "You do not own this route."
             }
         )
 
@@ -612,7 +627,8 @@ def delete_route(
             status_code=422,
             detail={
                 "success": False,
-                "message": "Route name is required."
+                "message": "Route name is required.",
+                "user_message": "A route name is required, please try again."
             }
         )
 
@@ -629,7 +645,8 @@ def delete_route(
                 status_code=404,
                 detail={
                     "success": False,
-                    "message": "Route to be deleted could not be found"
+                    "message": "Route to be deleted could not be found",
+                    "user_message": "Could not find the route you want to delete."
                 }
             )
         deleted_route_name = route.name
@@ -709,7 +726,8 @@ async def import_route(
             status_code=422,
             detail={
                 "success": False,
-                "message": "Cannot receive uploaded file"
+                "message": "Cannot receive uploaded file",
+                "user_message": "We could not receive the uploaded file, please try again later."
             }
         )
     
@@ -718,7 +736,8 @@ async def import_route(
             status_code=422,
             detail={
                 "success": False,
-                "message": "Imported route is too large, please pick a route under 5MB in size. "
+                "message": "Imported route is too large. ",
+                "user_message": "Imported route is too large, please pick a route under 5MB in size. "
             }
         )
     
@@ -735,7 +754,8 @@ async def import_route(
                 status_code=400,
                 detail={
                     "success": False,
-                    "message": "Please upload a file of the supported types. "
+                    "message": "ERROR : Unsupported file type",
+                    "user_message": "Please upload a file of the supported types. "
                 }
             )
         
@@ -964,20 +984,22 @@ def download_route_file(
             status_code=422,
             detail={
                 "success": False,
-                "message": "Route name and file type is required. "
+                "message": "Route name and file type is required. ",
+                "user_message": "Both the route name and route file type are required, please try again."
             }
         )
 
     # ensures that routes have a file type 
-    # also impossible that this is the case since download occurs through either a gpx or a geojson button and not path / query params, but this may be implemented in a later version
-    # so it is kept + it is a good habit 
+    # also impossible that this is the case since download occurs through either a gpx or a geojson button and not path / query params
+    # as path / query params may be implemented in the future, it is kept + it is a good habit 
     if file_type not in ["gpx", "geojson"]:
 
         raise HTTPException(
             status_code=422,
             detail={
                 "success": False,
-                "message": "Invalid file type. Use 'gpx' or 'geojson' format. "
+                "message": "Invalid file type. Use 'gpx' or 'geojson' format. ",
+                "user_message": "Invalid file type. Download routes as 'gpx' or 'geojson'."
             }
         )
 
@@ -996,7 +1018,8 @@ def download_route_file(
             status_code=404,
             detail={
                 "success": False,
-                "message": "Route not found or you don't own it"
+                "message": "Route not found or you don't own it",
+                "user_message": "Could not delete route as you do not own it."
             }
         )
 

--- a/src/Routes/routes_fastapi.py
+++ b/src/Routes/routes_fastapi.py
@@ -367,7 +367,7 @@ def save_route(
                 detail={
                     "success": False,
                     "message": "Invalid route data",
-                    "user_message": "File error. Please try uploading a different file."
+                    "user_message": "The route data is invalid. Please try again."
                 }
             )
         
@@ -617,7 +617,7 @@ def delete_route(
             detail={
                 "success": False,
                 "message": "Unauthenticated attmept to delete route",
-                "user_message": "You do not own this route."
+                "user_message": "Please log in to delete routes."
             }
         )
 
@@ -1020,7 +1020,7 @@ def download_route_file(
             detail={
                 "success": False,
                 "message": "Route not found or you don't own it",
-                "user_message": "Could not delete route as you do not own it."
+                "user_message": "Could not download the route. Check that it exists and belongs to you."
             }
         )
 

--- a/static/js/importRoute.js
+++ b/static/js/importRoute.js
@@ -30,8 +30,7 @@ export async function processImportedRouteFile(file) {
     const data = await response.json();
 
     if (!response.ok) {
-        showToast(data.message || "There was an error on our end, try again later");
-        throw new Error(`HTTP Error: ${response.status}`);
+        throw new Error( data.message || `(IMPORT ROUTE) HTTP Error: ${data}`, {cause: "Sorry, there was an error importing your route."})
     }
 
     if (data.success) {

--- a/static/js/importRoute.js
+++ b/static/js/importRoute.js
@@ -29,8 +29,8 @@ export async function processImportedRouteFile(file) {
 
     const data = await response.json();
 
-    if (!response.ok) {
-        throw new Error( data.message || `(IMPORT ROUTE) HTTP Error: ${data}`, {cause: "Sorry, there was an error importing your route."})
+    if (!response.ok || !data.success) {
+        throw new Error( data.message || `(IMPORT ROUTE) HTTP Error: ${data}`, {cause: data.user_message || data.message || "Sorry, there was an error importing your route."})
     }
 
     if (data.success) {

--- a/static/js/routes/loadRoute.js
+++ b/static/js/routes/loadRoute.js
@@ -55,9 +55,6 @@ export function displayLoadedRouteOnMap(data) {
   const vectorSource = routeLayer.getSource();
   vectorSource.clear();
 
-  console.log(JSON.stringify(data));
-  console.log(data);
-
   const format = new GeoJSON();
   const features = format.readFeatures(data.pathGeoJSON, {
     dataProjection: "EPSG:4326",

--- a/static/js/routes/loadRoute.js
+++ b/static/js/routes/loadRoute.js
@@ -55,6 +55,9 @@ export function displayLoadedRouteOnMap(data) {
   const vectorSource = routeLayer.getSource();
   vectorSource.clear();
 
+  console.log(JSON.stringify(data));
+  console.log(data);
+
   const format = new GeoJSON();
   const features = format.readFeatures(data.pathGeoJSON, {
     dataProjection: "EPSG:4326",

--- a/static/js/routes/routeApi.js
+++ b/static/js/routes/routeApi.js
@@ -77,6 +77,7 @@ export async function downloadRoute(routeName, format, DOMElement) {
   })
 
   if (!response.ok) {
+    const data = await response.json().catch(() => ({}))
     throw new Error(data.message || `Download Route Error : ${response.status}`, {cause: data.user_message || "Sorry, there was an error downloading your route, please try again later."});
   }
 

--- a/static/js/routes/routeApi.js
+++ b/static/js/routes/routeApi.js
@@ -23,23 +23,18 @@ export async function deleteRoute(routeName) {
     }),
   });
 
-  if (!response.ok) {
-    throw new Error(`HTTP error: ${response.status}`);
-  }
-
   const data = await response.json();
 
-  if (data.success) {
-    return data;
+  if (!response.ok || !data.success) {
+    throw new Error(data.message || `Load Route Error : ${response.status}`, {cause: data.user_message || "Sorry, there was an error downloading your route, please try again later."});
   }
-  else {
-    throw new Error(data.message || "Route deletion failed")
-  }
+
+  return data
 }
 
 /**
  * @param {string} routeName
- * @returns {Promise<{ success: boolean, path_geojson?: object, coordinates?: number[][], route_stats?: object, message?: string }>}
+ * @returns {Promise<{ success: boolean, path_geojson?: object, coordinates?: Array<Array<number>>, route_stats?: object, message?: string }>}
  */
 export async function loadRoute(routeName) {
   const url = window.appConfig.apiLoadRouteUrl;
@@ -52,18 +47,13 @@ export async function loadRoute(routeName) {
     }),
   });
 
-  if (!response.ok) {
-    throw new Error(`HTTP Error: ${response.status}`);
-  }
-
   const data = await response.json();
 
-  if (data.success) {
-    return data;
+  if (!response.ok || !data.success) {
+    throw new Error(data.message || `Load Route Error : ${response.status}`, {cause: data.user_message || "Sorry, there was an error loading your route, please try again later."});
   }
-  else {
-    throw new Error(data.message || "Loading the route failed")
-  }
+
+  return data;
 }
 
 /**
@@ -87,9 +77,9 @@ export async function downloadRoute(routeName, format, DOMElement) {
   })
 
   if (!response.ok) {
-    console.log(response.message || "no message from backend")
-    throw new Error(`HTTP Error, ${response.status}`)
+    throw new Error(data.message || `Download Route Error : ${response.status}`, {cause: data.user_message || "Sorry, there was an error downloading your route, please try again later."});
   }
+
   DOMElement.classList.remove('loading')
   return response
 }

--- a/static/js/routes/saveRoute.js
+++ b/static/js/routes/saveRoute.js
@@ -38,6 +38,7 @@ import {
 import { toLonLat } from "ol/proj.js";
 
 import localforage from "localforage";
+import { logError } from "../utils/logError-utils.js";
 
 let saveRouteForm = null;
 const allRoutesContainer = document.getElementById("all-routes-container");
@@ -71,111 +72,117 @@ async function handleSaveRoute(e) {
     eta = routeETADisplay?.textContent;
     elevationChange = routeElevationDisplay?.textContent
 
-    if (!window.appConfig.loggedIn) {
-      showLoginModal(true, 'save routes');
-      await localforage.setItem("unauthenticated-save-route-attempt", true);
-      await localforage.setItem("cachedRouteName", routeName);
-      return;
-    }
+    if (! await handleUnauthenticatedUser(routeName)) return;
 
-
-    const mode = getCurrentMode();
-    if (mode === "manual" && manualRouteState.pathCoords.length > 0) {
-      pathCoordinates = manualRouteState.pathCoords;
-    } else {
-      pathCoordinates = getCurrentPathData() || getLoadedRouteCoordinates() || []; // coords in these arrays may now have elevation data
-    }
-
-    // manually plotted points converted to lon lat as they are stored in web mercator (auto / loaded routes aren't)
-    if (mode === "manual" && manualRouteState.pathCoords.length > 0) {
-      pathCoordinates = pathCoordinates.map(coord => {
-        const lonLat = toLonLat([coord[0], coord[1]]);
-        return coord.length >= 3 ? [lonLat[0], lonLat[1], coord[2]] : lonLat;
-      });
-    }
-
-    pathCoordinates = normaliseCoordLength(pathCoordinates);
+    pathCoordinates = getPathCoordinates();
 
     if (pathCoordinates.length === 0) {
-      console.error("No coordinates found in pathCoords array")
-      showToast("There was an error saving your route. Please try again later.");
-      return false;
+      logError('Saving Route', "No coordinates found in pathCoords array", null, 'SAVE_ROUTE');
+      throw new Error("No coords in pathCoords array", {cause : "Sorry, there was an error saving your route, please try again later."});
     }
 
     rawDistanceKm = getLastKnownDistanceKm();
 
     if (rawDistanceKm === null || isNaN(rawDistanceKm)) {
-      console.error("No valid route distance to save");
-      showToast("There was an error saving your route. Please try again later.");
-      return false;
+      logError('Saving Route', "No distance value / distance value is NaN", null, 'SAVE_ROUTE');
+      throw new Error("No distance value", {cause : "Sorry, there was an error saving your route, please try again later."});
     }
   }
   catch (e) {
-    console.error(`Error whilst saving route: ${e}`)
-    showToast("There was an error saving your route. Please try again later.");
+    logError('Saving Route', e.message || 'None', null, 'SAVE_ROUTE')
+    showToast(e.cause || "Sorry, there was an error saving your route, please try again later.");
     return false;
   }
 
-  const url = window.appConfig.apiSaveRouteUrl;
+  try { 
 
-  fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      route_name: routeName,
-      coordinates: pathCoordinates,
-    }),
-  })
-    .then((response) => {
-      if (!response.ok) {
-        showToast("There was an error saving your route. Please try again later.")
-        return response.json().then((errorData) => {
-          throw new Error(
-            errorData.message ||
-              `Server responded with status ${response.status}`,
-          );
-        });
-      }
-      return response.json();
-    })
-    .then((data) => {
-      if (data.success) {
-        const routeNameInput = document.getElementById("route-name");
-        if (routeNameInput) routeNameInput.value = "";
+    const url = window.appConfig.apiSaveRouteUrl;
 
-        const routeInfo = data.route_info;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        route_name: routeName,
+        coordinates: pathCoordinates,
+      }),
+    });
 
-        const today = new Date();
+    const data = await response.json();
 
-        const formattedToday = new Intl.DateTimeFormat('en-GB', {
-          "day": "2-digit",
-          "month": "2-digit",
-          "year": "numeric"
-        }).format(today);
+    if (!response.ok) {
+      throw new Error(data.message || response.status, {cause : data.user_message || "Sorry, there was an error saving your route, please try again later."});
+    };
 
-        console.log(routeInfo)
-        
-        elevDisplayValue = routeInfo.elevation_gain_metres === 0 ? "No Data" : formatElevation(routeInfo.elevation_gain_metres);
+    if (!data.success) {
+      throw new Error(data.message || response.status, {cause : data.user_message || "Sorry, there was an error saving your route, please try again later."});
+    };
 
-        eta = formatETA(routeInfo.eta_seconds);
-        
-        if (noRouteCreateDiv) removeDOMElement(noRouteCreateDiv);   
-        
-        const formattedDistance = formatDistance(rawDistanceKm)
+    if (routeNameEntry) routeNameEntry.value = "";
 
-        const routeCard = createRouteCard(routeName, formattedToday, rawDistanceKm, formattedDistance, eta, elevDisplayValue);
+    const routeInfo = data.route_info;
 
-        if (allRoutesContainer) allRoutesContainer.insertAdjacentHTML("beforeend", routeCard);
-        homeButtonFunction();
-        updateSaveRouteContainer();
-      } else {
-        showToast( data.message || "There was an error saving your route. Please try again later.")
-        return false;
-      }
-    })
-    .catch((error) => {
-      showToast("There was an error saving your route. Please try again later.")
-      console.error("Error saving route:", error);
-      return false;
-    })
+    const today = new Date();
+
+    const formattedToday = new Intl.DateTimeFormat('en-GB', {
+      "day": "2-digit",
+      "month": "2-digit",
+      "year": "numeric"
+    }).format(today);
+    
+    elevDisplayValue = routeInfo.elevation_gain_metres === 0 ? "No Data" : formatElevation(routeInfo.elevation_gain_metres);
+
+    eta = formatETA(routeInfo.eta_seconds);
+    
+    if (noRouteCreateDiv) removeDOMElement(noRouteCreateDiv);   
+    
+    const formattedDistance = formatDistance(rawDistanceKm)
+
+    const routeCard = createRouteCard(routeName, formattedToday, rawDistanceKm, formattedDistance, eta, elevDisplayValue);
+
+    if (allRoutesContainer) allRoutesContainer.insertAdjacentHTML("beforeend", routeCard);
+    homeButtonFunction();
+    updateSaveRouteContainer();
+
+  }
+  catch (error) {
+    showToast( error.cause || "Sorry, there was an error saving your route, please try again later.")
+  }
 };
+
+/**
+ * Retrieves and formats coordinates of a present path
+ * 
+ * @returns {Array<Array<number>>}
+ */
+function getPathCoordinates() {
+  const mode = getCurrentMode();
+  let pathCoordinates = [];
+  
+  if (mode === "manual" && manualRouteState.pathCoords.length > 0) {
+    const webMercatorCoords = manualRouteState.pathCoords;
+
+    pathCoordinates = webMercatorCoords.map(coord => {
+      const lonLat = toLonLat([coord[0], coord[1]]);
+      return coord.length >= 3 ? [lonLat[0], lonLat[1], coord[2]] : lonLat;
+    });
+  } else {
+    pathCoordinates = getCurrentPathData() || getLoadedRouteCoordinates() || [];
+  }
+
+  return normaliseCoordLength(pathCoordinates);
+}
+
+/**
+ * 
+ * 
+ * @returns {Boolean}
+ */
+async function handleUnauthenticatedUser(routeName) {
+  if (!window.appConfig.loggedIn) {
+    showLoginModal(true, 'save routes');
+    await localforage.setItem("unauthenticated-save-route-attempt", true);
+    await localforage.setItem("cachedRouteName", routeName);
+    return false
+  }
+  return true
+}

--- a/static/js/routes/savedRoutesDashboard.js
+++ b/static/js/routes/savedRoutesDashboard.js
@@ -71,7 +71,7 @@ async function onLoadClick(event) {
     await setCurrentPathData(data.coordinates);
     await closeSavedRoutesDash();
   } catch (error) {
-    showToast(error.cause)
+    showToast(error.cause || "Sorry, there was an error loading your route, please try again later.")
   }
 
   event.preventDefault();
@@ -104,7 +104,7 @@ async function onDeleteClick(event) {
 
     }
   } catch (error) {
-    showToast(error.user_message || error.message || "Sorry, there was an error downloading your route, please try again later.")
+    showToast(error.cause || "Sorry, there was an error downloading your route, please try again later.")
   }
 
   event.preventDefault();
@@ -165,7 +165,7 @@ async function onDownloadClick(event, format, DOMElement) {
   } 
   catch(error) {
 
-    showToast(error.user_message || error.message || "Sorry, there was an error downloading your route, please try again later.")
+    showToast(error.cause || "Sorry, there was an error downloading your route, please try again later.")
   }
   finally {
     DOMElement.disabled = false;

--- a/static/js/routes/savedRoutesDashboard.js
+++ b/static/js/routes/savedRoutesDashboard.js
@@ -61,7 +61,6 @@ async function onLoadClick(event) {
   if (!route) return;
 
   try {
-    await closeSavedRoutesDash();
     const data = await loadRoute(route.routeName);
     await displayLoadedRouteOnMap(data);
     await initChartToggleListener();
@@ -70,8 +69,9 @@ async function onLoadClick(event) {
     // both set calls could set coords whereby each coord is formed of 3 elements i.e (x, y and elevation)
     await setLoadedRouteCoordinates(data.coordinates);
     await setCurrentPathData(data.coordinates);
+    await closeSavedRoutesDash();
   } catch (error) {
-    showE
+    showToast(error.cause)
   }
 
   event.preventDefault();
@@ -104,8 +104,7 @@ async function onDeleteClick(event) {
 
     }
   } catch (error) {
-
-    showToast("Sorry, there was an unexpected error, try again later. ")
+    showToast(error.user_message || error.message || "Sorry, there was an error downloading your route, please try again later.")
   }
 
   event.preventDefault();
@@ -134,7 +133,11 @@ async function onDownloadClick(event, format, DOMElement) {
   
   try {
 
+    console.log('BEFORE DOWNLOAD ROUTE')
+
     const response = await downloadRoute(route.routeName, format, DOMElement); 
+
+    console.log('AFTER DOWNLOAD ROUTE')
     
     const blob = await response.blob(); // this gets binary file
 
@@ -161,10 +164,8 @@ async function onDownloadClick(event, format, DOMElement) {
 
   } 
   catch(error) {
-  
-    logError("Downloading Route", error.message, null, "DOWNLOAD_ROUTE")
 
-    showToast("Sorry, there was an unexpected error, try again later. ")
+    showToast(error.user_message || error.message || "Sorry, there was an error downloading your route, please try again later.")
   }
   finally {
     DOMElement.disabled = false;

--- a/static/js/routing/routing.js
+++ b/static/js/routing/routing.js
@@ -50,20 +50,35 @@ export async function calculatePath(startPoint, endPoint) {
       }),
     });
 
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({})); 
+      const errorMessage = data.message || `Routing Error: ${response.status}`;
+      const userMessage = data.user_message || "Sorry, there was an unexpected error when calculating your route, please try again later."
+
+      logError("Calculating Path", errorMessage, null, "NO_PATH_FOUND");
+
+      throw new Error(
+        errorMessage,
+        {cause : userMessage}
+      )
+    };
+
     const data = await response.json();
 
-    if (!response.ok) {
-      throw new Error(data.message || "Sorry, there was an unexpected error when calculating your route, please try again later.")
+    if (!data.success) {
+      const errorMessage = data.message || "Routing Error";
+      const userMessage = data.user_message || "Sorry, there was an unexpected error when calculating your route, please try again later.";
+
+      throw new Error(
+        errorMessage,
+        {cause : userMessage}
+      );
+
     };
 
-    if (data.success) {
-      return data;
-    };
-
-    throw new Error(data.message || "Sorry, there was an unexpected error when calculating your route, please try again later.");
+    return data;
   }
   catch(error) {
-    logError("Calculating Path", error.message, null, "NO_PATH_FOUND");
     throw error;
   };
 };

--- a/static/js/routing/routing.js
+++ b/static/js/routing/routing.js
@@ -88,7 +88,6 @@ export async function getPathSegment(start, end) {
   });
 
   if (!response.ok) {
-    logError("Calculating Path", response, null, "NO_PATH_FOUND")
     throw new Error("Sorry, there was an unexpected error whilst calculating the path.");
   }
 
@@ -116,7 +115,7 @@ export async function addManualPoint(x, y) {
   const lonLatCoords = toLonLat(currentClick);
   const isInCumbria = isPointInPolygon(lonLatCoords, cumbriaBoundary);
   if (!isInCumbria) {
-      return {"success": false, "message": "Please click on a point within Cumbria"};
+    throw new Error("Please click on a point within Cumbria", {cause: "Please click on a point within Cumbria."});
   }
 
   // this restores the redo stack
@@ -173,10 +172,7 @@ export async function addManualPoint(x, y) {
       const data = await getPathSegment(lastLonLat, finalLonLat);
 
       if (!data.success) {
-        return {
-          "success": false,
-          "message": "Sorry, we could not find a path to that location."
-        };
+        throw new Error("Could not find path", {cause : "Sorry, we could not find a path to that location."})
       };
 
       segment = data.coordinates;
@@ -197,7 +193,6 @@ export async function addManualPoint(x, y) {
     }
   }
   catch (error) {
-    logError("Calculating Path", error.message, null, "NO_PATH_FOUND");
     throw error;
   }
 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -849,7 +849,7 @@ async function handleRouteImport() {
       };
     }
     catch (error) {
-      showToast(error.cause)
+      showToast(error.cause || "Sorry, there was an error importing your route, please try again later.")
       return;
     }
 
@@ -884,7 +884,7 @@ async function handleRouteImport() {
       return true;
 
     } catch (err) {
-      showToast(err.cause);
+      showToast(err.cause || "Sorry, there was an error importing your route, please try again later.");
     }
   }
   else if (selectedInputType === "url") {
@@ -1262,8 +1262,7 @@ async function handleAutoRouteGeneration(start=null, end=null) {
     if (saveContainer) saveContainer.style.display = "flex";
 
   } catch (error) {
-    const allKeys = Reflect.ownKeys(error); 
-    showToast(error.cause);
+    showToast(error.cause || "Sorry, there was an error calculating your route, please try again later.");
   } finally {
     generatePathButton.classList.remove("loading");
     generatePathButton.disabled = false;   

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -849,9 +849,6 @@ async function handleRouteImport() {
       };
     }
     catch (error) {
-      console.log(error)
-      console.log(error.stack); // Shows the exact function and line causing the SyntaxError
-      console.log(error.cause)
       showToast(error.cause)
       return;
     }
@@ -869,13 +866,16 @@ async function handleRouteImport() {
 
       const result = await response.json(); 
 
+      if (response.status === 422) {
+        throw new Error(`(IMPORT ROUTE) Incorrect Imput Error : ${result}`, { cause: result.user_message || result.message || "Sorry, there was an error importing your route."})
+      }
 
       if (!response.ok) {
-        throw new Error(`(IMPORT ROUTE) HTTP Error: ${result}`, {cause: "Sorry, there was an error importing your route."})
+        throw new Error(`(IMPORT ROUTE) HTTP Error: ${result}`, {cause: result.user_message || result.message || "Sorry, there was an error importing your route."})
       }
 
       if (!result.success) {
-        throw new Error(`(IMPORT ROUTE) Error: ${result}`, {cause: "Sorry, there was an error importing your route."})
+        throw new Error(`(IMPORT ROUTE) Error: ${result}`, {cause: result.user_message || result.message || "Sorry, there was an error importing your route."})
       }
 
       displayImportedRouteCard(result);

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1127,6 +1127,10 @@ export function homeButtonFunction() {
   const map = getMap();
   if (!map) return;
 
+  if (map.getView().getAnimating()) {
+    return;
+  }
+
   // this resets the coordinate input UI state
   if (startCoordEntry) {
     startCoordEntry.classList.remove("input-error", "is-active");

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1260,8 +1260,11 @@ async function handleAutoRouteGeneration(start=null, end=null) {
     if (saveContainer) saveContainer.style.display = "flex";
 
   } catch (error) {
-    showToast("Sorry, there was an unexpected error when calculating your route, please try again later.");
-    return;
+    console.log(error);
+    console.log(error.cause);
+    const allKeys = Reflect.ownKeys(error); 
+    console.log(allKeys); 
+    showToast(error.cause);
   } finally {
     generatePathButton.classList.remove("loading");
     generatePathButton.disabled = false;   

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1253,8 +1253,6 @@ async function handleAutoRouteGeneration(start=null, end=null) {
     setLastKnownDistanceKm(routeStats.total_distance);
     setLastAutoRouteStats(routeStats);
 
-    console.log(`AUTO ROUTE STATS : ${routeStats}`);
-
     displayAutoRouteStats(getLastAutoRouteStats());
     
     resetElevationChart();
@@ -1264,10 +1262,7 @@ async function handleAutoRouteGeneration(start=null, end=null) {
     if (saveContainer) saveContainer.style.display = "flex";
 
   } catch (error) {
-    console.log(error);
-    console.log(error.cause);
     const allKeys = Reflect.ownKeys(error); 
-    console.log(allKeys); 
     showToast(error.cause);
   } finally {
     generatePathButton.classList.remove("loading");
@@ -1325,7 +1320,6 @@ async function displayPath(data) {
       await localforage.setItem("cachedAutoRouteStartPointCoords", startMercatorCoord);
       await localforage.setItem("cachedAutoRouteEndPointCoords", endMercatorCoord);
       await localforage.setItem("cachedAutoRouteStats", data.route_stats);
-      console.log(data.route_stats);
     }
   }
 
@@ -1506,10 +1500,6 @@ async function displayAutoCachedRouteStats(routeStats) {
     if (statsDiv) {
       statsDiv.remove();
     };
-    
-    console.log(`LAST AUTO ROUTE STATS : ${JSON.stringify(getLastAutoRouteStats())}`)
-    console.log(`AUTO CACHED ROUTES : ${JSON.stringify(routeStats)}`)
-    console.log(`LAST AUTO ROUTE STATS : ${JSON.stringify(getLastAutoRouteStats())}`)
 
     statsDiv = document.createElement("div");
     statsDiv.id = "route-stats";
@@ -1524,7 +1514,6 @@ async function displayAutoCachedRouteStats(routeStats) {
 
 async function handleLoadManualCachedRoute() {
 
-  console.log('updating route state')
   const updateManualRouteState = (newUserClicks, newPathCoords, newSegmentCache) => {
     manualRouteState.userClicks = newUserClicks;
     manualRouteState.pathCoords = newPathCoords;

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1814,8 +1814,13 @@ async function manualRouteClickHandler(event) {
       throw new Error(response?.message || "Sorry, there was an error whilst creating the path. ")
     }
   } catch (error) {
-    showToast("Sorry, there was an error whilst creating the path.");
-    logError("Calculating Path", error.message || "Manual Route", null, "NO_PATH_FOUND");
+    if (error.cause) {
+      showToast(error.cause, "error", null);
+    }
+    else {
+      showToast("Sorry, there was an error whilst creating the path", "error", null);
+      logError("Calculating Path", error.message || "Manual Route", null, "NO_PATH_FOUND");
+    }
     return;
   }
 }

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -815,7 +815,7 @@ function collapseSaveRouteContainer() {
 async function handleRouteImport() {
   const selectedInputType = whichInputTypeSelected();
   let routeName;
-  let data; // this will store the return value of the flask route 'import_route_file', it is initialised first as if done so in the try statement then the next try statement cannot use it
+  let data; 
 
   if (selectedInputType === "file") {
 
@@ -830,16 +830,15 @@ async function handleRouteImport() {
       data = await processImportedRouteFile(file); 
 
       if (!data || !data.coords) {
-        showToast(data || "There was an error on our end. Please try again later.");
-        return false;
+        throw new Error(`(IMPORT ROUTE) HTTP Error: ${data}`, {cause: "Sorry, there was an error importing your route."})
       }
 
       const today = new Date();
         
       const formattedToday = new Intl.DateTimeFormat('en-GB', {
-      "day": "2-digit",
-      "month": "2-digit",
-      "year": "numeric"
+        day: "2-digit",
+        month: "2-digit",
+        year: "numeric"
       }).format(today);
 
       if (!importRouteNameEntry.value) {
@@ -850,8 +849,11 @@ async function handleRouteImport() {
       };
     }
     catch (error) {
-      showToast("There was an error on our end. Please try again later.")
-      console.error(`ERROR whilst importing route : ${error}`)
+      console.log(error)
+      console.log(error.stack); // Shows the exact function and line causing the SyntaxError
+      console.log(error.cause)
+      showToast(error.cause)
+      return;
     }
 
     try {
@@ -865,15 +867,15 @@ async function handleRouteImport() {
         }),
       });
 
+      const result = await response.json(); 
+
+
       if (!response.ok) {
-        showToast("There was an error on our end. Please try again later.");
-        return false;
+        throw new Error(`(IMPORT ROUTE) HTTP Error: ${result}`, {cause: "Sorry, there was an error importing your route."})
       }
 
-      const result = await response.json(); 
       if (!result.success) {
-        showToast(result.message || "Failed to save route.");
-        return false;
+        throw new Error(`(IMPORT ROUTE) Error: ${result}`, {cause: "Sorry, there was an error importing your route."})
       }
 
       displayImportedRouteCard(result);
@@ -882,9 +884,7 @@ async function handleRouteImport() {
       return true;
 
     } catch (err) {
-      showToast("There was an error on our end. Please try again later.");
-      console.error(`Error whilst trying to save imported route: ${err}`)
-      return false;
+      showToast(err.cause);
     }
   }
   else if (selectedInputType === "url") {
@@ -896,7 +896,6 @@ async function handleRouteImport() {
     }
 
     clearImportRouteInput();
-    console.log(`Importing route from URL: ${url}`);
     return url;
   }
 }
@@ -907,33 +906,35 @@ async function handleRouteImport() {
  */
 function validateFileInput(file) {
 
-  const fileName = file?.name;
+  try {
+
+    const fileName = file?.name;
 
     // this checks if a file is selected
     if (!file) {
-        showToast("Please select a file to import.");
-        return false;
+      throw new Error("Validation Error", {cause : "Please select a file to import."});
     }
 
     // this checks if the file is of the correct type
     if (!allowedFileTypes.some(type => fileName.endsWith(type))) {
-        showToast("Please select a valid file to import.");
-        return false;
+      throw new Error("Validation Error", {cause : "Please select a valid file to import."});
     }
 
     // this checks if the file size is too large (greater than 5MB)
     if (file.size > 5 * 1024 * 1024) {
-        showToast("File size is too large. Please select a file smaller than 5MB.");
-        return false;
+      throw new Error("Validation Error", {cause : "File is too large. Please select a file smaller than 5MB."});
     }
 
     // this checks if the file is empty or not
     if (file.size === 0) {
-      showToast("The selected file is empty.")
-      return false;
+      throw new Error("Validation Error", {cause : "The chosen file is empty, please choose a different file."});
     }
 
     return true;
+  }
+  catch (error) {
+    throw new Error(error.message, {cause: "There was an error validating your file, please try again or import a different file. "})
+  }
 }
 
 /**


### PR DESCRIPTION
Pull Request Template

## Summary
Improves error handling across the routing stack (auto-routing, route import, and the FastAPI routing endpoint), separating internal/log-facing error messages from user-facing ones via the `Error` `cause` property. Also raises the routing API rate limit and fixes a UI bug where the home button could interrupt an in-progress map animation.

## Related Issue
Closes ABD-34

## Type of Change
Select all that apply:
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (explain below)

## Description of Changes
- **Error attribution via `cause`**: Errors thrown in `routing.js` now carry a technical `message` (for logging) and a separate `cause` (a friendly, user-facing string). `routes_fastapi.py`'s `calculate_path` now returns both a `message` (e.g. `"Routing : HTTP 500 Error"`) and a `user_message` for the frontend to fall back on.
- **Route import error handling**: Hardened error handling around the route import flow so malformed/failed imports surface a clear message instead of failing silently or throwing an unhandled exception.
- **Auto-routing error handling + rate limit**: `handleAutoRouteGeneration` in `ui.js` now reads `error.cause` and shows that to the user via `showToast(error.cause)`, instead of a single hardcoded string, so different failure types produce different toasts. The routing API rate limit was also raised to reduce false-positive throttling during normal use.
- **Home button animation fix**: `homeButtonFunction()` now returns early if `map.getView().getAnimating()` is `true`, preventing the reset UI state logic from running while the map is mid-animation (which was previously causing a jarring/broken reset).

## Screenshots / Visuals (if applicable)
N/A - backend/error-handling and logic changes, no visual UI changes.

## Testing
- Manually triggered failed auto-routing requests (invalid coordinates, simulated 500 from `calculate_path`) and confirmed the toast now shows the friendly `user_message`/`cause` text rather than a generic fallback.
- Manually tested route import with malformed/invalid files to confirm the new error handling surfaces a message instead of failing silently.
- Clicked the home button while the map was mid-animation (e.g. right after generating a route) to confirm it now no-ops instead of corrupting the reset state.
- Tested locally against the dev server; no automated tests added for these changes.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have tested my changes
- [x] I have updated documentation if needed
- [x] I have referenced the related issue
- [x] This PR is scoped, focused, and ready for review

> **Note:**
> PRs for issues **not** tagged as contributor‑friendly may be closed without review.