### PR TITLE
Feat/merge auto and manual

### DIFF
--- a/src/Routes/routes_fastapi.py
+++ b/src/Routes/routes_fastapi.py
@@ -814,8 +814,11 @@ async def import_route(
             ]
 
             for point in points:
-                
-                lat, lon, ele = point[0], point[1], point[2]
+
+                if len(point) > 2:
+                    lat, lon, ele = point[0], point[1], point[2]
+                else:
+                    lat, lon, ele = point[0], point[1], 0
 
                 converted_points.append([lon, lat, ele])
 

--- a/static/css/base/tokens.css
+++ b/static/css/base/tokens.css
@@ -10,6 +10,10 @@
 */
 
 :root {
+
+  /* Spacing of left-sided elements to prevent being under the side-nav */
+  --side-nav-space: 70px;
+
   /* Brand blue (primary action color across the whole app) */
   --blue: #2563eb;
   --blue-dark: #1d4ed8;      /* report-issue.css hover shade */

--- a/static/css/base/tokens.css
+++ b/static/css/base/tokens.css
@@ -36,6 +36,7 @@
   --glass-bg: rgba(249, 250, 251, 0.4);   /* the glassmorphism slide-panel background */
   --secondary-bg: #e2e8f0;
   --secondary-bg-hover: #cbd5e1;
+  --tooltip-bg: rgba(206, 203, 203, 0.85);
 
   --panel-glass-bg: rgb(255 255 255 / 0.65); /* the glassmorphism routing panel background */
   --panel-glass-bg-hover: rgba(223, 221, 221, 0.65);
@@ -48,6 +49,7 @@
   --muted-strong: #475569;
   --muted-alt: #4b5563;
   --placeholder: #94a3b8;
+  --tooltip-ink: #FFFFFF;
 
   /* Borders */
   --border: #e2e8f0;
@@ -118,9 +120,9 @@ html.dark {
   --field-bg: #1c1c1e;
   --secondary-field-bg: #2c3038;
   --glass-bg: rgba(17, 24, 39, 0.85);
-
   --secondary-bg: rgb(69, 68, 68);
   --secondary-bg-hover: rgb(87, 87, 87);
+  --tooltip-bg: rgba(60, 60, 60, 0.85);
 
   --panel-glass-bg: rgb(31 41 55 / 0.75);
   --panel-glass-bg-hover: rgba(18, 25, 34, 0.75);

--- a/static/css/base/tokens.css
+++ b/static/css/base/tokens.css
@@ -37,6 +37,8 @@
   --secondary-bg: #e2e8f0;
   --secondary-bg-hover: #cbd5e1;
   --tooltip-bg: rgba(206, 203, 203, 0.85);
+  --list-item-bg: rgba(206, 203, 203, 0.85);
+  --list-item-bg-hover: rgba(121, 119, 119, 0.85);
 
   --panel-glass-bg: rgb(255 255 255 / 0.65); /* the glassmorphism routing panel background */
   --panel-glass-bg-hover: rgba(223, 221, 221, 0.65);
@@ -123,6 +125,8 @@ html.dark {
   --secondary-bg: rgb(69, 68, 68);
   --secondary-bg-hover: rgb(87, 87, 87);
   --tooltip-bg: rgba(60, 60, 60, 0.85);
+  --list-item-bg: rgb(90, 88, 88);
+  --list-item-bg-hover: rgba(67, 66, 66, 0.85);
 
   --panel-glass-bg: rgb(31 41 55 / 0.75);
   --panel-glass-bg-hover: rgba(18, 25, 34, 0.75);

--- a/static/css/components/tooltip.css
+++ b/static/css/components/tooltip.css
@@ -19,18 +19,19 @@ button[data-tooltip]::after {
   bottom: calc(100% + 8px);
   left: 50%;
   transform: translateX(-50%) translateY(4px);
-  background: rgba(49, 52, 57, 0.9);
+  background: var(--tooltip-bg);
   backdrop-filter: blur(30px);
   -webkit-backdrop-filter: blur(30px);
 
-  color: #fff;
+  color: var(--ink-strong);
   font-size: 12px;
   line-height: 1.3;
   white-space: normal;
 
   /* Buffer on the sides so corners don't flatten */
-  width: 10rem;
+  width: fit-content;
   box-sizing: border-box;
+  white-space: nowrap;
 
   padding: 6px 10px;
   border-radius: 6px;
@@ -51,7 +52,7 @@ button[data-tooltip]::before {
   left: 50%;
   transform: translateX(-50%) translateY(4px);
   border: 5px solid transparent;
-  border-top-color: #1f2937;
+  border-top-color: var(--tooltip-bg);
   margin-bottom: -2px;
   opacity: 0;
   visibility: hidden;

--- a/static/css/pages/map.css
+++ b/static/css/pages/map.css
@@ -63,7 +63,7 @@ html.dark {
   left: auto;
 }
 
-/* AUTOMATIC ROUTE GENERATION */
+/* MANUAL ROUTE CREATION */
 #start-end {
   position: absolute;
   top: 1rem;
@@ -175,7 +175,7 @@ html.dark {
 }
 
 .set-start-end-coord {
-  width: clamp(6.5rem, 7vw, 8.5rem);
+  width: clamp(4rem, 4.4vw, 6rem);
   font-size: clamp(0.75rem, 0.25vw, 1.1rem);
 }
 
@@ -183,17 +183,20 @@ html.dark {
   transform: translateY(0);
 }
 
-#auto-mode-routing-buttons {
+#routing-buttons {
   display: flex;
+  justify-content: center;
+  align-items: center;
   flex-direction: row;
-  gap: var(--space-sm);
+  gap: var(--space-xs);
   padding-top: .5rem;
+
 }
 
 .generate-button {
   position: relative;
-  width: 100%;
-  padding: 8px;
+  width: fit-content;
+  padding: .5rem;
   background: var(--blue);
   color: white;
   border: none;
@@ -207,10 +210,20 @@ html.dark {
   white-space: nowrap;
 }
 
+.routing-svg-button {
+  padding: .35rem .45rem .35rem .45rem;
+}
+
+.generate-button svg {
+  color: white;
+  height: 16px;
+  width: 16px;
+}
+
 .generate-button:hover {
   background: var(--blue-dark);
   box-shadow: var(--generate-button-hover-shadow);
-  transform: translateY(-1px);
+  transform: translateY(-1px) translate3d(0, 0, 0);
 }
 
 .generate-button:active {
@@ -337,9 +350,7 @@ html.dark {
 /* RESPONSIVE STYLES */
 
 @media (max-width: 1024px) {
-  #mode-toggle,
-  #start-end,
-  #manual-mode-content {
+  #start-end {
     left: 14px;
     max-width: calc(100vw - 28px);
   }
@@ -355,20 +366,7 @@ html.dark {
 }
 
 @media (max-width: 768px) {
-  #mode-toggle {
-    top: 6px;
-    left: 10px;
-    padding: 4px;
-    max-width: calc(100vw - 20px);
-  }
-
-  .mode-button {
-    padding: 5px 9px;
-    font-size: 11px;
-  }
-
-  #start-end,
-  #manual-mode-content {
+  #start-end {
     top: 42px;
     left: 10px;
     min-width: 0;
@@ -406,11 +404,6 @@ html.dark {
     padding: 6px 10px;
     font-size: 11px;
     text-align: center;
-  }
-
-  .set-start-end-coord {
-    width: 100%;
-    font-size: 0.8rem;
   }
 
   .generate-button {

--- a/static/css/pages/map.css
+++ b/static/css/pages/map.css
@@ -57,6 +57,57 @@ html.dark {
   overflow: hidden;
 }
 
+/* RIGHT-CLICK MAP OPTIONS */
+.map-context-menu {
+  position: fixed;
+  z-index: 1200;
+  min-width: 5rem;
+  padding: var(--space-2xs);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-surface);
+  font-family: var(--font-sans);
+}
+
+.map-context-menu-options {
+  padding: 0;
+  margin: var(--space-sm) var(--space-2xs);
+  list-style: none;
+}
+
+.map-context-menu-option {
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
+  margin-block: var(--space-2xs);
+  margin-inline: 0;
+  padding: var(--space-xs) var(--space-sm);
+  color: var(--ink);
+  background: var(--list-item-bg);
+  border: 0;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-align: left;
+}
+
+.map-context-menu-option:hover {
+  background-color: var(--list-item-bg-hover);
+}
+
+.map-context-menu-option:focus {
+  outline: none;
+}
+
+.map-context-menu-option:focus-visible {
+  background-color: var(--list-item-bg-hover);
+  outline: 2px solid var(--focus-ring, currentColor);
+  outline-offset: 2px;
+}
+
 /* OpenLayers */
 .ol-control {
   right: 8px;

--- a/static/css/pages/map.css
+++ b/static/css/pages/map.css
@@ -63,60 +63,11 @@ html.dark {
   left: auto;
 }
 
-/* MODE TOGGLING */
-#mode-toggle {
-  position: absolute;
-  top: 5px;
-  left: 70px;
-  z-index: 900;
-  background: var(--panel-glass-bg);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  border-radius: var(--panel-radius);
-  box-shadow: var(--panel-shadow);
-  border: 1px solid var(--border-alt);
-  padding: 5px;
-  font-family: var(--font-sans);
-  max-width: calc(100vw - 90px);
-}
-
-.mode-toggle-container {
-  display: flex;
-  gap: 3px;
-  flex-wrap: wrap;
-}
-
-.mode-button {
-  padding: 5px 11px;
-  background: rgb(241 245 249 / 0.75); /* --surface-subtle base color at a one-off alpha */
-  color: var(--muted-strong);
-  border: 1px solid var(--border-alt);
-  border-radius: 5px;
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  white-space: nowrap;
-}
-
-.mode-button:hover {
-  background: var(--secondary-bg);
-  border-color: var(--placeholder);
-  color: var(--mode-button-hover-text);
-}
-
-.mode-button.active {
-  background: var(--blue);
-  color: white;
-  border-color: var(--blue-dark-alt);
-  box-shadow: var(--action-shadow-sm);
-}
-
 /* AUTOMATIC ROUTE GENERATION */
 #start-end {
   position: absolute;
-  top: 48px;
-  left: 70px;
+  top: 1rem;
+  left: var(--side-nav-space);
   z-index: 1000;
   background: var(--panel-glass-bg);
   backdrop-filter: blur(10px);
@@ -265,33 +216,6 @@ html.dark {
 .generate-button:active {
   transform: translateY(0);
   box-shadow: var(--generate-button-active-shadow);
-}
-
-/* MANUAL ROUTE CREATION */
-#manual-mode-content {
-  position: absolute;
-  top: 48px;
-  left: 70px;
-  z-index: 1000;
-  background: var(--panel-glass-bg);
-  backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px);
-  border-radius: var(--panel-radius);
-  box-shadow: var(--panel-shadow);
-  border: 1px solid var(--border-alt);
-  min-width: 240px;
-  max-width: calc(100vw - 90px);
-  font-family: var(--font-sans);
-}
-
-.manual-instruction {
-  font-size: 12px;
-  color: var(--muted-strong);
-  margin-bottom: 8px;
-  padding: 6px 8px;
-  background: var(--surface-subtle);
-  border-radius: 4px;
-  border: 1px solid var(--border-alt);
 }
 
 /* SAVE / LOAD ROUTE PANEL */

--- a/static/css/pages/stats-panel.css
+++ b/static/css/pages/stats-panel.css
@@ -6,7 +6,7 @@
 #route-stats {
     position: absolute;
     bottom: 20px;
-    left: 70px;
+    left: var(--side-nav-space);
     z-index: 2;
     background: var(--panel-glass-bg);
     backdrop-filter: blur(10px);

--- a/static/js/elevationChart.js
+++ b/static/js/elevationChart.js
@@ -1,8 +1,8 @@
 // Local Imports 
 import { normaliseCoordLength, getCurrentPathData } from './routes/routeState.js';
-import { getRouteLayer } from './map.js';
+import { getManualRouteLayer, getRouteLayer } from './map.js';
 import { getTheme, getDistanceUnit } from './settingsState.js';
-import { createManualPointStyle } from './utils/style-utils.js';
+import { createElevationPointStyle, createManualPointStyle } from './utils/style-utils.js';
 
 // OpenLayers imports 
 import { fromLonLat, toLonLat } from 'ol/proj.js';
@@ -49,7 +49,7 @@ export function setHoverPointFeature(value) {
  * @returns {void}
  */
 function updateMapHoverPoint(coordinate) {
-  const routeLayer = getRouteLayer();
+  const routeLayer = getManualRouteLayer();
   if (!routeLayer) return;
   const source = routeLayer.getSource();
 
@@ -64,7 +64,7 @@ function updateMapHoverPoint(coordinate) {
       geometry: new Point(coord)
     });
 
-    hoverPointFeature.setStyle(createManualPointStyle("", "#FFFFFF", 7.5, "#0a45e7"));
+    hoverPointFeature.setStyle(createElevationPointStyle());
     source.addFeature(hoverPointFeature);
   } else {
     hoverPointFeature.getGeometry().setCoordinates(coord);
@@ -78,12 +78,12 @@ function updateMapHoverPoint(coordinate) {
  * @returns {void}
  */
 function clearMapHoverPoint() {
-  const routeLayer = getRouteLayer();
+  const routeLayer = getManualRouteLayer();
   if (!routeLayer || !hoverPointFeature) return;
   
   const source = routeLayer.getSource();
   source.removeFeature(hoverPointFeature);
-  hoverPointFeature = null; // Reset reference
+  hoverPointFeature = null; 
 };
 
 export function resetElevationChart() {

--- a/static/js/importRoute.js
+++ b/static/js/importRoute.js
@@ -1,13 +1,7 @@
 
 import {
-    showToast,
-    addClickListener,
     createRouteCard
 } from "./utils/ui-utils.js";
-
-import {
-    calculateEta
-} from "./utils/routing-utils.js";
 
 import {
     formatDistance,
@@ -45,7 +39,6 @@ export async function processImportedRouteFile(file) {
 export function displayImportedRouteCard(data) {
 
     const routeInfo = data.route_info;
-    console.log(routeInfo)
     const today = new Date();
 
     const routeName = routeInfo.route_name

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -35,12 +35,16 @@ import {
   LogOut,
   Coffee,
   MoveRight,
-  Keyboard
+  Keyboard,
+  Eraser,
+  Redo2,
+  Undo2
 } from 'lucide';
 
 export let map = null;
 export let tileLayer = null;
 export let routeLayer = null;
+export let manualRouteLayer = null;
 
 // Icon initialisation
 createIcons({
@@ -56,7 +60,10 @@ createIcons({
     LogOut,
     Coffee,
     MoveRight,
-    Keyboard
+    Keyboard,
+    Eraser,
+    Redo2,
+    Undo2
   }
 });
 
@@ -72,6 +79,27 @@ export function setRouteLayer(layer) {
 
 export function getRouteLayer() {
   return routeLayer;
+}
+
+export function setManualRoutelayer(layer) {
+  manualRouteLayer = layer;
+};
+
+export function getManualRouteLayer() {
+  if (manualRouteLayer === null) {
+    createManualRouteLayer();
+    return manualRouteLayer;
+  } else {
+    return manualRouteLayer;
+  }
+};
+
+export function removeManualRouteLayer() {
+  const map = getMap();
+  if (!map) return;
+
+  if (manualRouteLayer !== null) map.removeLayer(manualRouteLayer);
+  manualRouteLayer = null;
 }
 
 export function routeLayerHasFeatures() {
@@ -158,10 +186,24 @@ export function createRouteLayer() {
     zIndex: 999,
   });
 
-  const m = getMap();
-  if (m) m.addLayer(routeLayer);
+  const map = getMap();
+  if (map) map.addLayer(routeLayer);
   else console.error("Could not add routeLayer to the map");
 }
+
+export function createManualRouteLayer() {
+  manualRouteLayer = new VectorLayer({
+    source: new VectorSource(),
+    style: new Style({
+      stroke: new Stroke(getRouteStrokeStyle())
+    }),
+    zIndex: 999
+  });
+
+  const map = getMap();
+  if (map) map.addLayer(manualRouteLayer);
+  else console.error("Could not add manualRouteLayer to the map");
+};
 
 export function getPathColour() {
   return "#2563eb";
@@ -172,8 +214,10 @@ async function initApp() {
   await import("./auth/auth.js");
   const { initSettings } = await import("./settings.js");
   initSettings();
-  const { initUi } = await import("./ui.js");
+  const { initUi } = await import("./ui/ui.js");
   initUi();
+  const { initMapContextMenu } = await import('./ui/map-context-menu.js')
+  initMapContextMenu();
 }
 
 document.addEventListener("DOMContentLoaded", initApp);

--- a/static/js/routes/loadRoute.js
+++ b/static/js/routes/loadRoute.js
@@ -1,4 +1,4 @@
-import { getMap, getRouteLayer, getPathColour } from "../map.js";
+import { getMap, getRouteLayer } from "../map.js";
 
 import GeoJSON from "ol/format/GeoJSON.js";
 import Stroke from "ol/style/Stroke.js";
@@ -17,34 +17,17 @@ import {
 } from "../utils/format-utils.js"
 
 import {
-  getRouteStrokeStyle,
-  createManualPointStyle
+  getRouteStrokeStyle
 } from "../utils/style-utils.js"
 
 import {
   createStatsPanel
 } from "../utils/ui-utils.js"
 
-import { clearLastLoadedRouteStats, getLastLoadedRouteStats, setCurrentPathData, setLastKnownDistanceKm, setLastLoadedRouteStats, setLoadedRouteCoordinates } from "./routeState.js";
+import { getLastLoadedRouteStats, setLastKnownDistanceKm, setLastLoadedRouteStats } from "./routeState.js";
 
-import { deleteRoute, loadRoute } from "./routeApi.js";
-
-import { initChartToggleListener } from "../elevationChart.js";
 import { getSavedPointStyle } from "../saved_points/style.js";
 import { MAP_VIEW_PADDING } from "../constants.js";
-
-
-let routeList = null;
-let selectedRouteDisplay = null;
-let selectedRouteName = null;
-let selectedRouteType = null;
-let loadMessage = null;
-let loadRouteButton = null;
-let loadRouteDropdown = null;
-
-let onRouteLoaded = null;
-let updateLoadRouteVisibilityCallback = null;
-
 
 export function displayLoadedRouteOnMap(data) {
 
@@ -110,11 +93,13 @@ export function displayLoadedRouteOnMap(data) {
       // then zoom into the route
       function(complete) {
         if (complete) {
-          view.fit(vectorSource.getExtent(), {
-            size: map.getSize(),
-            padding: MAP_VIEW_PADDING,
-            duration: 1000
-          })
+          setTimeout(() => {
+            view.fit(vectorSource.getExtent(), {
+              size: map.getSize(),
+              padding: MAP_VIEW_PADDING,
+              duration: 1000
+            })
+          }, 100)
         }
       }
     );
@@ -122,11 +107,13 @@ export function displayLoadedRouteOnMap(data) {
   
   // otherwise, zoom into the route immediately
   else {
-    map.getView().fit(vectorSource.getExtent(), {
-      size: map.getSize(),
-      padding: MAP_VIEW_PADDING,
-      duration: 1000,
-    });
+    setTimeout(() => {
+      view.fit(vectorSource.getExtent(), {
+        size: map.getSize(),
+        padding: MAP_VIEW_PADDING,
+        duration: 1000
+      })
+    }, 100)
   }
   setLastLoadedRouteStats(data.route_stats)
   displayLoadedRouteStats(getLastLoadedRouteStats());

--- a/static/js/routes/routeState.js
+++ b/static/js/routes/routeState.js
@@ -2,7 +2,7 @@
 
 let currentPathData = null;
 let loadedRouteCoordinates = null;
-let currentMode = "auto";
+let currentMode = "manual";
 let lastKnownDistanceKm = null;
 let lastAutoRouteStats = null;
 let lastLoadedRouteStats = null;

--- a/static/js/routes/routeState.js
+++ b/static/js/routes/routeState.js
@@ -13,7 +13,6 @@ export const manualRouteState = {
   userClicks: [],
   pathCoords: [],
   manualRoutePoints: [],
-  initialElevation: 0,
   isSnapped: false,
   segmentCache: {},
   redoStack: []
@@ -87,8 +86,9 @@ export function clearManualRouteState() {
   manualRouteState.userClicks = [];
   manualRouteState.pathCoords = [];
   manualRouteState.manualRoutePoints = [];
-  manualRouteState.initialElevation = 0;
   manualRouteState.isSnapped = false;
+  manualRouteState.segmentCache = {};
+  manualRouteState.redoStack = [];
 }
 
 export function hasActiveRouteStatsPanel() {

--- a/static/js/routes/saveRoute.js
+++ b/static/js/routes/saveRoute.js
@@ -1,5 +1,4 @@
 import {
-  getCurrentMode, 
   getCurrentPathData, 
   getLastKnownDistanceKm, 
   getLoadedRouteCoordinates, 
@@ -17,7 +16,7 @@ import {
   homeButtonFunction,
   updateSaveRouteContainer,
   showLoginModal
-} from "../ui.js";
+} from "../ui/ui.js";
 
 import { getMap } from "../map.js";
 
@@ -155,10 +154,9 @@ async function handleSaveRoute(e) {
  * @returns {Array<Array<number>>}
  */
 function getPathCoordinates() {
-  const mode = getCurrentMode();
   let pathCoordinates = [];
   
-  if (mode === "manual" && manualRouteState.pathCoords.length > 0) {
+  if (manualRouteState.pathCoords.length > 0) {
     const webMercatorCoords = manualRouteState.pathCoords;
 
     pathCoordinates = webMercatorCoords.map(coord => {
@@ -182,6 +180,7 @@ async function handleUnauthenticatedUser(routeName) {
     showLoginModal(true, 'save routes');
     await localforage.setItem("unauthenticated-save-route-attempt", true);
     await localforage.setItem("cachedRouteName", routeName);
+    if (! await localforage.getItem('lastRoutingMode')) await localforage.setItem("lastRoutingMode", "manual");
     return false
   }
   return true

--- a/static/js/routes/savedRoutesDashboard.js
+++ b/static/js/routes/savedRoutesDashboard.js
@@ -5,7 +5,7 @@
 
 import { deleteRoute, downloadRoute, loadRoute } from "./routeApi.js";
 
-import { closeSavedRoutesDash } from "../ui.js"
+import { closeSavedRoutesDash } from "../ui/ui.js"
 
 import { displayLoadedRouteOnMap } from "./loadRoute.js";
 

--- a/static/js/routing/index.js
+++ b/static/js/routing/index.js
@@ -1,4 +1,5 @@
 export {
-    calculatePath,
-    addManualPoint
+    addManualPoint,
+    replaceManualRouteEnd,
+    replaceIntermediaryPoint
 } from './routing.js'

--- a/static/js/routing/routing.js
+++ b/static/js/routing/routing.js
@@ -177,6 +177,8 @@ export async function addManualPoint(x, y) {
       const finalLonLat = toLonLat(finalClick);
       const data = await getPathSegment(lastLonLat, finalLonLat);
 
+      console.log(data);
+
       if (!data.success) {
         throw new Error(data.message || "ERROR : addManualPoint()", {cause : ERROR_MESSAGES.ROUTING.PATH_CREATION_FAILED})
       };

--- a/static/js/routing/routing.js
+++ b/static/js/routing/routing.js
@@ -1,80 +1,17 @@
-import { manualRouteState,
+import {
+  manualRouteState,
   cumbriaBoundary,
   isPointInPolygon
 } from "../routes/routeState.js";
 
 import {
   updateManualRoute
-} from '../ui.js'
-import { logError } from "../utils/logError-utils.js";
+} from '../ui/ui.js'
 
 import { fromLonLat, toLonLat } from "ol/proj.js";
 import { getDistance } from "ol/sphere.js";
 import localforage from "localforage";
 import { ERROR_MESSAGES } from "../utils/error-contants.js";
-
-/**
- * Function used to calculate and return a path (and associated information) between two given points in projection EPSG: 4326 (Lon, Lat)
- * Specific to automatic routing
- * 
- * @param {String} startPoint Coordinate in the form "Lat, Lon"
- * @param {String} endPoint Coordinate in the form "Lat, Lon"
- * @returns 
- */
-export async function calculatePath(startPoint, endPoint) {
-  const url = window.appConfig.apiCalculatePathUrl;
-
-  // forms an array of the first and end coordinate in the format [Lat, Lon]
-  const rawStart = startPoint.split(",").map((num) => Number(num.trim()));
-  const rawEnd = endPoint.split(",").map((num) => Number(num.trim()));
-
-  // API expects [Lon, Lat] but coordinate is in [Lat, Lon]
-  const startArray = [rawStart[1], rawStart[0]];
-  const endArray = [rawEnd[1], rawEnd[0]];
-
-  try {
-
-    const response = await fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        start_point: startArray,
-        end_point: endArray,
-      }),
-    });
-
-    if (!response.ok) {
-      const data = await response.json().catch(() => ({})); 
-      const errorMessage = data.message || `ERROR : calculatePath()`;
-      const userMessage = data.user_message || ERROR_MESSAGES.ROUTING.PATH_CREATION_FAILED
-
-      logError("Calculating Path", errorMessage, null, "NO_PATH_FOUND");
-
-      throw new Error(
-        errorMessage,
-        {cause : userMessage}
-      )
-    };
-
-    const data = await response.json();
-
-    if (!data.success) {
-      const errorMessage = data.message || "ERROR : calculatePath()";
-      const userMessage = data.user_message || ERROR_MESSAGES.ROUTING.PATH_CREATION_FAILED;
-
-      throw new Error(
-        errorMessage,
-        {cause : userMessage}
-      );
-
-    };
-
-    return data;
-  }
-  catch(error) {
-    throw error;
-  };
-};
 
 /**
  * Calculates and returns information associated with a path between two given points (specific to manual routing)
@@ -108,46 +45,109 @@ export async function getPathSegment(start, end) {
   throw new Error( data.message || "ERROR : getPathSegment()", {cause : ERROR_MESSAGES.ROUTING.PATH_CREATION_FAILED});
 }
 
+function segmentKey(start, end) {
+  return JSON.stringify([start, end]);
+}
+
+function coordinatesEqual(first, second) {
+  return Boolean(first && second && first[0] === second[0] && first[1] === second[1]);
+}
+
+function toWebMercatorSegment(coordinates) {
+  return coordinates.map(coord =>
+    coord.length >= 3
+      ? [...fromLonLat([coord[0], coord[1]]), coord[2]]
+      : fromLonLat([coord[0], coord[1]])
+  );
+}
+
+async function resolveSegment(start, end, segmentCache) {
+  const key = segmentKey(start, end);
+  if (segmentCache[key]) return segmentCache[key];
+
+  const data = await getPathSegment(toLonLat(start), toLonLat(end));
+  return toWebMercatorSegment(data.coordinates);
+}
+
+function rebuildPathCoords(userClicks, segmentCache) {
+  if (userClicks.length === 0) return [];
+
+  const pathCoords = [userClicks[0]];
+  for (let index = 0; index < userClicks.length - 1; index += 1) {
+    const segment = segmentCache[segmentKey(userClicks[index], userClicks[index + 1])];
+    if (!segment) {
+      throw new Error("Missing cached manual route segment", {
+        cause: ERROR_MESSAGES.ROUTING.PATH_CREATION_FAILED
+      });
+    }
+    pathCoords.push(...segment.slice(1));
+  }
+  return pathCoords;
+}
+
+async function persistManualSegmentCache() {
+  await localforage.setItem("cachedSegmentCache", manualRouteState.segmentCache);
+}
+
 /**
  * Adds the entered point into the appropriate data structures and updates the UI
  * 
- * @param {Number} x X coordinate of clicked-on point in Web Mercator (as this is retrieved directly from a click on the map, and map's projection is Web Mercator)
+ * @param {Number} x X coordinate of clicked-on point in Web Mercator
  * @param {Number} y Y coordinate of clicked-on point in Web Mercator
- * @returns {Object} Object formed of success and message keys (message only if failed)
+ * @param {("normal"|"start"|"end")} [type="normal"] Type of point being added
+ * @param {Object} 
+ * @returns {Object} Holds success and (on failure) message values
  */
-export async function addManualPoint(x, y) {
+export async function addManualPoint(x, y, type="normal", options = {}) {
   const { userClicks, pathCoords, segmentCache } = manualRouteState;
   const currentClick = [x, y];
+  const { clearRedo = true } = options;
 
-  // The below code uses a more computationally expensive but much more accurate way of finding out if a point is in Cumbria
+  // this is a more computationally expensive but much more accurate way of finding out if a point is in Cumbria
   const lonLatCoords = toLonLat(currentClick);
   const isInCumbria = isPointInPolygon(lonLatCoords, cumbriaBoundary);
   if (!isInCumbria) {
     throw new Error("User clicked outside Cumbria", {cause: ERROR_MESSAGES.ROUTING.OUTSIDE_CUMBRIA});
   }
 
-  // this restores the redo stack
-  manualRouteState.redoStack = [];
+  if (clearRedo) manualRouteState.redoStack = [];
 
-  // returns prematurely after adding coord to the relevant arrays and updating manual route state if coord is the first one
+  // returns prematurely after populating manualRouteState if coord is the first one
   if (userClicks.length === 0) {
     userClicks.push(currentClick);
     pathCoords.push(currentClick);
+    await persistManualSegmentCache();
     await updateManualRoute();
-    return {"success": true};
-  }
- 
-  const lastClickedPoint = pathCoords[pathCoords.length - 1];
-  const start = userClicks[0];
-  let finalClick = currentClick;
-  const end = currentClick;
 
-  if (userClicks.length >= 3) {
+    return {
+      "success": true
+    };
+  }
+
+  const start = userClicks[0];
+  const lastClickedPoint = userClicks[userClicks.length - 1];
+  let finalClick = currentClick;
+
+  if (type === "normal" && manualRouteState.isSnapped) {
+    throw new Error("Closed route cannot accept another waypoint", {
+      cause: "Move or replace the end point before adding another waypoint to a closed route."
+    });
+  }
+
+  // handles start / end types
+  if (type === "start") {
+    return changeRouteStart(currentClick)
+  } else if (type === "end") {
+    return replaceManualRouteEnd(currentClick)
+  };
+
+  // if enough points exist, checks whether the new click closes the route (matches the start point)
+  if (userClicks.length >= 2) {
     const thresholdDistance = 50;
 
     // lon lat used to calculate distance (Web Mercator projection has distortion risk over long distances)
     const startLonLat = toLonLat(start);
-    const endLonLat = toLonLat(end);
+    const endLonLat = toLonLat(currentClick);
     const distance = getDistance(startLonLat, endLonLat);
 
     // if points are close enough snap the final point to the first point
@@ -161,54 +161,170 @@ export async function addManualPoint(x, y) {
     return;
   }
 
-  const A = userClicks[userClicks.length - 1]; 
-  const B = finalClick;                        
-  const key = JSON.stringify([A, B]);
-
-  let segment;
-
-  if (segmentCache[key]) { // this checks if the segment already exists in cache
-      segment = segmentCache[key]; // if yes, it just retrieves it
-  }
-  // otherwise, it calculates it and adds it to the cache 
-  else {
-      // conversion to lon lat as the API expects coordinates in the form [Lon, Lat]
-      const lastLonLat = toLonLat(lastClickedPoint);
-      const finalLonLat = toLonLat(finalClick);
-      const data = await getPathSegment(lastLonLat, finalLonLat);
-
-      console.log(data);
-
-      if (!data.success) {
-        throw new Error(data.message || "ERROR : addManualPoint()", {cause : ERROR_MESSAGES.ROUTING.PATH_CREATION_FAILED})
-      };
-
-      segment = data.coordinates;
-
-      // conversion to Web Mercator as the API sends coords in the form: [Lon, Lat], whereas OpenLayers map is in Web Mercator projection
-      segment = segment.map(coord =>
-        coord.length >= 3
-          ? [...fromLonLat([coord[0], coord[1]]), coord[2]]
-          : fromLonLat([coord[0], coord[1]])
-      );
-
-      // this stores the segment in cache 
-      segmentCache[key] = segment;
-
-      // this updates elevation change
-      manualRouteState.initialElevation += data.route_stats.elevation_change;
-
-  }
-
-  await localforage.setItem('cachedSegmentCache', segmentCache)
+  const key = segmentKey(lastClickedPoint, finalClick);
+  const segment = await resolveSegment(lastClickedPoint, finalClick, segmentCache);
+  segmentCache[key] = segment;
+  await persistManualSegmentCache();
 
   // this appends the segment to pathCoords (skips first point to prevent duplication)
   manualRouteState.pathCoords.push(... segment.slice(1))
 
   userClicks.push(finalClick);
-  manualRouteState.isSnapped = true;
+  manualRouteState.isSnapped = finalClick === start;
 
   await updateManualRoute();
 
   return {"success": true};
 }
+
+/**
+ * Replaces the final manual waypoint without retaining its stale route segment.
+ *
+ * @param {number[]} currentClick
+ * @returns
+ */
+export async function replaceManualRouteEnd(currentClick) {
+
+  try { 
+    const { userClicks, segmentCache } = manualRouteState;
+    
+    if (userClicks.length < 2) {
+      return addManualPoint(currentClick[0], currentClick[1], "normal", { clearRedo: false });
+    }
+
+    const oldEnd = userClicks[userClicks.length - 1];
+    const previousPoint = userClicks[userClicks.length - 2];
+    const replacementSegment = await resolveSegment(previousPoint, currentClick, segmentCache);
+    const proposedClicks = [...userClicks.slice(0, -1), currentClick];
+    const proposedCache = { ...segmentCache };
+
+    delete proposedCache[segmentKey(previousPoint, oldEnd)];
+    proposedCache[segmentKey(previousPoint, currentClick)] = replacementSegment;
+
+    manualRouteState.userClicks = proposedClicks;
+    manualRouteState.segmentCache = proposedCache;
+    manualRouteState.pathCoords = rebuildPathCoords(proposedClicks, proposedCache);
+    manualRouteState.isSnapped = coordinatesEqual(currentClick, proposedClicks[0]);
+    await persistManualSegmentCache();
+    await updateManualRoute();
+    return {
+      success: true
+    };
+  }
+  catch (error) {
+    throw new Error(`ERROR (replaceManualRouteEnd()) : ${error}`, {cause : ERROR_MESSAGES.ROUTING.GENERIC_ROUTE_ACTION})
+  }
+}
+
+/**
+ * Replaces an intermediary waypoint of a present route
+ *
+ * @param {number} index Index attribute of the intermediary point that was moved
+ * @param {number[]} newCoordinates Coordinates attribute of the intermediary point that was moved
+ * @returns {void}
+ */
+export async function replaceIntermediaryPoint(index, newCoordinates) {
+
+  try {
+    const { userClicks, segmentCache } = manualRouteState;
+
+    // Rejects invalid calls  
+    if (userClicks.length < 3 || index <= 0 || index >= userClicks.length - 1) {
+      throw new Error("Invalid intermediary waypoint index");
+    }
+
+    const oldPoint = userClicks[index];
+    const previousPoint = userClicks[index - 1];
+    const nextPoint = userClicks[index + 1];
+
+    // Computes new segments 
+    const [previousSegment, nextSegment] = await Promise.all([
+      resolveSegment(previousPoint, newCoordinates, segmentCache),
+      resolveSegment(newCoordinates, nextPoint, segmentCache)
+    ]);
+
+    // Replaces the old coordinate with the new one 
+    const newUserClicks = [...userClicks];
+    newUserClicks[index] = newCoordinates;
+    
+    // Deletes stale segments + Adds new segments 
+    const newSegmentCache = { ...segmentCache };
+
+    delete newSegmentCache[segmentKey(previousPoint, oldPoint)];
+    delete newSegmentCache[segmentKey(oldPoint, nextPoint)];
+
+    newSegmentCache[segmentKey(previousPoint, newCoordinates)] = previousSegment;
+    newSegmentCache[segmentKey(newCoordinates, nextPoint)] = nextSegment;
+
+    // Updates manualRouteState
+    manualRouteState.userClicks = newUserClicks;
+    manualRouteState.segmentCache = newSegmentCache;
+    manualRouteState.pathCoords = rebuildPathCoords(newUserClicks, newSegmentCache);
+    manualRouteState.redoStack = [];
+
+    await persistManualSegmentCache();
+    await updateManualRoute(); 
+
+    return {
+      success: true
+    };
+  }
+  catch (error) {
+    throw new Error(`ERROR (replaceIntermediaryPoint()) : ${error}`, {cause : ERROR_MESSAGES.ROUTING.GENERIC_ROUTE_ACTION})
+  }
+}
+
+/**
+ * Replaces the current start point of a route with the inputted coordinates
+ *
+ * @param {number[]} currentClick
+ * @returns {Object} Holds success
+ */
+async function changeRouteStart(currentClick) {
+
+  try {
+    const { userClicks, segmentCache } = manualRouteState;
+
+    const oldStart = userClicks[0];
+
+    // Moves starting point only if it is the only click 
+    if (userClicks.length === 1) {
+      userClicks[0] = currentClick;
+      manualRouteState.pathCoords = [currentClick];
+      await updateManualRoute();
+
+      return {
+        "success": true
+      };
+    }
+
+
+    // Calculates new segment 
+    const secondPoint = userClicks[1];
+    const newFirstSegment = await resolveSegment(currentClick, secondPoint, segmentCache);
+
+    // Deletes old cached segment and adds the new one 
+    const proposedCache = { ...segmentCache };
+    delete proposedCache[segmentKey(oldStart, secondPoint)];
+    proposedCache[segmentKey(currentClick, secondPoint)] = newFirstSegment;
+
+    const proposedClicks = [currentClick, ...userClicks.slice(1)];
+
+
+    // Updates manualRouteState 
+    manualRouteState.userClicks = proposedClicks;
+    manualRouteState.segmentCache = proposedCache;
+    manualRouteState.pathCoords = rebuildPathCoords(proposedClicks, proposedCache);
+    manualRouteState.isSnapped = proposedClicks.length > 1 && coordinatesEqual(proposedClicks.at(-1), currentClick);
+
+    await persistManualSegmentCache();
+    await updateManualRoute();
+
+    return {
+      "success": true
+    };
+  } 
+  catch(error) {
+    throw new Error(`ERROR (changeRouteStart()) : ${error}`, {cause : ERROR_MESSAGES.ROUTING.GENERIC_ROUTE_ACTION})
+  }
+};

--- a/static/js/saved_points/savedPoints.js
+++ b/static/js/saved_points/savedPoints.js
@@ -1,7 +1,7 @@
 import { getSavedPointStyle } from "./style.js";
 import { getMap } from "../map.js";
-import { showLoginModal, showModal} from "../ui.js";
-import { showToast } from "../utils/ui-utils.js";
+import { showLoginModal} from "../ui/ui.js";
+import { showToast, showModal } from "../utils/ui-utils.js";
 import { logError } from "../utils/logError-utils.js";
 import { fromLonLat, toLonLat } from "ol/proj.js";
 import { Feature } from "ol";
@@ -90,6 +90,12 @@ export function loadAndDisplaySavedPoints() {
       })
 }
 
+/**
+ * 
+ * @param {number[]} coordinate In Web Mercator or Lon Lat
+ * @param {string} name 
+ * @returns {void}
+ */
 export async function saveNewPoint(coordinate, name) {
 
   const isLoggedIn = window.appConfig.loggedIn
@@ -134,7 +140,6 @@ export async function saveNewPoint(coordinate, name) {
           return loadAndDisplaySavedPoints();
         }
       throw new Error(data.message)
-      return;
   }
   catch(error) {
     showToast(error.message || "There was an unexpected error whilst saving your point, try again later.");

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -21,7 +21,7 @@ import { formatDistance } from "./utils/format-utils.js";
 
 import { logout, deleteAccount } from "./auth/auth.js";
 
-import { applyTheme } from "./ui.js";
+import { applyTheme } from "./ui/ui.js";
 
 import { hasActiveRouteStatsPanel } from "./routes/routeState.js";
 

--- a/static/js/tours/tours.js
+++ b/static/js/tours/tours.js
@@ -118,7 +118,7 @@ export function createAutomaticRoutingTour(onTourEnd) {
             {
             popover: {
                 title: 'Welcome to Crestr',
-                description: 'This tour will go through automatic routing.'
+                description: 'This tour will show you how to build a route and navigate Crestr.'
             }
             },
             {
@@ -136,31 +136,24 @@ export function createAutomaticRoutingTour(onTourEnd) {
             }
             },
             {
-            element: '#mode-toggle',
-            popover: {
-                title: 'Switching modes',
-                description: 'This is where you can switch between automatic routing and manual routing.'
-            }
-            },
-            {
             element: '#search-row',
             popover: {
-                title: 'Automatic Routing',
+                title: 'Find an area',
                 description: 'Here you can enter locations which move the map to those locations.'
             }
             },
             {
             element: '#coordinates-area',
             popover: {
-                title: 'Automatic Routing',
-                description: 'Here you can enter start and end coordinates to form a route.'
+                title: 'Route endpoints',
+                description: 'Enter start and end coordinates to generate a route, or use the Set buttons and click the map.'
             }
             },
             {
             element: '#generate-path-button',
             popover: {
-                title: 'Automatic Routing',
-                description: 'Pressing this button will generate the path using the coordinates you entered.'
+                title: 'Create the route',
+                description: 'Press this button to create a route. You can then click the map to add more waypoints.'
             }
             }
         ]

--- a/static/js/ui.js
+++ b/static/js/ui.js
@@ -651,85 +651,6 @@ function setCoordEntry(entry, event) {
   updateCursor();
 }
 
-export function mapClickHandler(event) {
-  const map = getMap();
-  if (!map) return;
-
-  if (clickMode) {
-    updateCursor();
-  }
-
-  if (clickMode === "setStart") {
-    setCoordEntry(startCoordEntry, event);
-
-    // adding start point
-    const pointFeature = createPoint(event.coordinate, getSavedPointStyle("Start", "#00A86B"), "start", "Start");
-    addStartEndPoint(pointFeature, interactivePointLayer, "start");
-    setUpPointInteraction([interactivePointLayer]);
-
-    if (interactivePointLayer.getSource().getFeatures().length > 1) {
-      handleAutoRouteGeneration(startCoordEntry.value, endCoordEntry.value);
-    };
-
-    return;
-  }
-  if (clickMode === "setEnd") {
-    setCoordEntry(endCoordEntry, event);
-
-    // adding end point 
-    const pointFeature = createPoint(event.coordinate, getSavedPointStyle("End", "#D32F2F"), "end", "End")
-    addStartEndPoint(pointFeature, interactivePointLayer, "end");
-    setUpPointInteraction([interactivePointLayer]);
-
-    if (interactivePointLayer.getSource().getFeatures().length > 1) {
-      handleAutoRouteGeneration(startCoordEntry.value, endCoordEntry.value);
-    };
-
-    return;
-  }
-
-  if (getCurrentMode() !== "auto") return;
-
-  if (selectedPoint) {
-    selectedPoint.setStyle(getSavedPointStyle(selectedPoint.get("name")));
-    selectedPoint = null;
-  }
-
-  let featureClicked = false;
-  let newSelection = null;
-  const savedPointsLayer = getSavedPointsLayer();
-
-  map.forEachFeatureAtPixel(event.pixel, (feature, layer) => {
-    if (
-      layer === savedPointsLayer &&
-      feature.getGeometry() instanceof Point
-    ) {
-      newSelection = feature;
-      featureClicked = true;
-      return true;
-    }
-  });
-
-  if (newSelection) {
-    selectedPoint = newSelection;
-    const pointName = selectedPoint.get("name");
-    selectedPoint.setStyle(getSelectedPointStyle(pointName));
-    deletePointModalNameDisplay.textContent = pointName;
-    showModal(true, deletePointModal);
-  } 
-  else if (!featureClicked) {
-    const coordinate = event.coordinate;
-    const lonLat = toLonLat(coordinate);
-
-    // TO BE CHANGED TO CUSTOM MODAL 
-    const pointName = prompt(
-      `Do you want to save this coordinate: ${formatLatLon(lonLat, 6)}? \nEnter a name to save it:`,
-    );
-
-    if (pointName) saveNewPoint(coordinate, pointName);
-  }
-}
-
 //#endregion
 
 //#region OPEN/CLOSE PANEL FUNCTIONS
@@ -1028,6 +949,115 @@ function handleRouteImportType() {
         URLInputTypeContent.style.display = 'flex';
     }
 }
+
+//#endregion
+
+//#region MAP CLICK HANDLERS
+
+export function mapClickHandler(event) {
+  const map = getMap();
+  if (!map) return;
+
+  if (clickMode) {
+    updateCursor();
+  }
+
+  if (clickMode === "setStart") {
+    setCoordEntry(startCoordEntry, event);
+
+    // adding start point
+    const pointFeature = createPoint(event.coordinate, getSavedPointStyle("Start", "#00A86B"), "start", "Start");
+    addStartEndPoint(pointFeature, interactivePointLayer, "start");
+    setUpPointInteraction([interactivePointLayer]);
+
+    if (interactivePointLayer.getSource().getFeatures().length > 1) {
+      handleAutoRouteGeneration(startCoordEntry.value, endCoordEntry.value);
+    };
+
+    return;
+  }
+  if (clickMode === "setEnd") {
+    setCoordEntry(endCoordEntry, event);
+
+    // adding end point 
+    const pointFeature = createPoint(event.coordinate, getSavedPointStyle("End", "#D32F2F"), "end", "End")
+    addStartEndPoint(pointFeature, interactivePointLayer, "end");
+    setUpPointInteraction([interactivePointLayer]);
+
+    if (interactivePointLayer.getSource().getFeatures().length > 1) {
+      handleAutoRouteGeneration(startCoordEntry.value, endCoordEntry.value);
+    };
+
+    return;
+  }
+
+  if (getCurrentMode() !== "auto") return;
+
+  if (selectedPoint) {
+    selectedPoint.setStyle(getSavedPointStyle(selectedPoint.get("name")));
+    selectedPoint = null;
+  }
+
+  let featureClicked = false;
+  let newSelection = null;
+  const savedPointsLayer = getSavedPointsLayer();
+
+  map.forEachFeatureAtPixel(event.pixel, (feature, layer) => {
+    if (
+      layer === savedPointsLayer &&
+      feature.getGeometry() instanceof Point
+    ) {
+      newSelection = feature;
+      featureClicked = true;
+      return true;
+    }
+  });
+
+  if (newSelection) {
+    selectedPoint = newSelection;
+    const pointName = selectedPoint.get("name");
+    selectedPoint.setStyle(getSelectedPointStyle(pointName));
+    deletePointModalNameDisplay.textContent = pointName;
+    showModal(true, deletePointModal);
+  } 
+  else if (!featureClicked) {
+    const coordinate = event.coordinate;
+    const lonLat = toLonLat(coordinate);
+
+    // TO BE CHANGED TO CUSTOM MODAL 
+    const pointName = prompt(
+      `Do you want to save this coordinate: ${formatLatLon(lonLat, 6)}? \nEnter a name to save it:`,
+    );
+
+    if (pointName) saveNewPoint(coordinate, pointName);
+  }
+}
+
+async function manualRouteClickHandler(event) {
+
+  try { 
+    const coordinate = event.coordinate;
+
+    const response = await addManualPoint(coordinate[0], coordinate[1]);
+
+    // This checks success status
+    if (!response || !response.success) {
+
+      throw new Error(response?.message || "Error : manualRouteClickHandler()")
+    }
+  } catch (error) {
+    if (error.cause) {
+      console.error(error);
+      showToast(error.cause, "error", null);
+    }
+    else {
+      showToast(ERROR_MESSAGES.ROUTING.NO_PATH_FOUND, "error", null);
+      logError("Calculating Path", error.message || "Manual Route", null, "NO_PATH_FOUND");
+    }
+    return;
+  }
+}
+
 
 //#endregion
 
@@ -1877,29 +1907,6 @@ function redoManualRoutePoint() {
   });
 };
 
-async function manualRouteClickHandler(event) {
-
-  try { 
-    const coordinate = event.coordinate;
-
-    const response = await addManualPoint(coordinate[0], coordinate[1]);
-
-    // This checks success status
-    if (!response || !response.success) {
-
-      throw new Error(response?.message || "Error : manualRouteClickHandler()")
-    }
-  } catch (error) {
-    if (error.cause) {
-      showToast(error.cause, "error", null);
-    }
-    else {
-      showToast(ERROR_MESSAGES.ROUTING.NO_PATH_FOUND, "error", null);
-      logError("Calculating Path", error.message || "Manual Route", null, "NO_PATH_FOUND");
-    }
-    return;
-  }
-}
 //#endregion
 
 //#region SAVE ROUTE PANEL
@@ -2540,7 +2547,7 @@ export function initUi() {
   addClickListener(shortcutsModalCloseButton, () => showModal(false, shortcutsModal), "click");
   addClickListener(shortcutsModal, (e) => closeModalUponOutsideClick(e, shortcutsModalContent, shortcutsModal), "click");
 
-  onMapClick(mapClickHandler);
+  onMapClick(manualRouteClickHandler);
 
   // These event listeners are for returning the map to the Lake District + clearing inputs
   autoHomeButton?.addEventListener("click", homeButtonFunction);

--- a/static/js/ui/map-context-menu.js
+++ b/static/js/ui/map-context-menu.js
@@ -1,0 +1,115 @@
+import { toLonLat } from "ol/proj.js";
+import { formatLatLon } from "../utils/routing-utils.js";
+import { getMap } from "../map.js";
+import { saveNewPoint } from "../saved_points/savedPoints.js";
+import { showToast } from "../utils/ui-utils.js";
+
+const popup = document.getElementById('map-context-menu');
+
+const saveButton = document.getElementById('map-context-save-point');
+const savePointModal = document.getElementById('save-point-dialog');
+const savePointModalInput = document.getElementById('save-point-dialog-name-input');
+const savePointModalSaveButton = document.getElementById('save-point-dialog-save');
+
+const copyCoordinateButton = document.getElementById('map-context-copy-coordinate');
+
+// Menu item functions
+
+function handleCoordinateCopy(coordinate) {
+  if (!coordinate) {
+    console.error("ERROR (handleCoordinateCopy()) : Invalid / no coordinate passed in. ");
+    return;
+  }
+
+  const lonLat = formatLatLon(toLonLat(coordinate), 6);
+
+  navigator.clipboard.writeText(lonLat).then(
+    () => {
+      return;
+    },
+    () => {
+      showToast("Sorry, there was an unexpected error copying this coordinate to the clipboard");
+    }
+  );
+}
+
+/**
+ * Adds right-click behaviour to the options context menu / popup
+ */
+export function initMapContextMenu() {
+
+  const map = getMap();
+  if (!map) return; 
+
+  const viewport = map.getViewport();
+  if (!viewport || !popup || !saveButton || !copyCoordinateButton) return;
+
+  let coordinate = null;
+
+  // Helper functions
+
+  const closePopup = () => {
+    popup.hidden = true;
+  };
+
+  const resetCoordinate = () => {
+    coordinate = null;
+  }
+
+  const positionPopup = (event) => {
+    const popupRect = popup.getBoundingClientRect();
+    const gap = 8;
+    const maxLeft = Math.max(gap, window.innerWidth - popupRect.width - gap);
+    const maxTop = Math.max(gap, window.innerHeight - popupRect.height - gap);
+
+    popup.style.left = `${Math.min(Math.max(gap, event.clientX), maxLeft)}px`;
+    popup.style.top = `${Math.min(Math.max(gap, event.clientY), maxTop)}px`;
+  };
+
+  viewport.addEventListener("contextmenu", (event) => {
+    event.preventDefault();
+
+    coordinate = map.getEventCoordinate(event);
+    popup.hidden = false;
+    positionPopup(event);
+  });
+
+
+  // Event Listeners 
+
+  saveButton.addEventListener('click', () => {
+    closePopup();
+    savePointModal.show();
+  })
+
+  savePointModalSaveButton.addEventListener('click', () => {
+    const pointName = savePointModalInput.value.trim();
+    saveNewPoint(coordinate, pointName);
+
+    savePointModal.close();
+    savePointModalInput.value = "";
+    
+    resetCoordinate();
+  })
+
+  copyCoordinateButton.addEventListener('click', () => {
+    closePopup();
+    handleCoordinateCopy(coordinate);
+    resetCoordinate();
+  })
+
+  document.addEventListener("pointerdown", (event) => {
+    if (!popup.hidden && !popup.contains(event.target)) {
+      closePopup();
+      resetCoordinate();
+    };
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && !popup.hidden) {
+      event.preventDefault();
+      closePopup();
+      resetCoordinate();
+    };
+  });
+}

--- a/static/js/ui/ui.js
+++ b/static/js/ui/ui.js
@@ -6,129 +6,110 @@ import { Point, LineString } from "ol/geom.js"
 import VectorSource from "ol/source/Vector.js";
 import VectorLayer from "ol/layer/Vector.js";
 import Feature from "ol/Feature.js";
-import GeoJSON from "ol/format/GeoJSON.js"
 import { Translate } from "ol/interaction.js"
 
 // constants
-import { MAP_VIEW_PADDING } from "./constants.js";
+import { MAP_VIEW_PADDING } from "../constants.js";
 
 // LocalForage
 import localforage from "localforage";
 
 // Local File Imports
 
-import {
-  calculateEta,
-  calculateTotalDistance,
-  formatLatLon
-} from "./utils/routing-utils.js";
+import { formatLatLon } from "../utils/routing-utils.js";
 
 import {
-  createManualPointStyle,
-  getRouteStrokeStyle
-} from "./utils/style-utils.js";
+  createManualPointStyle
+} from "../utils/style-utils.js";
 
 import {
   formatDistance,
   formatETA,
   formatElevation
-} from "./utils/format-utils.js";
+} from "../utils/format-utils.js";
 
 import {
   showToast,
   addClickListener,
   removeDOMElement,
   createStatsPanel,
-  parseCoordString
-} from "./utils/ui-utils.js";
+  parseCoordString,
+  showModal,
+  closeModals,
+  closeModalUponOutsideClick
+} from "../utils/ui-utils.js";
 
-import { moveMapToPosition } from "./utils/map-utils.js";
+import { moveMapToPosition } from "../utils/map-utils.js";
 
-import { calculatePath, addManualPoint } from "./routing/index.js";
+import { addManualPoint, replaceIntermediaryPoint } from "../routing/index.js";
 
 import {
   getMap,
   onMapClick,
   getRouteLayer,
-  getPathColour,
-  setRouteLayer,
-  routeLayerHasFeatures
-} from "./map.js";
+  getManualRouteLayer,
+  removeManualRouteLayer
+} from "../map.js";
 
 import {
   loadAndDisplaySavedPoints,
   getSavedPointsLayer,
   saveNewPoint,
   deleteSavedPoint
-} from "./saved_points/index.js";
+} from "../saved_points/index.js";
 
 import {
   getSavedPointStyle,
   getSelectedPointStyle,
-} from "./saved_points/style.js";
+} from "../saved_points/style.js";
 
 import {
-  initSaveRoute,
-  loadRoute,
-} from "./routes/index.js";
+  initSaveRoute
+} from "../routes/index.js";
 
 import {
   getCurrentMode,
-  setCurrentMode,
   getCurrentPathData,
   setCurrentPathData,
   getLoadedRouteCoordinates,
-  setLoadedRouteCoordinates,
   clearPathState,
   clearManualRouteState,
   manualRouteState,
   setLastKnownDistanceKm,
   getLastAutoRouteStats,
-  setLastLoadedRouteStats,
   getLastLoadedRouteStats,
-  setLastAutoRouteStats,
   clearLastAutoRouteStats,
   clearLastLoadedRouteStats,
-  hasElevation, 
-  extractElevation,
-  extractElevationProfile,
-  getElevationRange,
-  calculateElevationGain,
-  isPointInPolygon
-} from "./routes/routeState.js";
+  isPointInPolygon,
+} from "../routes/routeState.js";
 
 import {
   initCursorManager,
   updateCursor,
-  setCursor,
-  forceApplyCursor,
-} from "./cursorManager.js";
+  setCursor
+} from "../cursorManager.js";
 
-import { setOnDistanceUnitChange } from "./settings.js";
+import { setOnDistanceUnitChange } from "../settings.js";
 
-import { getTheme } from "./settingsState.js";
+import { getTheme } from "../settingsState.js";
 
-import { displayLoadedRouteOnMap, displayLoadedRouteStats } from "./routes/loadRoute.js";
+import { displayLoadedRouteStats } from "../routes/loadRoute.js";
 
-import { createElevationProfile, initChartToggleListener, resetElevationChart, setHoverPointFeature, toggleElevationChart } from "./elevationChart.js";
+import { createElevationProfile, initChartToggleListener, resetElevationChart, setHoverPointFeature, toggleElevationChart } from "../elevationChart.js";
 
-import { displayImportedRouteCard, processImportedRouteFile } from "./importRoute.js";
+import { displayImportedRouteCard, processImportedRouteFile } from "../importRoute.js";
 
 import { 
   createAutomaticRoutingTour,
   createImportRoutePanelTour,
-  createManualRoutingTour,
   createSavedRouteDashboardTour,
   createSavingRoutesTour,
   createSettingsTour
-} from "./tours/tours.js";
+} from "../tours/tours.js";
 
-import { login, logout } from "./auth/auth.js";
-import { logError } from "./utils/logError-utils.js";
-import { Vector } from "ol/source.js";
-import Style from "ol/style/Style.js";
-import Stroke from "ol/style/Stroke.js";
-import { ERROR_MESSAGES } from "./utils/error-contants.js";
+import { logout } from "../auth/auth.js";
+import { logError } from "../utils/logError-utils.js";
+import { ERROR_MESSAGES } from "../utils/error-contants.js";
 
 //#endregion
 
@@ -138,22 +119,17 @@ export const defaultCentre = Array.isArray(window.appConfig?.mapInitialCentre)
   ? window.appConfig.mapInitialCentre
   : [-3.198308, 54.465458];
 
-const autoModeOption = document.getElementById("auto-mode-option");
-const manualModeOption = document.getElementById("manual-mode-option");
-
 const setStartCoordButton = document.getElementById("set-start-coord-button");
 const setEndCoordButton = document.getElementById("set-end-coord-button");
 
 const startCoordEntry = document.getElementById("start-point-entry");
 const endCoordEntry = document.getElementById("end-point-entry");
 
-const autoHomeButton = document.getElementById("auto-home-button");
-const manualHomeButton = document.getElementById("manual-home-button");
+const homeButton = document.getElementById("home-button");
 
 const generatePathButton = document.getElementById("generate-path-button");
 
-const clearAutoRouteButton = document.getElementById("clear-auto-route-button");
-const clearManualRouteButton = document.getElementById("clear-manual-route");
+const clearRouteButton = document.getElementById('clear-route-button');
 
 const undoManualRouteButton = document.getElementById("undo-manual-route");
 const redoManualRouteButton = document.getElementById("redo-manual-route");
@@ -163,10 +139,6 @@ const searchForAreaButton = document.getElementById("search-for-area-button");
 
 const mapElement = document.getElementById("map");
 
-
-// automatic mode + manual mode contents i.e mode-specific panels
-const autoModeContent = document.getElementById("auto-mode-content");
-const manualModeContent = document.getElementById("manual-mode-content");
 
 // saved route div 
 const saveRouteDiv = document.getElementById("save-route");
@@ -189,6 +161,13 @@ const deletePointModalDeleteButton = document.getElementById("point-delete-delet
 const deletePointModalExitButton = document.getElementById("point-delete-exit-button");
 const deletePointModalContent = deletePointModal.querySelector('.modal-content');
 
+// save point modal
+const savePointModal = document.getElementById('save-point-dialog');
+const savePointModalContent = savePointModal.querySelector('.modal-content');
+const savePointModalInput = document.getElementById('save-point-dialog-name-input');
+const savePointModalCloseButton = document.getElementById('save-point-dialog-close');
+const savePointModalSaveButton = document.getElementById('save-point-dialog-save');
+
 // login modal
 const loginModal = document.getElementById('login-dialog');
 const loginModalLoginButton = document.getElementById('login-dialog-login');
@@ -199,8 +178,6 @@ const loginModalContent = loginModal.querySelector('.modal-content');
 const reportIssueModal = document.getElementById('report-issue-dialog');
 const reportIssueModalSubmit = document.getElementById('report-issue-dialog-submit');
 const reportIssueModalExit = document.getElementById('report-issue-dialog-exit');
-const reportIssueModalContent = reportIssueModal.querySelector('.modal-content');
-const reportIssueResultLabel = document.getElementById('report-issue-result-label');
 const reportIssueTitleInput = document.getElementById("report-issue-title");
 const reportIssueTextAreaInput = document.getElementById("report-issue-description");
 
@@ -250,22 +227,16 @@ const fileInputType = document.getElementById('file-route-input-type');
 const URLInputType = document.getElementById('url-route-input-type')
 
 // driver.js tours
-let savedRouteDashTourDriver;
-let manualRoutingTourDriver;
-let importRouteTourDriver;
 let automaticRoutingTourDriver;
 let savingRoutesTourDriver;
 
 
 // grouped elements
-const panels = [savedRoutesDashContent, importRoutePanel, settingPanel];
-const modals = [donateModal, reportIssueModal, shortcutsModal, loginModal, loadLastRouteModal, deletePointModal]
-
 const allowedFileTypes = ['.gpx', '.kml', '.geojson', '.fit'];
 
 let clickMode = null;
-let manualRouteLayer = null;
 let selectedPoint = null;
+let manualRouteFeature = null;
 
 // Start and End points 
 
@@ -273,12 +244,6 @@ let interactivePointLayerInteraction = null; // holds the OpenLayer interaction 
 let interactivePointLayer = null; // stores the vector layer which holds the point features 
 
 //#endregion
-
-// hides save route button + panel if there is no route
-
-export function getClickMode() {
-  return clickMode;
-}
 
 //#region MOBILE CHECK
 
@@ -313,50 +278,6 @@ function checkIfMobile() {
 }
 //#endregion
 
-//#region GENERAL MODAL
-
-/**
- * Catches clicks outside of a modal in order to close the modal upon these clicks. 
- * 
- * @param {Event} e 
- * @param {HTMLDivElement} modalContent 
- * @param {HTMLDialogElement} modal 
- * @returns {void}
- */
-function closeModalUponOutsideClick(e, modalContent, modal) {
-  if (modalContent && !modalContent.contains(e.target)) {
-      modal.close()
-    }
-};
-
-/**
- * Toggles the provided modal
- * @param {boolean} show true if you want to show the modal, false if you want to hide the modal
- * @param {HTMLDialogElement} modal The modal you want to open/close
- * @returns {void} 
- */
-export function showModal(show, modal) {
-  if (show) {
-    modal.showModal();
-  } 
-  else {
-    modal.close();
-  }
-};
-
-/**
- * Closes all modals within the application
- * 
- * @returns {void}
- */
-function closeModals() {
-  modals.forEach(modal => {
-    modal.close();
-  })
-}
-
-//#endregion
-
 //#region LOGIN MODAL
 
 /**
@@ -373,7 +294,7 @@ export function showLoginModal(show, actionName = 'perform this action') {
     // This updates the message dynamically
     messageElement.textContent = `An account is required to ${actionName}.`;
     loginModal.showModal();
-  } 
+  }
   else {
     loginModal.close();
   }
@@ -431,8 +352,6 @@ async function handleInitialLoadCachedRoute() {
 //#region REPORT ISSUE MODAL
 
 /**
- * Opens the modal if the input is truthy and closes the modal if the input is falsy
- * 
  * @param {Boolean} show True to show the modal, false to hide the modal
  */
 function showReportIssueModal(show) {
@@ -441,6 +360,8 @@ function showReportIssueModal(show) {
     reportIssueModal.showModal();
   } else {
     reportIssueModal.close();
+    reportIssueTitleInput.value = "";
+    reportIssueTextAreaInput.value = "";
   }
 }
 
@@ -638,17 +559,33 @@ function setEndCoord() {
   updateCursor();
 }
 
-function setCoordEntry(entry, event) {
-  // event.coordinate is in Web Mercator
-  // this means conversion to lat/lon is required for display
-  const lonLat = toLonLat(event.coordinate);
+/**
+ * 
+ * @param {HTMLInputElement} entry 
+ * @param {number[]} coordinate In Web Mercator projection
+ */
+function setCoordEntry(entry, coordinate) {
+  const lonLat = toLonLat(coordinate);
+
   entry.value = formatLatLon(lonLat, 6);
   entry.placeholder = "Coordinates";
   entry.classList.remove("input-error");
-  setCoordInputActiveState(startCoordEntry, false);
-  setCoordInputActiveState(endCoordEntry, false);
+  entry.classList.remove('is-active')
+
   clickMode = null;
   updateCursor();
+}
+
+/**
+ * Updates the start and end point entries relative to manualRouteState.userClicks
+ * 
+ * @returns {void}
+ */
+function syncCoordinateInputs() {
+  const { userClicks } = manualRouteState;
+
+  startCoordEntry.value = userClicks.length > 0 ? formatLatLon(toLonLat(userClicks[0]), 6) : "";
+  endCoordEntry.value = userClicks.length > 1 ? formatLatLon(toLonLat(userClicks[userClicks.length - 1]), 6) : "";
 }
 
 //#endregion
@@ -954,97 +891,41 @@ function handleRouteImportType() {
 
 //#region MAP CLICK HANDLERS
 
-export function mapClickHandler(event) {
-  const map = getMap();
-  if (!map) return;
-
-  if (clickMode) {
-    updateCursor();
-  }
-
-  if (clickMode === "setStart") {
-    setCoordEntry(startCoordEntry, event);
-
-    // adding start point
-    const pointFeature = createPoint(event.coordinate, getSavedPointStyle("Start", "#00A86B"), "start", "Start");
-    addStartEndPoint(pointFeature, interactivePointLayer, "start");
-    setUpPointInteraction([interactivePointLayer]);
-
-    if (interactivePointLayer.getSource().getFeatures().length > 1) {
-      handleAutoRouteGeneration(startCoordEntry.value, endCoordEntry.value);
-    };
-
-    return;
-  }
-  if (clickMode === "setEnd") {
-    setCoordEntry(endCoordEntry, event);
-
-    // adding end point 
-    const pointFeature = createPoint(event.coordinate, getSavedPointStyle("End", "#D32F2F"), "end", "End")
-    addStartEndPoint(pointFeature, interactivePointLayer, "end");
-    setUpPointInteraction([interactivePointLayer]);
-
-    if (interactivePointLayer.getSource().getFeatures().length > 1) {
-      handleAutoRouteGeneration(startCoordEntry.value, endCoordEntry.value);
-    };
-
-    return;
-  }
-
-  if (getCurrentMode() !== "auto") return;
-
-  if (selectedPoint) {
-    selectedPoint.setStyle(getSavedPointStyle(selectedPoint.get("name")));
-    selectedPoint = null;
-  }
-
-  let featureClicked = false;
-  let newSelection = null;
-  const savedPointsLayer = getSavedPointsLayer();
-
-  map.forEachFeatureAtPixel(event.pixel, (feature, layer) => {
-    if (
-      layer === savedPointsLayer &&
-      feature.getGeometry() instanceof Point
-    ) {
-      newSelection = feature;
-      featureClicked = true;
-      return true;
-    }
-  });
-
-  if (newSelection) {
-    selectedPoint = newSelection;
-    const pointName = selectedPoint.get("name");
-    selectedPoint.setStyle(getSelectedPointStyle(pointName));
-    deletePointModalNameDisplay.textContent = pointName;
-    showModal(true, deletePointModal);
-  } 
-  else if (!featureClicked) {
-    const coordinate = event.coordinate;
-    const lonLat = toLonLat(coordinate);
-
-    // TO BE CHANGED TO CUSTOM MODAL 
-    const pointName = prompt(
-      `Do you want to save this coordinate: ${formatLatLon(lonLat, 6)}? \nEnter a name to save it:`,
-    );
-
-    if (pointName) saveNewPoint(coordinate, pointName);
-  }
-}
-
 async function manualRouteClickHandler(event) {
+
+  if (handleSelectSavedPoint(event)) return;
+
+  generatePathButton.disabled = true;
+  generatePathButton.classList.add('loading');
+
+  setCoordInputActiveState(startCoordEntry, false);
+  setCoordInputActiveState(endCoordEntry, false);
 
   try { 
     const coordinate = event.coordinate;
+    const type = clickMode === "setStart"
+      ? "start"
+      : clickMode === "setEnd"
+        ? "end"
+        : "normal";
 
-    const response = await addManualPoint(coordinate[0], coordinate[1]);
+    if (type === "end" && manualRouteState.userClicks.length === 0) {
+      throw new Error("Start point required", { cause: "Set a start point before setting the end point." });
+    }
+
+    if (manualRouteState.userClicks.length === 0) clearAutoRoute();
+
+    const response = await addManualPoint(coordinate[0], coordinate[1], type);
 
     // This checks success status
     if (!response || !response.success) {
 
       throw new Error(response?.message || "Error : manualRouteClickHandler()")
     }
+
+    clickMode = null;
+    syncCoordinateInputs();
+    updateCursor();
   } catch (error) {
     if (error.cause) {
       console.error(error);
@@ -1056,69 +937,15 @@ async function manualRouteClickHandler(event) {
     }
     return;
   }
+  finally {
+    generatePathButton.disabled = false;
+    generatePathButton.classList.remove('loading');
+  }
 }
 
-
-//#endregion
-
-//#region MODE SWITCHING
-
-function handleToggles(event) {
-  manualModeOption.classList.remove("active");
-  autoModeOption.classList.remove("active");
-  event.currentTarget.classList.add("active");
-};
-
-async function switchToAutoMode() {
-  const map = getMap();
-  if (!map) return;
-
-  if (getCurrentMode() === 'auto') return;
-
-  await localforage.setItem("lastRoutingMode", "auto");
-
-  setCurrentMode("auto");
-  updateCursor();
-  autoModeOption.classList.add("active");
-  manualModeOption.classList.remove("active");
-  autoModeContent.style.display = "block";
-  manualModeContent.style.display = "none";
-
-  map.un("click", manualRouteClickHandler);
-  map.on("click", mapClickHandler);
-
-  clearManualRoute();
-  clearAutoRoute();
-};
-
-async function switchToManualMode() {
-  const map = getMap();
-  if (!map) return;
-
-  if (getCurrentMode() === 'manual') return;
-
-  await localforage.setItem("lastRoutingMode", "manual");
-  
-  setCurrentMode("manual");
-  updateCursor();
-  manualModeOption.classList.add("active");
-  autoModeOption.classList.remove("active");
-  autoModeContent.style.display = "none";
-  manualModeContent.style.display = "block";
-
-  map.un("click", mapClickHandler);
-  map.on("click", manualRouteClickHandler);
-  clearAutoRoute();
-
-  if (!localStorage.getItem('seenManualRoutingTour')) {
-    manualRoutingTourDriver = createManualRoutingTour();
-
-    manualRoutingTourDriver.drive();
-
-    localStorage.setItem('seenManualRoutingTour', 'True')
-  }
-  return;
-};
+export function getClickMode() {
+  return clickMode;
+}
 
 //#endregion
 
@@ -1162,10 +989,6 @@ export function clearAutoRoute() {
   if (saveContainer) saveContainer.style.display = "none";
   updateSaveRouteContainer();
 
-  // this also wipes the manual route if the user is in manual mode 
-  if (getCurrentMode() === "manual") {
-    clearManualRoute();
-  }
 }
 
 export function clearManualRoute() {
@@ -1173,11 +996,11 @@ export function clearManualRoute() {
   if (!map) return;
 
   clearManualRouteState();
+  removeManualRouteLayer();
+  manualRouteFeature = null;
 
-  // this removes the temporary manual route layer
-  if (manualRouteLayer) {
-    map.removeLayer(manualRouteLayer);
-    manualRouteLayer = null;
+  if (interactivePointLayer) {
+    interactivePointLayer.getSource().clear();
   }
 
   // this also clears the permanent route layer (in case anything was drawn there)
@@ -1185,6 +1008,8 @@ export function clearManualRoute() {
 
   document.getElementById("route-stats")?.remove();
   if (saveContainer) saveContainer.style.display = "none";
+  if (startCoordEntry) startCoordEntry.value = "";
+  if (endCoordEntry) endCoordEntry.value = "";
   updateSaveRouteContainer();
   resetElevationChart();
 }
@@ -1302,426 +1127,238 @@ function searchArea() {
 };
 //#endregion
 
-//#region AUTOMATIC ROUTING
-
-async function handleAutoRouteGeneration(start=null, end=null) {
-  const startPoint = start || startCoordEntry?.value || "";
-  const endPoint = end || endCoordEntry?.value || "";
-
-  if (await localforage.getItem('lastRoutingMode') !== "auto") localforage.setItem('lastRoutingMode', "auto");
-
-  if (validateInputCoords(startPoint, endPoint) !== true) return;
-
-  generatePathButton.disabled = true;
-  generatePathButton.classList.add("loading");
-
-  try {
-    const response = await calculatePath(startPoint, endPoint); // response.coordinates may return coordinates whereby each element has 3 values (x, y and elevation)
-
-    const routeStats = await displayPath(response);
-
-    setLastKnownDistanceKm(routeStats.total_distance);
-    setLastAutoRouteStats(routeStats);
-
-    displayAutoRouteStats(getLastAutoRouteStats());
-    
-    resetElevationChart();
-    initChartToggleListener();
-    createElevationProfile(response.coordinates);
-
-    if (saveContainer) saveContainer.style.display = "flex";
-
-  } catch (error) {
-    showToast(error.cause || ERROR_MESSAGES.ROUTING.PATH_CREATION_FAILED);
-  } finally {
-    generatePathButton.classList.remove("loading");
-    generatePathButton.disabled = false;   
-  }
-};
-
-async function displayPath(data) {
-
-  try { 
-  const map = getMap();
-  const routeLayer = getRouteLayer();
-  if (!map || !routeLayer) return null;
-
-  const routeLayerSource = routeLayer.getSource();
-  const interactivePointLayerSource = interactivePointLayer.getSource();
-
-  routeLayerSource.clear();
-  
-  interactivePointLayerSource.getFeatures()
-  .filter(feature => feature.get('type') === 'start' || feature.get('type') === 'end')
-  .forEach(feature => interactivePointLayerSource.removeFeature(feature))
-
-  // this clears the hovered point feature to prevent the preserving of stale OL point features
-  setHoverPointFeature(null);
-
-  const pathFeature = new GeoJSON().readFeature(data.pathGeoJSON, {
-    dataProjection: "EPSG:4326",
-    featureProjection: "EPSG:3857",
-  });
-
-  await routeLayerSource.addFeature(pathFeature);
-
-  const coordinates = data.coordinates;
-
-
-  if (coordinates.length >= 2) {
-    const startCoord = coordinates[0];
-    const endCoord = coordinates[coordinates.length - 1];
-
-    // this converts coordinates into Web Mercator format, as the backend sends the path back in [Lon, Lat] format (Web Mercator is the OpenLayers map projection)
-    const startMercatorCoord = fromLonLat([startCoord[0], startCoord[1]]);
-    const endMercatorCoord = fromLonLat([endCoord[0], endCoord[1]]);
-
-    // this creates and then displays (by adding them to the interactivePointLayerSource) the start and end point features
-    const startPointFeature = createPoint(startMercatorCoord, getSavedPointStyle("Start", "#00A86B"), "start", "Start")
-    const endPointFeature = createPoint(endMercatorCoord, getSavedPointStyle("End", "#D32F2F"), "end", "End")
-
-    interactivePointLayerSource.addFeature(startPointFeature)
-    interactivePointLayerSource.addFeature(endPointFeature)
-
-    // only caches routes if user is not logged in
-    if (!window.appConfig.loggedIn) {
-      await localforage.setItem("cachedAutoRouteCoordinates", data.pathGeoJSON);
-      await localforage.setItem("cachedAutoRouteStartPointCoords", startMercatorCoord);
-      await localforage.setItem("cachedAutoRouteEndPointCoords", endMercatorCoord);
-      await localforage.setItem("cachedAutoRouteStats", data.route_stats);
-    }
-  }
-
-  setCurrentPathData(data.coordinates); // data.coordinates are [lon, lat, elev] (EPSG:4326)
-
-
-  setTimeout(() => {
-    map.getView().fit(routeLayerSource.getExtent(), {
-      padding: [300, 300, 300, 430],
-      duration: 1200,
-    });
-    map.render();
-  }, 100);
-
-  return data.route_stats;
-  } 
-  catch(error) {
-    throw new Error(error.message, {cause : ERROR_MESSAGES.ROUTING.PATH_CREATION_FAILED})
-  }
-};
-
-async function displayAutoRouteStats(routeStats) {
-
-  let statsDiv = document.getElementById("route-stats");
-
-  if (statsDiv) {
-    statsDiv.remove();
-  };
-
-  statsDiv = document.createElement("div");
-  statsDiv.id = "route-stats";
-  document.body.appendChild(statsDiv);
-
-  statsDiv.innerHTML = createStatsPanel(formatDistance(parseFloat(routeStats.total_distance)), formatETA(routeStats.eta_seconds), formatElevation(routeStats.elevation_gain))
-};
-
-//#endregion
-
 //#region CACHED ROUTES
 
 async function handleLoadCachedRoute() {
-  const routeType = await localforage.getItem("lastRoutingMode"); // needed to differentiate between cached auto routes / cached manual routes
   if (loadLastRouteModal) showModal(false, loadLastRouteModal); // hides modal 
 
   try {
-    if (routeType === "auto") {
-      await handleLoadAutoCachedRoute();
-    }
-    else if (routeType === "manual") {
-      switchToManualMode();
-      await handleLoadManualCachedRoute();
-    }
-    else {
-      throw new Error("Invalid route type given")
-    }
+    handleLoadManualCachedRoute()
   }
   catch(error) {
     showToast("There was an error loading your last route", "error", null);
     throw new Error(error.message)
   }
   finally {
-    localforage.clear();
-  }
-}
-
-async function handleLoadAutoCachedRoute() {
-  try {
-      await displayAutoCachedRoute();
-
-      const [cachedCoords, cachedRouteStats, startWebMercator, endWebMercator] = await Promise.all([
-        await localforage.getItem("cachedAutoRouteCoordinates"),
-        await localforage.getItem('cachedAutoRouteStats'),
-        await localforage.getItem('cachedAutoRouteStartPointCoords'),
-        await localforage.getItem('cachedAutoRouteEndPointCoords')
-      ])
-
-      const parsedStats = typeof cachedRouteStats === "string" ? JSON.parse(cachedRouteStats) : cachedRouteStats;
-      setLastAutoRouteStats(parsedStats)
-
-      console.log(cachedRouteStats)
-      console.log(parsedStats)
-      console.log(JSON.stringify(parsedStats))
-
-      setLastKnownDistanceKm(parsedStats.total_distance);
-      startCoordEntry.value = formatLatLon(toLonLat(startWebMercator))
-      endCoordEntry.value = formatLatLon(toLonLat(endWebMercator))
-
-      await displayAutoCachedRouteStats(parsedStats);
-
-      resetElevationChart();
-      initChartToggleListener();
-      createElevationProfile(cachedCoords.geometry.coordinates);
-
-      setCurrentPathData(cachedCoords.geometry.coordinates);
-
-      if (saveContainer) saveContainer.style.display = "flex";
-  }
-  catch(error) {
-    throw new Error(error.message);
-  }
-}
-    
-/**
- * Loads the last cached route, automatically determines if route is manual / auto generated and retrieves the appropriate cached data 
- * makes use of localforage as opposed to localstorage due to high volume data 
- * @param {void}
- * @returns {void}
- */
-async function displayAutoCachedRoute() {
-  const map = getMap(); 
-
-  // if (await localforage.getItem('unauthenticated-save-route-attempt')) localforage.setItem('unauthenticated-save-route-attempt', false);
-
-  try {  
-
-    const routeLayer = getRouteLayer();
-
-    const routeLayerSource = routeLayer.getSource();
-    const interactivePointLayerSource = interactivePointLayer.getSource();
-
-    // clears all current features if present (unlikely given this occurs upon app load)
-    routeLayerSource.clear();
-    interactivePointLayerSource.getFeatures()
-    .filter(feature => feature.get('type') === 'start' || feature.get('type') === 'end')
-    .forEach(feature => interactivePointLayerSource.removeFeature(feature))
-
-    // clears the hovered point feature to prevent the preserving of stale OL point features
-    setHoverPointFeature(null);
-
-    // retrieves cached data in parallel 
-    const [cachedCoords, cachedStartCoords, cachedEndCoords] = await Promise.all([
-      localforage.getItem("cachedAutoRouteCoordinates"),
-      localforage.getItem("cachedAutoRouteStartPointCoords"),
-      localforage.getItem("cachedAutoRouteEndPointCoords")
-    ]);
-
-    // recreates the path, start point and end point features 
-    const pathFeature = new GeoJSON().readFeature(cachedCoords, {
-      dataProjection: "EPSG:4326",
-      featureProjection: "EPSG:3857",
-    });
-
-    const startPointFeature = createPoint(
-      cachedStartCoords,
-      getSavedPointStyle("Start", "#00A86B"),
-      "start",
-      "Start"
-    )
-
-    const endPointFeature = createPoint(
-      cachedEndCoords,
-      getSavedPointStyle("End", "#D32F2F"),
-      "end", 
-      "End"
-    )
-
-    // adds the features to the sources of the vector layers on the map --> displays the features on the map 
-    routeLayerSource.addFeature(pathFeature);
-    addStartEndPoint(startPointFeature, interactivePointLayer, "start");
-    addStartEndPoint(endPointFeature, interactivePointLayer, "end");
-    setUpPointInteraction([interactivePointLayer]);
-
-    setTimeout(() => {
-      map.getView().fit(routeLayerSource.getExtent(), {
-        padding: MAP_VIEW_PADDING,
-        duration: 1200,
-      });
-      map.render();
-    }, 100);
-  }
-  catch (error) {
-    throw new Error(error.message);
-  }
-}
-
-async function displayAutoCachedRouteStats(routeStats) {
-  try {
-
-    let statsDiv = document.getElementById("route-stats");
-
-    if (statsDiv) {
-      statsDiv.remove();
-    };
-
-    statsDiv = document.createElement("div");
-    statsDiv.id = "route-stats";
-    document.body.appendChild(statsDiv);
-
-    statsDiv.innerHTML = createStatsPanel(formatDistance(parseFloat(routeStats.total_distance)), formatETA(routeStats.eta_seconds), formatElevation(routeStats.elevation_gain));
-  }
-  catch (error) {
-    throw new Error(error.message)
+    // localforage.clear();
   }
 }
 
 async function handleLoadManualCachedRoute() {
 
-  const updateManualRouteState = (newUserClicks, newPathCoords, newSegmentCache) => {
-    manualRouteState.userClicks = newUserClicks;
-    manualRouteState.pathCoords = newPathCoords;
-    manualRouteState.segmentCache = newSegmentCache;
-  }
-
-  const newUserClicks = await localforage.getItem('cachedUserClicks');
-  const newPathCoords = await localforage.getItem('cachedPathCoords');
-  const newSegmentCache = await localforage.getItem('cachedSegmentCache');
-
-  await updateManualRouteState(newUserClicks, newPathCoords, newSegmentCache)
-
   const map = getMap();
-  if (!map) return;
 
-  if (manualRouteLayer) map.removeLayer(manualRouteLayer);
-  if (!removeExistingStats()) return;
+  const [userClicks, pathCoords, segmentCache] = await Promise.all([
+    localforage.getItem("cachedUserClicks"),
+    localforage.getItem("cachedPathCoords"),
+    localforage.getItem("cachedSegmentCache")
+  ]);
 
-  if (saveContainer) saveContainer.style.display = "flex";
-
-  const { userClicks, pathCoords } = manualRouteState;
-  const totalDistanceKm = calculateTotalDistance(pathCoords) / 1000;
-  const distanceDisplay = formatDistance(totalDistanceKm);
-  const etaDisplay = calculateEta(totalDistanceKm);
-  const isSnappedToEnd = checkIfCircularRoute();
-  const features = [];
-  const elevationGainDisplay = formatElevation(calculateElevationGain(pathCoords));
-
-  localforage.setItem('cachedUserClicks', userClicks)
-  localforage.setItem('cachedPathCoords', pathCoords)
-  
-  setLastKnownDistanceKm(totalDistanceKm);
-
-  userClicks.forEach((point, index) => {
-    const feature = new Feature({
-      geometry: new Point(point),
-      type: "point",
-    });
-    feature.set("index", index);
-    features.push(feature);
-  });
-
-  if (pathCoords.length > 1) {
-    features.push(
-      new Feature({
-        geometry: new LineString(pathCoords),
-        type: "line",
-      }),
-    );
+  if (!Array.isArray(userClicks) || !Array.isArray(pathCoords) || !segmentCache || typeof segmentCache !== "object") {
+    throw new Error("Cached manual route is incomplete");
   }
 
-  manualRouteLayer = new VectorLayer({
-    source: new VectorSource({ features }),
-    style(feature) {
-      const featureType = feature.get("type");
-      if (featureType === "point") {
-        const index = feature.get("index");
-        const isStart = index === 0;
-        const isEnd = index === userClicks.length - 1;
+  manualRouteState.userClicks = userClicks;
+  manualRouteState.pathCoords = pathCoords;
+  manualRouteState.segmentCache = segmentCache;
+  manualRouteState.redoStack = [];
+  manualRouteFeature = null;
+  removeManualRouteLayer();
+  await updateManualRoute();
+  syncCoordinateInputs();
 
-        if (isSnappedToEnd) {
-          if (isStart) return getSavedPointStyle("Start/End", "#00A86B");
-          if (isEnd) return getSavedPointStyle("", "#00A86B");
-        }
-        if (isStart) return getSavedPointStyle("Start", "#00A86B");
-        if (isEnd) return getSavedPointStyle("End", "#D32F2F");
-        return createManualPointStyle("", "#000", 6.5);
-      }
-      return new Style({
-        stroke: new Stroke(getRouteStrokeStyle()),
+  const manualRouteLayer = getManualRouteLayer();
+  if (pathCoords.length > 0) {
+    setTimeout(() => {
+      getMap()?.getView().fit(manualRouteLayer.getSource().getExtent(), {
+        padding: MAP_VIEW_PADDING,
+        duration: 1200,
       });
-    },
-  });
+    }, 50);
 
-  map.addLayer(manualRouteLayer);
-
-  const isOnePoint = pathCoords.length === 1;
-
-  updateManualRouteStats(isOnePoint, distanceDisplay, etaDisplay, elevationGainDisplay, pathCoords);
-  createElevationProfile(pathCoords);
-
-  setTimeout(() => {
-    map.getView().fit(manualRouteLayer.getSource().getExtent(), {
-      padding: MAP_VIEW_PADDING,
-      duration: 1200,
-    });
-    map.render();
-  }, 100);
+    map.renderSync();
+  }
 }
 
 //#endregion
 
 //#region MANUAL ROUTING
 
-function checkIfCircularRoute() {
-  const tolerance = 0.000001;
-  const { userClicks } = manualRouteState;
+/**
+ * Creates a manual route with a given start and end point 
+ * 
+ * @param {number} [start] 
+ * @param {number} [end] 
+ * @returns {void}
+ */
+async function handleManualRouteGeneration(start = null, end = null) {
 
-  if (userClicks.length > 3) {
-    const start = userClicks[0];
-    const end = userClicks[userClicks.length - 1];
-    if (
-      Math.abs(start[0] - end[0]) < tolerance &&
-      Math.abs(start[1] - end[1]) < tolerance
-    ) {
-      return true;
-    }
+  const startPoint = start || startCoordEntry?.value || "";
+  const endPoint = end || endCoordEntry?.value || "";
+
+  if (!validateInputCoords(startPoint, endPoint)) return;
+
+  const parsedStart = parseCoordString(startPoint);
+  const parsedEnd = parseCoordString(endPoint);
+  const startMercator = toWebMercator(parsedStart);
+  const endMercator = toWebMercator(parsedEnd);
+
+  if (!startMercator || !endMercator) return;
+
+  generatePathButton.disabled = true;
+  generatePathButton.classList.add("loading");
+
+  try {
+    clearManualRoute();
+    await localforage.setItem("lastRoutingMode", "manual");
+
+    await addManualPoint(startMercator[0], startMercator[1]);
+    await addManualPoint(endMercator[0], endMercator[1]);
+
+    syncCoordinateInputs();
+  } 
+  catch (error) {
+    clearManualRoute();
+    showToast(error.cause || ERROR_MESSAGES.ROUTING.PATH_CREATION_FAILED, "error");
+  } 
+  finally {
+    generatePathButton.disabled = false;
+    generatePathButton.classList.remove("loading");
   }
-  return false;
+}
+
+/**
+ * Handles the clearing of route stats and save button if there are no current coordinates
+ *
+ * @returns {void}
+ */
+function cleanRouteUI() {
+  document.getElementById("route-stats")?.remove();
+  resetElevationChart();
+  if (saveRouteContainer && getCurrentMode() === "manual") {
+    saveRouteContainer.style.display = "none";
+    collapseSaveRouteContainer();
+  }
 };
 
-function removeExistingStats() {
-  if (manualRouteState.userClicks.length === 0) {
-    document.getElementById("route-stats")?.remove();
-    resetElevationChart();
-    if (saveRouteContainer && getCurrentMode() === "manual") {
-      saveRouteContainer.style.display = "none";
-      collapseSaveRouteContainer();
-    }
-    return false;
+/**
+ * Updates key point features, such as start, end and intermediary points 
+ * 
+ * @param {number[][]} userClicks 
+ * @returns {void}
+ */
+function syncManualEndpointMarkers(userClicks) {
+  if (!interactivePointLayer) return;
+  const source = interactivePointLayer.getSource();
+
+  source.clear();
+
+  if (userClicks.length === 0) return;
+
+  const isClosed = manualRouteState.isSnapped
+
+
+  const startPointFeature = createPoint(
+    userClicks[0],
+    getSavedPointStyle(isClosed ? "Start/End" : "Start", "#00A86B"),
+    isClosed ? "start-end" : "start",
+    isClosed ? "Start/End" : "Start"
+  );
+  
+  addStartEndPoint(
+    startPointFeature,
+    interactivePointLayer,
+    isClosed ? "start-end" : "start"
+  );
+
+  
+  if (userClicks.length >= 2 && !isClosed) {
+
+    const endPointFeature = createPoint(
+      userClicks[userClicks.length - 1], 
+      getSavedPointStyle("End", "#D32F2F"),
+      "end",
+      "End"
+    )
+
+    addStartEndPoint(
+      endPointFeature,
+      interactivePointLayer,
+      "end"
+    );
   }
-  return true;
-};
+
+  // This adds intermediary points (if there are any)
+  for (let i = 1; i < userClicks.length - 1; i++) {
+
+    const intermediaryPointFeature = createPoint(
+      userClicks[i],
+      createManualPointStyle(),
+      "route-waypoint",
+      undefined,
+      i
+    );
+
+    addStartEndPoint(
+      intermediaryPointFeature,
+      interactivePointLayer,
+      "route-waypoint"
+    );
+  }
+
+  setUpPointInteraction([interactivePointLayer]);
+}
 
 export async function updateManualRoute() {
   const map = getMap();
   if (!map) return;
 
-  if (manualRouteLayer) map.removeLayer(manualRouteLayer);
-  if (!removeExistingStats()) return;
-
-  if (saveContainer) saveContainer.style.display = "flex";
+  let manualRouteLayer = getManualRouteLayer();
 
   try {
 
     const { userClicks, pathCoords } = manualRouteState;
+    syncManualEndpointMarkers(userClicks);
+
+
+    if (userClicks.length === 0) {
+      cleanRouteUI();
+      return;
+    } else {
+      saveContainer.style.display = "flex";
+    }
+
+    if (pathCoords.length > 1) {
+      if (!manualRouteFeature) {
+        manualRouteFeature = new Feature({
+          geometry: new LineString(pathCoords),
+          type: "line",
+        });
+
+        manualRouteLayer.getSource().addFeature(manualRouteFeature);
+      } else {
+        manualRouteFeature.getGeometry().setCoordinates(pathCoords);
+      }
+    } else {
+      manualRouteLayer.getSource().removeFeature(manualRouteFeature);
+      manualRouteFeature = null;
+    }
+
+    if (pathCoords.length === 1) {
+      setLastKnownDistanceKm(0);
+      updateManualRouteStats(true, formatDistance(0), formatETA(0), formatElevation(0));
+      resetElevationChart();
+      if (!window.appConfig.loggedIn) {
+        await localforage.setItem("cachedUserClicks", userClicks);
+        await localforage.setItem("cachedPathCoords", pathCoords);
+        await localforage.setItem("cachedManualRouteStats", {
+          total_distance: 0,
+          eta_seconds: 0,
+          elevation_gain: 0
+        });
+      }
+      return;
+    }
 
     const transformedPathCoords = pathCoords.map(coord => {
       const [lon, lat] = toLonLat(coord);
@@ -1739,7 +1376,12 @@ export async function updateManualRoute() {
 
     const routeStats = await routeStatsResponse.json().catch(() => ({}));
 
-    if (!routeStatsResponse.ok || !routeStats) {
+    if (
+      !routeStatsResponse.ok ||
+      !Number.isFinite(Number(routeStats.distance_km)) ||
+      !Number.isFinite(Number(routeStats.eta_seconds)) ||
+      !Number.isFinite(Number(routeStats.elevation_gain_m))
+    ) {
       throw new Error(routeStats.message || "ERROR : updateManualRoute()", {cause : routeStats.user_message || ERROR_MESSAGES.ROUTING.PATH_CREATION_FAILED})
     };
 
@@ -1750,75 +1392,32 @@ export async function updateManualRoute() {
     // sets display values 
     const distanceDisplay = formatDistance(routeStats.distance_km);
     const etaDisplay = formatETA(routeStats.eta_seconds);
-    const isSnappedToEnd = checkIfCircularRoute();
     const elevationGainDisplay = formatElevation(routeStats.elevation_gain_m);
-
-    const features = []; 
-    
-    console.log(JSON.stringify(routeStats));
 
 
     // caches route info if not logged in, used to allow user to continue routing if they login 
     if (!window.appConfig.loggedIn) {
       await localforage.setItem('cachedUserClicks', userClicks);
       await localforage.setItem('cachedPathCoords', pathCoords);
-      await localforage.setItem('cachedManualRouteStats', {"total_distance": routeStats.distance_km, "elevation_gain": formatElevation(routeStats.elevation_gain_m)});
-    }
-
-    userClicks.forEach((point, index) => {
-      const feature = new Feature({
-        geometry: new Point(point),
-        type: "point",
+      await localforage.setItem('cachedManualRouteStats', {
+        total_distance: Number(routeStats.distance_km),
+        eta_seconds: Number(routeStats.eta_seconds),
+        elevation_gain: Number(routeStats.elevation_gain_m)
       });
-      feature.set("index", index);
-      features.push(feature);
-    });
-
-    if (pathCoords.length > 1) {
-      features.push(
-        new Feature({
-          geometry: new LineString(pathCoords),
-          type: "line",
-        }),
-      );
     }
-
-    manualRouteLayer = new VectorLayer({
-      source: new VectorSource({ features }),
-      style(feature) {
-        const featureType = feature.get("type");
-        if (featureType === "point") {
-          const index = feature.get("index");
-          const isStart = index === 0;
-          const isEnd = index === userClicks.length - 1;
-
-          if (isSnappedToEnd) {
-            if (isStart) return getSavedPointStyle("Start/End", "#00A86B");
-            if (isEnd) return getSavedPointStyle("", "#00A86B");
-          }
-          if (isStart) return getSavedPointStyle("Start", "#00A86B");
-          if (isEnd) return getSavedPointStyle("End", "#D32F2F");
-          return createManualPointStyle("", "#000", 6.5);
-        }
-        return new Style({
-          stroke: new Stroke(getRouteStrokeStyle()),
-        });
-      },
-    });
-
-    map.addLayer(manualRouteLayer);
 
     const isOnePoint = pathCoords.length === 1;
 
-    updateManualRouteStats(isOnePoint, distanceDisplay, etaDisplay, elevationGainDisplay, pathCoords);
+    updateManualRouteStats(isOnePoint, distanceDisplay, etaDisplay, elevationGainDisplay);
     createElevationProfile(pathCoords);
+
   }
   catch (error) {
     throw new Error(error.message || "ERROR : updateManualRoute()", {cause : error.cause || ERROR_MESSAGES.ROUTING.PATH_CREATION_FAILED});
   }
 };
 
-function updateManualRouteStats(isOnePoint, distanceDisplay, etaDisplay, elevationGainDisplay, pathCoords) {
+function updateManualRouteStats(isOnePoint, distanceDisplay, etaDisplay, elevationGainDisplay) {
   let statsDiv = document.getElementById("route-stats");
   let firstRender = !statsDiv
 
@@ -1846,7 +1445,7 @@ function updateManualRouteStats(isOnePoint, distanceDisplay, etaDisplay, elevati
   }
 }
 
-export function undoManualRoutePoint() {
+export async function undoManualRoutePoint() {
 
   const { userClicks, segmentCache } = manualRouteState;
 
@@ -1856,11 +1455,14 @@ export function undoManualRoutePoint() {
     document.getElementById('route-stats')?.remove();
     resetElevationChart();
     collapseSaveRouteContainer();
+    await updateManualRoute();
+    syncCoordinateInputs();
     return;
   }
 
   // this removes the last click
   const removed = userClicks.pop();
+  manualRouteState.isSnapped = false;
 
   // this adds the removed point to the redo stack
   manualRouteState.redoStack.push(removed);
@@ -1869,7 +1471,8 @@ export function undoManualRoutePoint() {
 
   // this updates the UI and exits if there are no clicks
   if (userClicks.length === 0) {
-    updateManualRoute();
+    await updateManualRoute();
+    syncCoordinateInputs();
     return;
   }
 
@@ -1894,17 +1497,22 @@ export function undoManualRoutePoint() {
   }
 
   // this updates the UI
-  updateManualRoute();
+  await updateManualRoute();
+  syncCoordinateInputs();
 };
 
-function redoManualRoutePoint() {
+async function redoManualRoutePoint() {
   const restoredPoint = manualRouteState.redoStack.pop();
   
   if (!restoredPoint) return;
 
-  addManualPoint(restoredPoint[0], restoredPoint[1]).catch((error) => {
+  try {
+    await addManualPoint(restoredPoint[0], restoredPoint[1], "normal", { clearRedo: false });
+    syncCoordinateInputs();
+  } catch (error) {
+    manualRouteState.redoStack.push(restoredPoint);
     showToast(error.cause || "Sorry, we couldn't redo your point.", "error", null);
-  });
+  }
 };
 
 //#endregion
@@ -1927,7 +1535,7 @@ export function updateSaveRouteContainer() {
 //#region DRIVER.JS
 
 async function handleSaveRouteTour() {
-  await handleAutoRouteGeneration('54.454722, -3.267793', '54.454195, -3.211540');
+  await handleManualRouteGeneration('54.454722, -3.267793', '54.454195, -3.211540');
 
   setTimeout(() => {
     savingRoutesTourDriver = createSavingRoutesTour(homeButtonFunction);
@@ -1972,8 +1580,11 @@ function toWebMercator(latLon) {
 
 /**
  * Handles a change on either the start or end coordinate input.
+ *
+ * @param {HTMLInputElement} entry
+ * @param {"start" | "end"} type
  */
-function handleCoordEntryChange(entry, type) {
+async function handleCoordEntryChange(entry, type) {
   const raw = entry?.value?.trim() ?? "";
   const parsed = parseCoordString(raw);
 
@@ -1984,40 +1595,27 @@ function handleCoordEntryChange(entry, type) {
   const mercatorCoords = toWebMercator(parsed);
   if (!mercatorCoords) return;
 
-  const style = getSavedPointStyle(
-    type === "start" ? "Start" : "End",
-    "#074df0"
-  );
-
   // returning prematurely if the point is not in Cumbria 
   if (!isPointInPolygon(toLonLat(mercatorCoords))) {
     showToast("Please choose a point within Cumbria.")
     return;
   }
 
-  // this creates the point feature 
-  const pointFeature = createPoint(
-    mercatorCoords,
-    style,
-    type,
-    type === "start" ? "Start" : "End"
-  );
-
-  // this adds the point feature and adds the OpenLayers interaction to it
-  addStartEndPoint(pointFeature, interactivePointLayer, type);
-  setUpPointInteraction([interactivePointLayer]);
-
   const map = getMap();
   map.renderSync();
 
-  const startVal = startCoordEntry?.value?.trim();
-  const endVal = endCoordEntry?.value?.trim();
+  try {
+    if (type === "end" && manualRouteState.userClicks.length === 0) {
+      showToast("Set a start point before setting the end point.", "error");
+      entry.value = "";
+      return;
+    }
 
-  if (startVal && endVal) {
-    handleAutoRouteGeneration(startVal, endVal);
-  }
-  else {
-    moveMapToPosition(map, [parsed[1], parsed[0]], 1200, 12); // reversed order as moveMap expects coords in [Lon, Lat format], whereas parsed is in [Lat, Lon] format
+    await addManualPoint(mercatorCoords[0], mercatorCoords[1], type);
+    syncCoordinateInputs();
+  } catch (error) {
+    syncCoordinateInputs();
+    showToast(error.cause || ERROR_MESSAGES.ROUTING.PATH_CREATION_FAILED, "error");
   }
 }
 
@@ -2026,16 +1624,18 @@ function handleCoordEntryChange(entry, type) {
  *
  * @param {ol.Feature} pointFeature The point feature to add
  * @param {ol.layer.Vector} vectorLayer The vector layer that will contain the feature
- * @param {string} type Feature type identifier (e.g. `"start"` or `"end"`)
+ * @param {"start"|"end"|"route-waypoint"} type Feature type identifier (e.g. `"start"` or `"end"`)
  * @returns {void}
  */
 function addStartEndPoint(pointFeature, vectorLayer, type) {
   const vectorLayerSource = vectorLayer.getSource();
 
-  // this removes any existing features which are of the same type 
-  vectorLayerSource.getFeatures()
-  .filter(feature => feature.get('type') === type)
-  .forEach(feature => vectorLayerSource.removeFeature(feature))
+  // this removes any existing features which are of the same type (for start and end points)
+  if (type !== "route-waypoint") {
+    vectorLayerSource.getFeatures()
+      .filter(feature => feature.get('type') === type)
+      .forEach(feature => vectorLayerSource.removeFeature(feature));
+  }
 
   vectorLayerSource.addFeature(pointFeature)
 }
@@ -2045,11 +1645,12 @@ function addStartEndPoint(pointFeature, vectorLayer, type) {
  *
  * @param {Array<number>} coordinates Coordinates in EPSG:3857.
  * @param {ol.style.Style} style Style to apply to the feature.
- * @param {string} type Logical point type (e.g. "start", "end", "waypoint").
- * @param {string} [label] Display label for the point.
+ * @param {"start"|"end"|"start-end"|"route-waypoint"} type Logical point type (e.g. "start", "end", "waypoint").
+ * @param {"Start"|"End"|"Start/End"|undefined} [label] Display label for the point.
+ * @param {number} [index] For intermediary points
  * @returns {ol.Feature}
  */
-export function createPoint(coordinates, style, type, label) {
+export function createPoint(coordinates, style, type, label, index) {
 
     const point = new Feature({
         geometry: new Point(coordinates)
@@ -2057,6 +1658,7 @@ export function createPoint(coordinates, style, type, label) {
 
     point.set("type", type);
     point.set("label", label);
+    if (type === "route-waypoint") point.set("index", index);
     point.setStyle(style);
 
     return point;
@@ -2087,30 +1689,30 @@ export function setUpPointInteraction(layers) {
   
   map.addInteraction(interactivePointLayerInteraction); 
 
-  interactivePointLayerInteraction.on('translateend', (event) => {
+  interactivePointLayerInteraction.on('translateend', async (event) => {
     const movedFeature = event.features.item(0);
     if (!movedFeature) return;
 
     const newCoordinates = movedFeature.getGeometry().getCoordinates();
     const pointType = movedFeature.get("type");
-    const newLonLatCoordinate = toLonLat(newCoordinates);
-    const coordinateString = formatLatLon(newLonLatCoordinate, 6);
+    try {
+      if (!isPointInPolygon(toLonLat(newCoordinates))) {
+        throw new Error("Waypoint moved outside Cumbria", { cause: ERROR_MESSAGES.ROUTING.OUTSIDE_CUMBRIA });
+      }
 
-    // this updates the correct input
-    if (pointType === "start") {
-      startCoordEntry.value = coordinateString;
-    } else if (pointType === "end") {
-      endCoordEntry.value = coordinateString;
+      if (pointType === "start") {
+        await addManualPoint(newCoordinates[0], newCoordinates[1], "start");
+      } else if (pointType === "end" || pointType === "start-end") {
+        await addManualPoint(newCoordinates[0], newCoordinates[1], "end");
+      } else if (pointType === "route-waypoint") {
+        await replaceIntermediaryPoint(movedFeature.get("index"), newCoordinates);
+      }
+      syncCoordinateInputs();
+    } catch (error) {
+      syncManualEndpointMarkers(manualRouteState.userClicks);
+      syncCoordinateInputs();
+      showToast(error.cause || ERROR_MESSAGES.ROUTING.PATH_CREATION_FAILED, "error");
     }
-
-    const startVal = startCoordEntry?.value?.trim();
-    const endVal = endCoordEntry?.value?.trim();
-
-    // this ensures routes are only recalculated if both points are present
-    if (startVal && endVal) {
-      handleAutoRouteGeneration(startVal, endVal);
-    }
-
   });
 }
 
@@ -2126,6 +1728,44 @@ function deselectSelectedPoint() {
   }
   return
 };
+
+/**
+ * Handles user clicks on saved points 
+ * 
+ * @param {Event} event 
+ * @returns {boolean} True if a point has been clicked and false if not
+ */
+function handleSelectSavedPoint(event) {
+  const map = getMap();
+
+  if (selectedPoint) {
+    selectedPoint.setStyle(getSavedPointStyle(selectedPoint.get("name")));
+    selectedPoint = null;
+  }
+
+  let featureClicked = false;
+  let newSelection = null;
+  const savedPointsLayer = getSavedPointsLayer();
+
+  map.forEachFeatureAtPixel(event.pixel, (feature, layer) => {
+    if ( layer === savedPointsLayer && feature.getGeometry() instanceof Point ) {
+      newSelection = feature;
+      featureClicked = true;
+      return;
+    }
+  });
+
+  if (newSelection) {
+    selectedPoint = newSelection;
+    const pointName = selectedPoint.get("name");
+    selectedPoint.setStyle(getSelectedPointStyle(pointName));
+    deletePointModalNameDisplay.textContent = pointName;
+    showModal(true, deletePointModal);
+    return true;
+  } else {
+    return false;
+  }
+}
 
 //#endregion
 
@@ -2158,7 +1798,7 @@ function handleDistanceUnitToggle() {
     displayAutoRouteStats(getLastAutoRouteStats());
     toggleElevationChart();
   }
-  else if (getLastLoadedRouteStats) {
+  else if (getLastLoadedRouteStats()) {
     displayLoadedRouteStats(getLastLoadedRouteStats());
     toggleElevationChart();
   }
@@ -2229,20 +1869,6 @@ function appShortcuts(e, key) {
     e.preventDefault();
     searchEntry.focus();
   }
-
-  // this switches to auto mode if ctrl/cmd + a is pressed
-  if (isModifier && e.shiftKey && key === 'a') {
-    e.preventDefault();
-    switchToAutoMode();
-    return;
-  };
-
-  // this switches to manual mode if ctrl/cmd + m is pressed
-  if (isModifier && e.shiftKey && key === 'm') {
-    e.preventDefault();
-    switchToManualMode();
-    return;
-  };
 
   return;
 }
@@ -2358,17 +1984,6 @@ function handlePanelShortcut(e, panel, open, close) {
 
   closeModals();
 
-  /**
-  * Helper to tell if any other panels are open
-  * 
-  * @param {HTMLDivElement} currentPanel 
-  * @returns {Boolean} 
-  */
-  const isOtherPanelOpen = (currentPanel) => {
-    return panels.some(panel => panel.style.width === "100vw" && panel !== currentPanel);
-  };
-
-
   if (panel.style.width === "100vw") {
     close();
   } else {
@@ -2413,20 +2028,16 @@ function initInteractivePointLayer(map) {
 function initPointDeleteHandlers() {
   if (!deletePointModal) return;
 
-  // for hiding if clicking anywhere outside the modal
   deletePointModal.addEventListener("click", (e) => {
     closeModalUponOutsideClick(e, deletePointModalContent, deletePointModal)
   });
 
-  // for deselecting the currently-selected point when the modal is closed 
   deletePointModal.addEventListener("close", deselectSelectedPoint);
 
-  // for when the user clicks the 'exit' button on the modal
   deletePointModalExitButton?.addEventListener("click", () => {
     showModal(false, deletePointModal)
   });
 
-  // for when the user clicks 'delete point' on the modal
   deletePointModalDeleteButton?.addEventListener("click", () => {
     deleteSavedPoint(selectedPoint)
   });
@@ -2455,13 +2066,8 @@ export function initUi() {
   // These event listeners are for settings and preferences.
   setOnDistanceUnitChange(() => handleDistanceUnitToggle());
 
-  // This ensures mobile users are warned about the poor design of the mobile web UI
   window.addEventListener("load", checkIfMobile);
-
-  // This ensures that points are loaded near instantly 
   window.addEventListener('DOMContentLoaded', loadAndDisplaySavedPoints);
-
-  // This ensures that the theme of the app changes if system settings switch to dark mode after sunset 
   window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
     applyTheme(getTheme());
   });
@@ -2495,26 +2101,23 @@ export function initUi() {
     radio.addEventListener('change', handleRouteImportType);
   });
 
-  // These event listeners are for route mode selection.
-  addClickListener(autoModeOption, handleToggles, "click");
-  addClickListener(manualModeOption, handleToggles, "click");
-  addClickListener(autoModeOption, switchToAutoMode, "click");
-  addClickListener(manualModeOption, switchToManualMode, "click");
-
-  // These event listeners are for automatic route generation.
-  generatePathButton.addEventListener("click", () => handleAutoRouteGeneration());
-  addClickListener(clearAutoRouteButton, clearAutoRoute, "click");
+  // These event listeners are for the routing panel
   addClickListener(searchForAreaButton, searchArea, "click");
+
   addClickListener(setStartCoordButton, setStartCoord, "click");
   addClickListener(setEndCoordButton, setEndCoord, "click");
+
   addClickListener(startCoordEntry, () => handleCoordEntryChange(startCoordEntry, "start"), 'change')
   addClickListener(endCoordEntry, () => handleCoordEntryChange(endCoordEntry, "end"), 'change')
 
-  // These event listeners are for manual route creation.
-  addClickListener(clearManualRouteButton, clearManualRoute, "click");
+  addClickListener(clearRouteButton, clearManualRoute, "click");
+  addClickListener(homeButton, homeButtonFunction, "click");
+
   addClickListener(undoManualRouteButton, undoManualRoutePoint, "click");
   addClickListener(redoManualRouteButton, redoManualRoutePoint, "click");
   addClickListener(noRouteCreateButton, noRouteCreateFunction, "click");
+
+  generatePathButton.addEventListener("click", () => handleManualRouteGeneration());
 
   // These event listeners are for route saving.
   addClickListener(saveRouteToggleButton, toggleSaveRouteContainer, "click");
@@ -2526,6 +2129,10 @@ export function initUi() {
   addClickListener(loginModalExitButton, () => showModal(false, loginModal), 'click');
   addClickListener(loginModalLoginButton, loginModalLogin, 'click');
   addClickListener(loginModal, (e) => closeModalUponOutsideClick(e, loginModalContent, loginModal), 'click');
+
+  // Save Point Modal
+  addClickListener(savePointModalCloseButton, () => showModal(false, savePointModal), "click");
+  addClickListener(savePointModal, (e) => closeModalUponOutsideClick(e, savePointModalContent, savePointModal), "click");
 
   // Report Issue Modal
   addClickListener(reportIssueModalExit, () => showReportIssueModal(false), "click");
@@ -2548,10 +2155,6 @@ export function initUi() {
   addClickListener(shortcutsModal, (e) => closeModalUponOutsideClick(e, shortcutsModalContent, shortcutsModal), "click");
 
   onMapClick(manualRouteClickHandler);
-
-  // These event listeners are for returning the map to the Lake District + clearing inputs
-  autoHomeButton?.addEventListener("click", homeButtonFunction);
-  manualHomeButton?.addEventListener("click", homeButtonFunction);
 
   // These event listeners are for updating the map cursor.
   mapElement?.addEventListener("mouseup", () => {

--- a/static/js/utils/error-contants.js
+++ b/static/js/utils/error-contants.js
@@ -6,5 +6,7 @@ export const ERROR_MESSAGES = {
             "Sorry, we could not find a path to that location.",
         OUTSIDE_CUMBRIA:
             "Please click on a point within Cumbria.",
+        GENERIC_ROUTE_ACTION: // e.g undo route, redo route, clear path
+            "Sorry, there was an unexpected error performing that action, please try again later"
     },
 };

--- a/static/js/utils/style-utils.js
+++ b/static/js/utils/style-utils.js
@@ -13,39 +13,43 @@ import Circle from "ol/style/Circle"
 import Style from "ol/style/Style"
 
 
-
 /**
- * 
- * @param {string} label The text to be displayed above the point
- * @param {string} colour The inner (fill) colour of the point
- * @param {number} radius Radius of the point
- * @param {string} strokeBorderColor Border colour of the point + text  
- * @returns {Object} The styling to be applied to the point via OL
+ * Returns the styling to be applied to intermediary points on a route
+ * @returns {ol.style.Style}
  */
-export function createManualPointStyle(label, colour, radius=7.5, strokeBorderColor="#FFFFFF") {
+export function createManualPointStyle() {
   return new Style({
-    image : new Circle({
-      radius : radius,
-      fill : new Fill({
-        color : colour
+    image: new Circle({
+      radius: 6.5,
+      fill: new Fill({
+        color: "#000000"
       }),
-      stroke : new Stroke({
-        color : strokeBorderColor,
-        width : 3
+      stroke: new Stroke({
+        color: "#FFFFFF",
+        width: 3
       })
     }),
-    text : label ? new Text({
-      text : label,
-      font : "bold 12px sans-serif",
-      fill : new Fill({
-        color : "black"
+    zIndex: 1000
+  })
+}
+
+/**
+ * Returns the styling to be applied to dynamic points created on a route by the elevation chart 
+ * @returns {ol.style.Style} 
+ */
+export function createElevationPointStyle() {
+  return new Style({
+    image: new Circle({
+      radius: 7.5,
+      fill: new Fill({
+        color: '#FFFFFF'
       }),
-      stroke : new Stroke({
-        color : strokeBorderColor,
-        width : 3
-      }),
-      offsetY : -15
-    }) : null
+      stroke: new Stroke({
+        color: '#0a45e7',
+        width: 3
+      })
+    }),
+    zIndex: 1200
   })
 }
 

--- a/static/js/utils/ui-utils.js
+++ b/static/js/utils/ui-utils.js
@@ -9,19 +9,22 @@
  *      - createNoRouteCard()
  *      - createStatsPanel(distanceDisplay, etaDisplay, elevationGain)
  *      - parseCoordString(value)
+ *      - closeModalUponOutsideClick(e, modalContent, modal)
+ *      - showModal(show, modal)
+ *      - closeModals()
  */
       
 
 
 
-// GENERAL 
+//#region GENERAL 
 
 /**
  * Parses a coordinate string in the form "X, Y" (or "X,Y").
  * Returns [x, y] as numbers or null if the format is invalid.
  * Never throws.
  * @param {String} value
- * @returns {Array<number> | null}
+ * @returns {number[] | null}
  */
 export function parseCoordString(value) {
   if (typeof value !== "string") return null;
@@ -167,7 +170,9 @@ export function showToast(message, type = "error", modal = null) {
     closeButton.addEventListener("click", removeToast);
 }
 
-// DOM RELATED 
+//#endregion
+
+//#region DOM RELATED
 
 /**
  * 
@@ -175,7 +180,7 @@ export function showToast(message, type = "error", modal = null) {
  * 
  * @param {DOMElement} element 
  * @param {function} func 
- * @param {Event} type 
+ * @param {string} type 
  */
 export function addClickListener(element, func, type) {
   if (element) element.addEventListener(type, func);
@@ -321,3 +326,60 @@ export function createStatsPanel(distanceDisplay, etaDisplay, elevationGain) {
         </div>
     `
 }
+
+//#endregion
+
+//#region MODALS
+
+/**
+ * Catches clicks outside of a modal in order to close the modal upon these clicks. 
+ * 
+ * @param {Event} e 
+ * @param {HTMLDivElement} modalContent 
+ * @param {HTMLDialogElement} modal 
+ * @returns {void}
+ */
+export function closeModalUponOutsideClick(e, modalContent, modal) {
+  if (modalContent && !modalContent.contains(e.target)) {
+      modal.close()
+    }
+};
+
+/**
+ * Toggles the provided modal
+ * @param {boolean} show true if you want to show the modal, false if you want to hide the modal
+ * @param {HTMLDialogElement} modal The modal you want to open/close
+ * @returns {void} 
+ */
+export function showModal(show, modal) {
+  if (show) {
+    modal.showModal();
+  }
+  else {
+    modal.close();
+  }
+};
+
+/**
+ * Closes all modals within the application
+ * 
+ * @returns {void}
+ */
+export function closeModals() {
+
+    const modals = [
+        document.getElementById('save-point-dialog'),
+        document.getElementById('shortcuts-dialog'),
+        document.getElementById('load-last-route-dialog'),
+        document.getElementById('donate-modal'),
+        document.getElementById('report-issue-dialog'),
+        document.getElementById('login-dialog'),
+        document.getElementById("delete-point-confirmation-dialog")
+    ]
+
+    modals.forEach(modal => {
+        modal.close();
+    })
+}
+
+//#endregion

--- a/templates/map.html
+++ b/templates/map.html
@@ -230,6 +230,40 @@
             </div>
         </dialog>
 
+        <!-- ##### CONTEXT MENU ##### -->
+        <div id="map-context-menu" class="map-context-menu" role="menu" aria-label="Map options" hidden>
+            <ul class="map-context-menu-options">
+                <li>
+                    <button id="map-context-save-point" class="map-context-menu-option" type="button" role="menuitem">
+                        Save point
+                    </button>
+                    <button id="map-context-copy-coordinate" class="map-context-menu-option" type="button" role="menuitem">
+                        Copy Coordinates
+                    </button>
+                </li>
+            </ul>
+        </div>
+
+        <!-- ##### SAVE POINT ##### -->
+        <dialog id="save-point-dialog" class="modal-overlay">
+            <div class="modal-wrapper">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h2>Save Point</h2>
+                    </div>
+                    <div class="modal-body">
+                        <div class="field">
+                            <input type="text" id="save-point-dialog-name-input" name="save-point-name" class="field-input" aria-label="Input to add issue title" placeholder="Name" required>
+                        </div>
+                    </div>
+                    <div class="modal-actions">
+                        <button type="button" id="save-point-dialog-close" class="modal-btn modal-btn-secondary">Close</button>
+                        <button id="save-point-dialog-save" class="modal-btn modal-btn-normal">Save</button>
+                    </div>
+                </div>
+            </div>
+        </dialog>
+
         <!-- ##### REPORT ISSUE MODAL ##### -->
         <dialog id="report-issue-dialog" class="modal-overlay">
             <div class="modal-wrapper">
@@ -394,7 +428,6 @@
                 </div>
             </div>
         </dialog>
-
 
         <div id="map"></div>
     </div>

--- a/templates/map.html
+++ b/templates/map.html
@@ -77,21 +77,13 @@
 
     <div id="map-content">
 
-        <!-- ##### AUTO / MANUAL TOGGLE ##### -->
-        <div id="mode-toggle">
-            <div class="mode-toggle-container">
-                <button id="auto-mode-option" class="mode-button active">Auto</button>
-                <button id="manual-mode-option" class="mode-button">Manual</button>
-            </div>
-        </div>
-
         <!-- ##### MAIN ROUTING PANEL ##### -->
         <div id="start-end">
             <div class="coords-header">
-                <span class="coords-title">Path Generation</span>
-                <button id="auto-home-button" class="home-button"><i data-lucide="rotate-ccw"></i></button>
+                <span class="coords-title">Route Creation</span>
+                <button id="home-button" class="home-button"><i data-lucide="rotate-ccw"></i></button>
             </div>
-            <div class="coords-content" id="auto-mode-content">
+            <div class="coords-content" id="manual-mode-content">
                     <div id="search-row" class="coord-row">
                         <label for="search-entry" class="coord-label">Search for an Area</label>
                         <div class="coord-input-group">
@@ -104,42 +96,55 @@
                             <label for="start-point-entry" class="coord-label">Start Coordinates</label>
                             <div class="coord-input-group">
                                 <input type="text" id="start-point-entry" name="start_point" placeholder="Coordinates" required class="coord-input" list="start-points-list">
-                                <button type="button" id="set-start-coord-button" class="coord-button set-start-end-coord">Set Start Point</button>
+                                <button type="button" id="set-start-coord-button" class="coord-button set-start-end-coord">Set</button>
                             </div>
                         </div>
                         <div class="coord-row">
                             <label for="end-point-entry" class="coord-label">End Coordinates</label>
                             <div class="coord-input-group">
                                 <input type="text" id="end-point-entry" name="end_point" placeholder="Coordinates" required class="coord-input" list="end-points-list">
-                                <button type="button" id="set-end-coord-button" class="coord-button set-start-end-coord">Set End Point</button>
+                                <button type="button" id="set-end-coord-button" class="coord-button set-start-end-coord">Set</button>
                             </div>
                         </div>
                     </div>
-                    <div id="auto-mode-routing-buttons">
+                    <div id="routing-buttons">
 
-                        <button type="button" class="generate-button loading-button" id="generate-path-button">
-                            <span class="loading-button-text" id="generate-path-button-text">Generate path</span>
+                        <button
+                            type="button"
+                            class="generate-button loading-button"
+                            id="generate-path-button"
+                        >
+                            <span class="loading-button-text" id="generate-path-button-text">Create route</span>
                             <span class="loader"></span>
                         </button>
 
-                        <button type="button" class="generate-button btn-secondary" id="clear-auto-route-button">Clear Path</button>
-                    </div>
-            </div>
-        </div>
+                        <button
+                            type="button"
+                            id="undo-manual-route"
+                            class="generate-button routing-svg-button"
+                            data-tooltip="Undo"
+                        >
+                            <i data-lucide="undo-2"></i>
+                        </button>
 
-        <!-- ##### MANUAL ROUTING PANEL ##### -->
-        <div id="manual-mode-content" style="display: none;">
-            <div id="manual-routing-header" class="coords-header">
-                <span class="coords-title">Manual Route Creation</span>
-                <button id="manual-home-button" class="home-button"><i data-lucide="rotate-ccw"></i></button>
-            </div>
-            <div id="manual-routing-actions" class="coords-content">
-                <p class="manual-instruction">Click on the map to place points</p>
-                <div style="display: flex; align-items: center; justify-content: center; gap: .5rem;">
-                    <button type="button" id="undo-manual-route" class="generate-button">Undo Point</button>
-                    <button type="button" id="redo-manual-route" class="generate-button">Redo Point</button>
-                </div>
-                <button type="button" id="clear-manual-route" class="generate-button" style="background-color: #b91c1c;">Clear Route</button>
+                        <button
+                            type="button"
+                            id="redo-manual-route"
+                            class="generate-button routing-svg-button"
+                            data-tooltip="Redo"
+                        >
+                            <i data-lucide="redo-2"></i>
+                        </button>
+
+                        <button
+                            type="button"
+                            id="clear-route-button"
+                            class="generate-button btn-secondary routing-svg-button"
+                            data-tooltip="Clear Route"
+                        >
+                            <i data-lucide="eraser"></i>
+                        </button>
+                    </div>
             </div>
         </div>
 
@@ -333,14 +338,6 @@
                     <div class="modal-body shortcuts-modal-body">
                         <div class="shortcuts-group">
                             <h3 class="shortcuts-group-title">General</h3>
-                            <div class="shortcut-item">
-                                <span class="shortcut-name">Switch to Auto Mode</span>
-                                <span class="shortcut-key"><kbd>Ctrl/⌘</kbd><span class="shortcut-key-plus">+</span><kbd>Shift</kbd><span class="shortcut-key-plus">+</span><kbd>A</kbd></span>
-                            </div>
-                            <div class="shortcut-item">
-                                <span class="shortcut-name">Switch to Manual Mode</span>
-                                <span class="shortcut-key"><kbd>Ctrl/⌘</kbd><span class="shortcut-key-plus">+</span><kbd>Shift</kbd><span class="shortcut-key-plus">+</span><kbd>M</kbd></span>
-                            </div>
                             <div class="shortcut-item">
                                 <span class="shortcut-name">Focus Map Search</span>
                                 <span class="shortcut-key"><kbd>Ctrl/⌘</kbd><span class="shortcut-key-plus">+</span><kbd>Shift</kbd><span class="shortcut-key-plus">+</span><kbd>K</kbd></span>


### PR DESCRIPTION
# Pull Request Template

## Summary

This PR aims to simplify the routing experience by merging automatic and manual routing modes into a single workflow and removing the old mode-switching UI.

It also adds a map context menu for common point actions (this is where the option to save a point exists now, as well as the newly added copy coordinate action), a keyboard shortcut for resetting the map view, and several smaller UI and code-quality improvements.

## Related Issue
ABD-37
## Type of Change

Select all that apply:

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [x] Refactor
* [x] Other (UI and code cleanup)

## Description of Changes

* Merged automatic and manual routing modes into a single routing workflow

* Made manual routing the default map click behaviour

* Removed the old routing mode-switching component and its unused CSS

* Reduced the size of the routing panel following removal of the mode switcher

* Added a context menu with actions for:
  * Saving a point
  * Copying coordinates

* Added a keyboard shortcut for resetting the map view using the existing `homeButtonFunction()`

* Added the reset-view shortcut to the shortcuts dialog

* Reordered panel and modal closing behaviour inside `homeButtonFunction()`

* Moved general-purpose modal utilities from `ui.js` into `ui-utils.js`

* Added a guard for imported GPX routes without elevation data, falling back to `0` where elevation values are unavailable

* Added the `GENERIC_ROUTE_ACTION` error message

* Split point styling functions so manual intermediary points and elevation-profile hover points can be styled independently

* Updated imports and JSDoc documentation following the refactors


These changes reduce unnecessary routing state and UI complexity while keeping manual and automatic route creation available within the same workflow.

## Screenshots / Visuals (if applicable)

### The routing panel

<img width="306" height="277" alt="image" src="https://github.com/user-attachments/assets/2bb4b87b-4069-4305-b7f7-5e66b3e7155a" />

### The context menu

<img width="172" height="128" alt="image" src="https://github.com/user-attachments/assets/abb80405-01e3-454b-b4f9-b0f955945021" />


## Testing

Manually tested:

* Automatic route creation.
* Manual route creation.
* Switching between manual and automatic behaviour within the merged routing workflow.
* Reset-view keyboard shortcut.
* Existing reset-view button behaviour.
* Context-menu save-point action.
* Context-menu copy-coordinate action.
* Opening and closing affected panels and modals.
* GPX imports with and without elevation data.
* Elevation-profile hover points and manual intermediary point styling.

## Checklist

* [x] My code follows the project’s style guidelines
* [x] I have tested my changes
* [x] I have updated documentation if needed
* [x] I have referenced the related issue
* [x] This PR is scoped, focused, and ready for review

> **Note:**
> PRs for issues **not** tagged as contributor-friendly may be closed without review.
