### PR TITLE
PR fix: Add guard against empty search attempts 

### DIFF
--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -1223,52 +1223,54 @@ export function homeButtonFunction() {
 //#endregion
 
 //#region SEARCHING FUNCTION
-function searchArea() {
 
-  if (!searchEntry) {
-    showToast("Search entry not found.");
-    return;
-  }
-
-
-  const searchValue = searchEntry.value;
-  searchEntry.value = "";
+/**
+ * Responsible for moving to a given location
+ * 
+ * @returns {void}
+ */
+async function searchArea() {
 
   const map = getMap();
   if (!map) return;
 
-  fetch(window.appConfig.apiSearchAreaUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ search_input: searchValue }),
-  })
-    .then((response) => response.json())
-    .then((data) => {
-      if (!data.success) return;
+  try { 
+    if (!searchEntry) {
+      throw new Error("ERROR in searchArea() : Search Entry not found", {cause : ERROR_MESSAGES.SEARCH.GENERIC});
+    };
 
-      const view = map.getView();
+    const searchValue = searchEntry.value;
 
-      // this converts the received coordinates into web mercator (as search API sends coords in [lon, lat] format)
-      const searchCenter = fromLonLat(data.coordinates);
-      if (view.getZoom() >= 7) {
-        view.animate(
-          { center: view.getCenter(), duration: 1000, zoom: 10 },
-          () =>
-            view.animate({
-              center: searchCenter,
-              duration: 1000,
-              zoom: 14,
-            }),
-        );
-      } else {
-        view.animate({
-          center: searchCenter,
-          duration: 1000,
-          zoom: 14,
-        });
-      }
-    })
-    .catch((error) => showToast("There was an unexpected error, please try again later."));
+    if (!searchValue) throw new Error("ERROR in searchArea() : searchValue is empty", {cause : "Please enter a location. "})
+
+    const response = await fetch(window.appConfig.apiSearchAreaUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ search_input: searchValue }),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      throw new Error(data.message || `HTTP ERROR IN searchArea(): ${response.status}`, {cause : data.user_message || ERROR_MESSAGES.SEARCH.GENERIC});
+    };
+
+    if (!data.success) {
+      throw new Error(data.message || "Error in searchArea()", {cause : data.user_message || ERROR_MESSAGES.SEARCH.GENERIC});
+    };
+
+    const view = map.getView();
+
+    const searchCenter = fromLonLat(data.coordinates);
+
+    view.animate({
+      center: searchCenter,
+      zoom: 14,
+      duration: 1500,
+    }); 
+  } catch (error) {
+    showToast(error.cause || ERROR_MESSAGES.SEARCH.GENERIC);
+  };
 };
 //#endregion
 

--- a/static/js/utils/error-contants.js
+++ b/static/js/utils/error-contants.js
@@ -1,10 +1,10 @@
 export const ERROR_MESSAGES = {
     ROUTING: {
-        PATH_CREATION_FAILED:
-            "Sorry, there was an error whilst creating a path, please try again later.",
-        NO_PATH_FOUND:
-            "Sorry, we could not find a path to that location.",
-        OUTSIDE_CUMBRIA:
-            "Please click on a point within Cumbria.",
+        PATH_CREATION_FAILED: "Sorry, there was an error whilst creating a path, please try again later.",
+        NO_PATH_FOUND: "Sorry, we could not find a path to that location.",
+        OUTSIDE_CUMBRIA: "Please click on a point within Cumbria.",
+    },
+    SEARCH : {
+        GENERIC : "Sorry, there was an unexpected error finding that location, please try again later. "
     },
 };


### PR DESCRIPTION
# Pull Request Template

## Summary
This PR aims to fix a bug where a request with an empty input was sent to the `/search/search-area` API endpoint. It does this by adding a guard clause against empty inputs. When activated, the user is shown an error toast prompting them to enter a name for an area before pressing the 'Search' button

## Related Issue
Closes ABD-36

## Type of Change
Select all that apply:
- [x] Bug fix  
- [ ] New feature  
- [ ] Documentation update  
- [ ] Refactor  
- [ ] Other (explain below)

## Description of Changes
- `js/ui.js`: Added the guard clause in the `searchArea()` function
- `js/utils/error-constants.js`: Added a generic error message specific to the search action (`ERROR_MESSAGES.SEARCH.GENERIC`)

## Screenshots / Visuals (if applicable)
N/A

## Testing
- Attempted to search for an area without an input, this correctly resulted in the appropriate toast message being shown
- Attempted to search for an area with a valid input, this correctly resulted in the app moving the map to the searched-for area

## Checklist
- [x] My code follows the project’s style guidelines  
- [x] I have tested my changes  
- [x] I have updated documentation if needed  
- [x] I have referenced the related issue  
- [x] This PR is scoped, focused, and ready for review  

> **Note:**  
> PRs for issues **not** tagged as contributor‑friendly may be closed without review.
