### PR TITLE
PR feat : Add shortcut for reset view button

### DIFF
--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1167,6 +1167,10 @@ export function homeButtonFunction() {
     return;
   }
 
+  // closes any modals / panels to return to the map view 
+  closeModals();
+  closePanels();
+
   // this resets the coordinate input UI state
   if (startCoordEntry) {
     startCoordEntry.classList.remove("input-error", "is-active");
@@ -2206,6 +2210,19 @@ function appShortcuts(e, key) {
 
   const isModifier = e.metaKey || e.ctrlKey;
 
+  // resets view and inputs 
+  if (isModifier && e.shiftKey && key === 'h') {
+    e.preventDefault();
+    homeButtonFunction();
+    return;
+  };
+
+  // focuses on the search input entry 
+  if (isModifier && e.shiftKey && key === 'k') {
+    e.preventDefault();
+    searchEntry.focus();
+  }
+
   // this switches to auto mode if ctrl/cmd + a is pressed
   if (isModifier && e.shiftKey && key === 'a') {
     e.preventDefault();
@@ -2213,17 +2230,14 @@ function appShortcuts(e, key) {
     return;
   };
 
-  if (isModifier && e.shiftKey && key === 'k') {
-    e.preventDefault();
-    searchEntry.focus();
-  }
-    
   // this switches to manual mode if ctrl/cmd + m is pressed
   if (isModifier && e.shiftKey && key === 'm') {
     e.preventDefault();
     switchToManualMode();
     return;
   };
+
+  return;
 }
 
 /**

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -315,8 +315,6 @@ function checkIfMobile() {
 
 //#region GENERAL MODAL
 
-//#region GENERAL MODAL
-
 /**
  * Catches clicks outside of a modal in order to close the modal upon these clicks. 
  * 

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1163,13 +1163,13 @@ export function homeButtonFunction() {
   const map = getMap();
   if (!map) return;
 
-  if (map.getView().getAnimating()) {
-    return;
-  }
-
   // closes any modals / panels to return to the map view 
   closeModals();
   closePanels();
+
+  if (map.getView().getAnimating()) {
+    return;
+  }
 
   // this resets the coordinate input UI state
   if (startCoordEntry) {

--- a/templates/map.html
+++ b/templates/map.html
@@ -323,7 +323,7 @@
             </div>
         </dialog>
 
-        <!-- ##### DELETE POINT MODAL ##### -->
+        <!-- ##### KEYBOARD SHORTCUTS MODAL ##### -->
         <dialog id="shortcuts-dialog" class="modal-overlay" aria-labelledby="shortcuts-dialog-heading">
             <div class="modal-wrapper">
                 <div class="modal-content shortcuts-modal-content">
@@ -332,7 +332,7 @@
                     </div>
                     <div class="modal-body shortcuts-modal-body">
                         <div class="shortcuts-group">
-                            <h3 class="shortcuts-group-title">Routing</h3>
+                            <h3 class="shortcuts-group-title">General</h3>
                             <div class="shortcut-item">
                                 <span class="shortcut-name">Switch to Auto Mode</span>
                                 <span class="shortcut-key"><kbd>Ctrl/⌘</kbd><span class="shortcut-key-plus">+</span><kbd>Shift</kbd><span class="shortcut-key-plus">+</span><kbd>A</kbd></span>
@@ -344,6 +344,10 @@
                             <div class="shortcut-item">
                                 <span class="shortcut-name">Focus Map Search</span>
                                 <span class="shortcut-key"><kbd>Ctrl/⌘</kbd><span class="shortcut-key-plus">+</span><kbd>Shift</kbd><span class="shortcut-key-plus">+</span><kbd>K</kbd></span>
+                            </div>
+                            <div class="shortcut-item">
+                                <span class="shortcut-name">Reset View and Inputs</span>
+                                <span class="shortcut-key"><kbd>Ctrl/⌘</kbd><span class="shortcut-key-plus">+</span><kbd>Shift</kbd><span class="shortcut-key-plus">+</span><kbd>H</kbd></span>
                             </div>
                         </div>
 


### PR DESCRIPTION
Pull Request Template

## Summary
This PR aims to add a user-requested keyboard shortcut which resets the map view. This is done by mapping the key combination `Ctrl/⌘` + `Shift` + `H` to the `homeButtonFunction()`. This function was also altered to close all panels and modals. 

## Related Issue
Closes ABD-35

## Type of Change
Select all that apply:
- [ ] Bug fix  
- [x] New feature  
- [ ] Documentation update  
- [ ] Refactor  
- [ ] Other (explain below)

## Description of Changes
- `templates/map.html` : Added the new shortcut (action + key combination ) 
- `static/js/ui.js` : Added the new key combination in the `appShortcuts()` function, if pressed, this would call `homeButtonFunction`, this function was altered to call `closePanels()` and `closeModals()`


## Screenshots / Visuals (if applicable)
N/A - Nothing changed visually 

## Testing
- Tested the shortcut to ensure that :
  - it was not caught at system level by MacOS / Windows 
  - it correctly resetted the view and inputs
  - it correctly closed panels if open
  - it correctly closed modals if open

## Checklist
- [x] My code follows the project’s style guidelines  
- [x] I have tested my changes  
- [x] I have updated documentation if needed  
- [x] I have referenced the related issue  
- [x] This PR is scoped, focused, and ready for review  

> **Note:**  
> PRs for issues **not** tagged as contributor‑friendly may be closed without review.
